### PR TITLE
fix: Respect doubleSided property for face-category materials

### DIFF
--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -2550,7 +2550,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
                     } else {
                         encoder.setDepthStencilState(depthStencilStates["opaque"])
                     }
-                    encoder.setCullMode(.back)
+                    encoder.setCullMode(isDoubleSided ? .none : .back)
                     encoder.setFrontFacing(.counterClockwise)
                     // Z-FIGHTING FIX: Body renders first but pushed back in depth
                     // Negative bias pushes away from camera, allowing overlays to win
@@ -2566,7 +2566,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
                     } else {
                         encoder.setDepthStencilState(depthStencilStates["opaque"])
                     }
-                    encoder.setCullMode(.back)
+                    encoder.setCullMode(isDoubleSided ? .none : .back)
                     encoder.setFrontFacing(.counterClockwise)
                     // Apply depth bias for clothing (overlay layer)
                     let bias = depthBiasCalculator.depthBias(for: item.materialName, isOverlay: true)
@@ -2597,7 +2597,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
                         }
                     }
 
-                    encoder.setCullMode(.back)
+                    encoder.setCullMode(isDoubleSided ? .none : .back)
                     encoder.setFrontFacing(.counterClockwise)
 
                     // Apply material-specific depth bias from calculator
@@ -2697,7 +2697,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
                 default:
                     // Unknown face category - fallback to opaque
                     encoder.setDepthStencilState(depthStencilStates["opaque"])
-                    encoder.setCullMode(.back)
+                    encoder.setCullMode(isDoubleSided ? .none : .back)
                     encoder.setFrontFacing(.counterClockwise)
                 }
             } else {


### PR DESCRIPTION
## Summary
- Fixed backface culling bug where body, clothing, skin, and default face-category rendering paths hardcoded `setCullMode(.back)`, ignoring the material's `doubleSided` property
- This made the inside of thin-sheet geometry (coats, skirts, ruffles) invisible when classified as face-adjacent materials
- Now uses the existing `isDoubleSided` variable (from `effectiveDoubleSided`) to match the non-face rendering path behavior

## Test plan
- [x] `swift build` passes
- [x] All 1179 tests pass
- [x] PNG renders of AvatarSample_A and AvatarSample_C show solid, visible clothing
- [x] MOV orbit render completes at 88.9 fps with no visual artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)