### PR TITLE
feat: Add compositor bone accessor and IK idle grounding mode

### DIFF
--- a/Sources/VRMMetalKit/Animation/IKLayer.swift
+++ b/Sources/VRMMetalKit/Animation/IKLayer.swift
@@ -38,7 +38,7 @@ public final class IKLayer: AnimationLayer {
         case right
     }
 
-    public enum GroundingMode {
+    public enum GroundingMode: Sendable {
         case walkCycle       // Original: use FootContactDetector
         case idleGrounding   // Pin both feet at rest positions
     }

--- a/Sources/VRMMetalKit/Animation/ProceduralAnimation.swift
+++ b/Sources/VRMMetalKit/Animation/ProceduralAnimation.swift
@@ -200,6 +200,11 @@ public class AnimationLayerCompositor {
         compositedMorphs
     }
 
+    /// Get the composited rotation for a specific bone after all layers are evaluated
+    public func getCompositedBoneRotation(_ bone: VRMHumanoidBone) -> simd_quatf? {
+        compositedBones[bone]?.rotation
+    }
+
     /// Update all layers and apply composited result to model
     public func update(deltaTime: Float, context: AnimationContext) {
         guard let model = model else { return }

--- a/Tests/VRMMetalKitTests/Animation/AnimationLayeringTests.swift
+++ b/Tests/VRMMetalKitTests/Animation/AnimationLayeringTests.swift
@@ -278,11 +278,11 @@ final class AnimationLayeringTests: XCTestCase {
     }
 }
 
-// MARK: - AnimationLayer (Future Implementation)
+// MARK: - AnimationLayerSpec (Future Implementation)
 
-/// Represents an animation layer for blending
+/// Represents a planned animation layer for blending
 /// 🔴 RED: This class needs to be implemented
-public struct AnimationLayer {
+public struct AnimationLayerSpec {
     let name: String
     let clip: AnimationClip
     let weight: Float

--- a/Tests/VRMMetalKitTests/Animation/IKLayerTests.swift
+++ b/Tests/VRMMetalKitTests/Animation/IKLayerTests.swift
@@ -353,6 +353,8 @@ final class IKLayerTests: XCTestCase {
 
     func testCompositor_GetCompositedBoneRotation_ReturnsValueAfterUpdate() {
         let compositor = AnimationLayerCompositor()
+        let model = createMinimalModel()
+        compositor.setup(model: model)
         let mockLayer = MockBoneLayer(bone: .head, rotation: simd_quatf(angle: .pi / 4, axis: SIMD3<Float>(0, 1, 0)))
         compositor.addLayer(mockLayer)
 
@@ -365,6 +367,8 @@ final class IKLayerTests: XCTestCase {
 
     func testCompositor_GetCompositedBoneRotation_UnaffectedBoneReturnsNil() {
         let compositor = AnimationLayerCompositor()
+        let model = createMinimalModel()
+        compositor.setup(model: model)
         let mockLayer = MockBoneLayer(bone: .head, rotation: simd_quatf(angle: .pi / 4, axis: SIMD3<Float>(0, 1, 0)))
         compositor.addLayer(mockLayer)
 
@@ -373,6 +377,14 @@ final class IKLayerTests: XCTestCase {
 
         XCTAssertNil(compositor.getCompositedBoneRotation(.hips),
             "Bone not affected by any layer should return nil")
+    }
+
+    // MARK: - Helpers
+
+    private func createMinimalModel() -> VRMModel {
+        let json = #"{"asset":{"version":"2.0"}}"#
+        let gltf = try! JSONDecoder().decode(GLTFDocument.self, from: Data(json.utf8))
+        return VRMModel(specVersion: .v1_0, meta: VRMMeta(licenseUrl: ""), humanoid: nil, gltf: gltf)
     }
 }
 

--- a/Tests/VRMMetalKitTests/Animation/IKLayerTests.swift
+++ b/Tests/VRMMetalKitTests/Animation/IKLayerTests.swift
@@ -321,4 +321,81 @@ final class IKLayerTests: XCTestCase {
         layer.kneeForwardDirection = SIMD3<Float>(0, 0, -1)
         XCTAssertEqual(layer.kneeForwardDirection, SIMD3<Float>(0, 0, -1))
     }
+
+    func testIKLayer_DefaultGroundingMode() {
+        let layer = IKLayer()
+        switch layer.groundingMode {
+        case .walkCycle:
+            break // expected
+        case .idleGrounding:
+            XCTFail("Default grounding mode should be .walkCycle")
+        }
+    }
+
+    func testIKLayer_GroundingModeSettable() {
+        let layer = IKLayer()
+        layer.groundingMode = .idleGrounding
+        switch layer.groundingMode {
+        case .idleGrounding:
+            break // expected
+        case .walkCycle:
+            XCTFail("Grounding mode should be .idleGrounding after setting")
+        }
+    }
+
+    // MARK: - Compositor Bone Accessor Tests
+
+    func testCompositor_GetCompositedBoneRotation_ReturnsNilBeforeUpdate() {
+        let compositor = AnimationLayerCompositor()
+        XCTAssertNil(compositor.getCompositedBoneRotation(.head),
+            "Should return nil when no layers have been evaluated")
+    }
+
+    func testCompositor_GetCompositedBoneRotation_ReturnsValueAfterUpdate() {
+        let compositor = AnimationLayerCompositor()
+        let mockLayer = MockBoneLayer(bone: .head, rotation: simd_quatf(angle: .pi / 4, axis: SIMD3<Float>(0, 1, 0)))
+        compositor.addLayer(mockLayer)
+
+        let context = AnimationContext(time: 0, deltaTime: 1.0 / 60.0)
+        compositor.update(deltaTime: context.deltaTime, context: context)
+
+        let result = compositor.getCompositedBoneRotation(.head)
+        XCTAssertNotNil(result, "Should return rotation after layer evaluation")
+    }
+
+    func testCompositor_GetCompositedBoneRotation_UnaffectedBoneReturnsNil() {
+        let compositor = AnimationLayerCompositor()
+        let mockLayer = MockBoneLayer(bone: .head, rotation: simd_quatf(angle: .pi / 4, axis: SIMD3<Float>(0, 1, 0)))
+        compositor.addLayer(mockLayer)
+
+        let context = AnimationContext(time: 0, deltaTime: 1.0 / 60.0)
+        compositor.update(deltaTime: context.deltaTime, context: context)
+
+        XCTAssertNil(compositor.getCompositedBoneRotation(.hips),
+            "Bone not affected by any layer should return nil")
+    }
+}
+
+// MARK: - Mock Layer for Compositor Tests
+
+private final class MockBoneLayer: AnimationLayer {
+    let identifier: String = "mockBone"
+    let priority: Int = 1
+    var isEnabled: Bool = true
+    let affectedBones: Set<VRMHumanoidBone>
+
+    private let bone: VRMHumanoidBone
+    private let rotation: simd_quatf
+
+    init(bone: VRMHumanoidBone, rotation: simd_quatf) {
+        self.bone = bone
+        self.rotation = rotation
+        self.affectedBones = [bone]
+    }
+
+    func update(deltaTime: Float, context: AnimationContext) {}
+
+    func evaluate() -> LayerOutput {
+        LayerOutput(bones: [bone: ProceduralBoneTransform(rotation: rotation)])
+    }
 }


### PR DESCRIPTION
## Summary
- **`AnimationLayerCompositor.getCompositedBoneRotation(_:)`** — public accessor to read the total composited rotation for any bone after `update()`. Enables callers (e.g. Muse eye tracking) to perform VOR compensation against the full composited head rotation rather than just one layer.
- **`IKLayer.GroundingMode`** — new enum (`.walkCycle` / `.idleGrounding`). Idle grounding pins both feet at their rest positions captured during `initialize()`, preventing foot slide from hip translations during idle animation weight shifts. Walk cycle mode is unchanged (default).

## Test plan
- [x] `swift build --target VRMMetalKit` passes
- [x] `swift build --target VRMMetalKitTests` passes
- [ ] Existing test suite passes (VRMVideoRenderer has pre-existing linker issue)
- [ ] On-device verification in Muse: feet don't slide during weight shifts, eye VOR compensates all head layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)