### PR TITLE
Fix MToonShader matcapFactor type error

### DIFF
--- a/Sources/VRMMetalKit/Shaders/MToonShader.swift
+++ b/Sources/VRMMetalKit/Shaders/MToonShader.swift
@@ -614,7 +614,7 @@ public struct MToonMaterialUniforms {
 
         // Validate matcap factor
         guard all(matcapFactor .>= 0) && all(matcapFactor .<= 4) else {
-            throw VRMMaterialValidationError.matcapFactorOutOfRange(matcapFactor)
+            throw VRMMaterialValidationError.matcapFactorOutOfRange(SIMD4(matcapFactor, 1.0))
         }
 
         // Validate rim fresnel power


### PR DESCRIPTION
## Summary

Fixes a compilation error in `MToonShader.swift` where `matcapFactor` (SIMD3<Float>) was being passed to an error case that expects SIMD4<Float>.

## Changes

- Convert `matcapFactor` from SIMD3 to SIMD4 when throwing `matcapFactorOutOfRange` error
- Resolves build failure on main branch

## Testing

- ✅ `swift build` completes successfully
- ✅ All existing tests pass
- ✅ Verified VRM model loading works correctly (AvatarSample_C.vrm.glb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)