### PR TITLE
Add missing Apache License headers to renderer files

### DIFF
--- a/Sources/VRMMetalKit/Renderer/RendererContext.swift
+++ b/Sources/VRMMetalKit/Renderer/RendererContext.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 @preconcurrency import Metal
 import simd
@@ -20,18 +36,19 @@ struct RendererBootstrapContext {
     let device: MTLDevice
     let config: RendererConfig
     let strictValidator: StrictValidator?
-    let pipelineManager: VRMPipelineManager
+    // FIXME: VRMPipelineManager type doesn't exist yet - WIP refactoring
+    // let pipelineManager: VRMPipelineManager
 
     init(
         device: MTLDevice,
         config: RendererConfig,
-        strictValidator: StrictValidator?,
-        pipelineManager: VRMPipelineManager
+        strictValidator: StrictValidator?
+        // pipelineManager: VRMPipelineManager
     ) {
         self.device = device
         self.config = config
         self.strictValidator = strictValidator
-        self.pipelineManager = pipelineManager
+        // self.pipelineManager = pipelineManager
     }
 }
 
@@ -73,17 +90,18 @@ struct RenderPassContext {
     let commandBuffer: MTLCommandBuffer
     let encoder: MTLRenderCommandEncoder
     let uniformsBuffer: MTLBuffer
-    let pipelineManager: VRMPipelineManager
+    // FIXME: VRMPipelineManager type doesn't exist yet - WIP refactoring
+    // let pipelineManager: VRMPipelineManager
 
     init(
         commandBuffer: MTLCommandBuffer,
         encoder: MTLRenderCommandEncoder,
-        uniformsBuffer: MTLBuffer,
-        pipelineManager: VRMPipelineManager
+        uniformsBuffer: MTLBuffer
+        // pipelineManager: VRMPipelineManager
     ) {
         self.commandBuffer = commandBuffer
         self.encoder = encoder
         self.uniformsBuffer = uniformsBuffer
-        self.pipelineManager = pipelineManager
+        // self.pipelineManager = pipelineManager
     }
 }

--- a/Sources/VRMMetalKit/Renderer/Systems/VRMDrawCallExecutor.swift
+++ b/Sources/VRMMetalKit/Renderer/Systems/VRMDrawCallExecutor.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 import Metal
 
@@ -52,7 +68,7 @@ final class VRMDrawCallExecutor {
         let idxInfo = "\(indexTypeStr)/\(prim.indexBufferOffset)/\(prim.indexCount)"
         let skinInfo = "\(skinIdxStr)/\(paletteCountStr)/\(paletteVersionStr)"
         vrmLog("[DRAW] i=\(drawIndex) mesh='\(meshName)' prim=\(meshPrimIdx) mat='\(materialName)' mode=\(modeStr) idx=\(idxInfo) skin=\(skinInfo) pso=\(psoLabel) pos_slot=\(positionSlot)")
-	
+
         if drawIndex == 14 && frameCounter <= 2 {
             vrmLog("[DRAW 14 DEBUG] Enter draw loop for wedge primitive (index=\(index))")
         }

--- a/Sources/VRMMetalKit/Renderer/Systems/VRMRenderItemBuilder.swift
+++ b/Sources/VRMMetalKit/Renderer/Systems/VRMRenderItemBuilder.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 import Metal
 
@@ -62,7 +78,7 @@ final class VRMRenderItemBuilder {
 
         for (nodeIndex, node) in model.nodes.enumerated() {
             if frameCounter <= 2 {
-                vrmLog("[NODE SCAN] Node \(nodeIndex) '(node.name ?? "unnamed")': mesh=\(node.mesh ?? -1)")
+                vrmLog("[NODE SCAN] Node \(nodeIndex) '\(node.name ?? "unnamed")': mesh=\(node.mesh ?? -1)")
             }
 
             guard let meshIndex = node.mesh,
@@ -72,7 +88,7 @@ final class VRMRenderItemBuilder {
 
             let mesh = model.meshes[meshIndex]
             if frameCounter <= 2 {
-                vrmLog("[DRAW LIST] Node[\(nodeIndex)] '(node.name ?? "?")' → mesh[\(meshIndex)] '(mesh.name ?? "?")' skin=\(node.skin ?? -1)")
+                vrmLog("[DRAW LIST] Node[\(nodeIndex)] '\(node.name ?? "?")' → mesh[\(meshIndex)] '\(mesh.name ?? "?")' skin=\(node.skin ?? -1)")
             }
             totalMeshes += 1
 
@@ -142,7 +158,7 @@ final class VRMRenderItemBuilder {
                 var effectiveAlphaMode = alpha
                 var effectiveAlphaCutoff = primitive.materialIndex.flatMap { idx in idx < model.materials.count ? model.materials[idx].alphaCutoff : nil } ?? 0.5
                 if effectiveAlphaMode == "opaque" && faceCategory == "eyebrow" {
-                    vrmLog("[FACE FIX] Forcing eyebrow material '(materialName)' to MASK mode")
+                    vrmLog("[FACE FIX] Forcing eyebrow material '\(materialName)' to MASK mode")
                     effectiveAlphaMode = "mask"
                     effectiveAlphaCutoff = 0.35
                 }
@@ -153,7 +169,7 @@ final class VRMRenderItemBuilder {
                 let isFaceMaterial = faceCategory != nil
                 let isEyeMaterial = faceCategory == "eye" || faceCategory == "highlight"
 
-                var item = RenderItem(
+                let item = RenderItem(
                     node: node,
                     mesh: mesh,
                     primitive: primitive,
@@ -179,7 +195,7 @@ final class VRMRenderItemBuilder {
         allItems.sort { $0.renderOrder < $1.renderOrder }
 
         if frameCounter % 60 == 0 {
-            vrmLog("[RenderItemBuilder] Sorted render items: opaque=\\(opaqueCount) mask=\\(maskCount) blend=\\(blendCount) faceSkin=\\(faceSkinCount)")
+            vrmLog("[RenderItemBuilder] Sorted render items: opaque=\(opaqueCount) mask=\(maskCount) blend=\(blendCount) faceSkin=\(faceSkinCount)")
         }
 
         cachedRenderItems = allItems
@@ -191,9 +207,9 @@ final class VRMRenderItemBuilder {
 
     private func logFaceCandidate(nodeName: String, meshName: String, materialName: String, alpha: String, primitive: VRMPrimitive) {
         vrmLog("[FACE MATERIAL DEBUG] Potential face material detected:")
-        vrmLog("  - Node: '(nodeName)'")
-        vrmLog("  - Mesh: '(meshName)'")
-        vrmLog("  - Material: '(materialName)'")
+        vrmLog("  - Node: '\(nodeName)'")
+        vrmLog("  - Mesh: '\(meshName)'")
+        vrmLog("  - Material: '\(materialName)'")
         vrmLog("  - Alpha mode: \(alpha)")
         vrmLog("  - IndexCount: \(primitive.indexCount)")
     }

--- a/Sources/VRMMetalKit/Renderer/Systems/VRMRenderItemSelector.swift
+++ b/Sources/VRMMetalKit/Renderer/Systems/VRMRenderItemSelector.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 
 struct RenderSelectionInput {
@@ -97,7 +113,7 @@ final class VRMRenderItemSelector {
 
             if prim.indexType == .uint16 {
                 let base = indexBuffer.contents().advanced(by: prim.indexBufferOffset)
-                let indexPtr = base.bindMentalMemory(to: UInt16.self, capacity: prim.indexCount)
+                let indexPtr = base.bindMemory(to: UInt16.self, capacity: prim.indexCount)
                 for i in 0..<indicesToRead {
                     let idx = Int(indexPtr[i])
                     indicesStr.append("\(idx)")

--- a/Sources/VRMMetalKit/Renderer/Systems/VRMUniformBufferRing.swift
+++ b/Sources/VRMMetalKit/Renderer/Systems/VRMUniformBufferRing.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 @preconcurrency import Metal
 


### PR DESCRIPTION
## Summary
Adds missing Apache License 2.0 headers to five renderer files that were committed without them in 6694fc5.

## Changes
- ✅ Add Apache License headers to all five files
- ✅ Fix compilation errors (VRMPipelineManager references commented out)
- ✅ Fix string interpolation syntax in log calls  
- ✅ Change `var item` to `let item` (was never mutated)

## Files Updated
- `Sources/VRMMetalKit/Renderer/RendererContext.swift`
- `Sources/VRMMetalKit/Renderer/Systems/VRMRenderItemSelector.swift`
- `Sources/VRMMetalKit/Renderer/Systems/VRMRenderItemBuilder.swift`
- `Sources/VRMMetalKit/Renderer/Systems/VRMDrawCallExecutor.swift`
- `Sources/VRMMetalKit/Renderer/Systems/VRMUniformBufferRing.swift`

## Notes
These files appear to be WIP refactoring work. The `VRMPipelineManager` type referenced in `RendererContext.swift` and `RenderPassContext` doesn't exist yet, so those references have been commented out with FIXME notes.

## Test Plan
- [x] `swift build` completes successfully
- [ ] GitHub Actions license header check should pass

Fixes https://github.com/arkavo-org/VRMMetalKit/actions/runs/19396797502

🤖 Generated with [Claude Code](https://claude.com/claude-code)