### PR TITLE
perf: Render hot-path fixes and benchmark target (−66% median)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,6 +64,10 @@ let package = Package(
             name: "VRMVideoRenderer",
             dependencies: ["VRMMetalKit"]
         ),
+        .executableTarget(
+            name: "VRMBenchmark",
+            dependencies: ["VRMMetalKit"]
+        ),
         .testTarget(
             name: "VRMMetalKitTests",
             dependencies: ["VRMMetalKit"],

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,10 @@ let package = Package(
                 .copy("Resources/VRMMetalKitShaders.metallib")
             ],
             swiftSettings: [
-                .define("VRM_METALKIT_ENABLE_DEBUG_ANIMATION"),
+                // Debug flags (VRM_METALKIT_ENABLE_LOGS / _DEBUG_ANIMATION /
+                // _DEBUG_PHYSICS / _DEBUG_LOADER) are opt-in at build time via
+                // `-Xswiftc -D<FLAG>`. Leaving them off by default keeps the
+                // hot path clean of string-building and validation work.
                 .enableExperimentalFeature("StrictConcurrency")
             ]
         ),

--- a/Sources/VRMBenchmark/main.swift
+++ b/Sources/VRMBenchmark/main.swift
@@ -24,11 +24,13 @@ import VRMMetalKit
 
 struct BenchmarkOptions {
     var inputPath: String = ""
+    var vrmaPath: String? = nil
     var frames: Int = 500
     var warmup: Int = 30
     var width: Int = 1024
     var height: Int = 1024
     var sampleCount: Int = 1
+    var fps: Double = 60
     var label: String = "baseline"
 }
 
@@ -40,15 +42,19 @@ func usage() {
     CPU frame-time percentiles plus renderer counters.
 
     Options:
+      --vrma PATH      Optional VRMA animation file; enables per-frame
+                       animation playback so skinning and spring physics
+                       do real work each frame (recommended).
       --frames N       Number of measured frames (default 500)
       --warmup N       Warm-up frames (default 30)
+      --fps N          Animation playback rate in frames/sec (default 60)
       --width W        Render width  (default 1024)
       --height H       Render height (default 1024)
       --sample-count N MSAA sample count (default 1)
       --label NAME     Tag printed in the report header (default "baseline")
 
     Recommended invocation:
-      swift run -c release VRMBenchmark <path> --frames 500
+      swift run -c release VRMBenchmark <vrm-path> --vrma <vrma-path> --frames 500
 
     Env fallback: if no <path> argument is given, AVATAR_SAMPLE_A is used.
     """)
@@ -74,6 +80,10 @@ func parseArguments() -> BenchmarkOptions? {
             i += 1; opts.height = Int(args[i]) ?? opts.height
         case "--sample-count":
             i += 1; opts.sampleCount = Int(args[i]) ?? opts.sampleCount
+        case "--vrma":
+            i += 1; opts.vrmaPath = args[i]
+        case "--fps":
+            i += 1; opts.fps = Double(args[i]) ?? opts.fps
         case "--label":
             i += 1; opts.label = args[i]
         default:
@@ -187,6 +197,31 @@ struct VRMBenchmarkCLI {
         }
         let loadMs = (CFAbsoluteTimeGetCurrent() - loadStart) * 1000.0
 
+        // Optional VRMA animation. When supplied, we run the animation player
+        // every frame so skinning, spring physics, and morph paths do real
+        // work (a static pose skips most of the per-frame CPU cost).
+        let player: AnimationPlayer?
+        let animDurationSec: Double
+        if let vrmaPath = opts.vrmaPath {
+            guard FileManager.default.fileExists(atPath: vrmaPath) else {
+                print("ERROR: VRMA file not found: \(vrmaPath)"); exit(1)
+            }
+            do {
+                let clip = try VRMAnimationLoader.loadVRMA(
+                    from: URL(fileURLWithPath: vrmaPath), model: model)
+                let p = AnimationPlayer()
+                p.load(clip)
+                p.play()
+                player = p
+                animDurationSec = Double(clip.duration)
+            } catch {
+                print("ERROR: failed to load VRMA: \(error)"); exit(1)
+            }
+        } else {
+            player = nil
+            animDurationSec = 0
+        }
+
         // Configure renderer
         var config = RendererConfig()
         config.sampleCount = opts.sampleCount
@@ -226,6 +261,8 @@ struct VRMBenchmarkCLI {
             print("ERROR: failed to create depth texture"); exit(1)
         }
 
+        let dt = Float(1.0 / opts.fps)
+
         func renderOnce(_ cpuTimeMs: inout Double) {
             // Wrap in autoreleasepool so Metal objects (command buffers, render
             // pass descriptors, encoders) are released every frame instead of
@@ -247,6 +284,9 @@ struct VRMBenchmarkCLI {
                 guard let cb = commandQueue.makeCommandBuffer() else { return }
 
                 let t0 = CACurrentMediaTime()
+                // Advance animation before drawing so per-frame measurement
+                // captures both the animation CPU cost and the render cost.
+                player?.update(deltaTime: dt, model: model)
                 renderer.drawOffscreenHeadless(
                     to: colorTex, depth: depthTex,
                     commandBuffer: cb, renderPassDescriptor: rpd)
@@ -285,6 +325,7 @@ struct VRMBenchmarkCLI {
         VRMMetalKit Render Benchmark — \(opts.label)
         ======================================================================
         Model          : \(url.lastPathComponent)
+        Animation      : \(opts.vrmaPath.map { "\(($0 as NSString).lastPathComponent) (\(String(format: "%.2f", animDurationSec))s @ \(opts.fps) fps)" } ?? "none (static pose)")
         Load time      : \(String(format: "%.1f ms", loadMs))
         Resolution     : \(opts.width)x\(opts.height) (MSAA \(opts.sampleCount)x)
         Warmup frames  : \(opts.warmup)

--- a/Sources/VRMBenchmark/main.swift
+++ b/Sources/VRMBenchmark/main.swift
@@ -1,0 +1,318 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import Metal
+import QuartzCore
+import simd
+import VRMMetalKit
+
+// MARK: - CLI
+
+struct BenchmarkOptions {
+    var inputPath: String = ""
+    var frames: Int = 500
+    var warmup: Int = 30
+    var width: Int = 1024
+    var height: Int = 1024
+    var sampleCount: Int = 1
+    var label: String = "baseline"
+}
+
+func usage() {
+    print("""
+    Usage: VRMBenchmark <path-to-vrm> [options]
+
+    Runs N frames of drawOffscreenHeadless against a VRM model and reports
+    CPU frame-time percentiles plus renderer counters.
+
+    Options:
+      --frames N       Number of measured frames (default 500)
+      --warmup N       Warm-up frames (default 30)
+      --width W        Render width  (default 1024)
+      --height H       Render height (default 1024)
+      --sample-count N MSAA sample count (default 1)
+      --label NAME     Tag printed in the report header (default "baseline")
+
+    Recommended invocation:
+      swift run -c release VRMBenchmark <path> --frames 500
+
+    Env fallback: if no <path> argument is given, AVATAR_SAMPLE_A is used.
+    """)
+}
+
+func parseArguments() -> BenchmarkOptions? {
+    var opts = BenchmarkOptions()
+    let args = Array(CommandLine.arguments.dropFirst())
+
+    var i = 0
+    while i < args.count {
+        let a = args[i]
+        switch a {
+        case "-h", "--help":
+            usage(); return nil
+        case "--frames":
+            i += 1; opts.frames = Int(args[i]) ?? opts.frames
+        case "--warmup":
+            i += 1; opts.warmup = Int(args[i]) ?? opts.warmup
+        case "--width":
+            i += 1; opts.width = Int(args[i]) ?? opts.width
+        case "--height":
+            i += 1; opts.height = Int(args[i]) ?? opts.height
+        case "--sample-count":
+            i += 1; opts.sampleCount = Int(args[i]) ?? opts.sampleCount
+        case "--label":
+            i += 1; opts.label = args[i]
+        default:
+            if opts.inputPath.isEmpty && !a.hasPrefix("--") {
+                opts.inputPath = a
+            }
+        }
+        i += 1
+    }
+
+    if opts.inputPath.isEmpty {
+        if let envPath = ProcessInfo.processInfo.environment["AVATAR_SAMPLE_A"] {
+            opts.inputPath = envPath
+        } else {
+            usage(); return nil
+        }
+    }
+    return opts
+}
+
+// MARK: - Math helpers (duplicated from VRMRender/main.swift to keep target standalone)
+
+func lookAtMatrix(eye: SIMD3<Float>, center: SIMD3<Float>, up: SIMD3<Float>) -> matrix_float4x4 {
+    let f = simd_normalize(center - eye)
+    let s = simd_normalize(simd_cross(f, up))
+    let u = simd_cross(s, f)
+    var r = matrix_float4x4(diagonal: SIMD4<Float>(1, 1, 1, 1))
+    r.columns.0 = SIMD4<Float>(s.x, u.x, -f.x, 0)
+    r.columns.1 = SIMD4<Float>(s.y, u.y, -f.y, 0)
+    r.columns.2 = SIMD4<Float>(s.z, u.z, -f.z, 0)
+    r.columns.3 = SIMD4<Float>(-simd_dot(s, eye), -simd_dot(u, eye), simd_dot(f, eye), 1)
+    return r
+}
+
+func perspectiveMatrix(fovRadians: Float, aspect: Float, near: Float, far: Float) -> matrix_float4x4 {
+    let t = tan(fovRadians / 2)
+    var r = matrix_float4x4()
+    r.columns.0 = SIMD4<Float>(1 / (aspect * t), 0, 0, 0)
+    r.columns.1 = SIMD4<Float>(0, 1 / t, 0, 0)
+    r.columns.2 = SIMD4<Float>(0, 0, -(far + near) / (far - near), -1)
+    r.columns.3 = SIMD4<Float>(0, 0, -(2 * far * near) / (far - near), 0)
+    return r
+}
+
+// MARK: - Statistics
+
+struct FrameStats {
+    let count: Int
+    let minMs: Double
+    let maxMs: Double
+    let meanMs: Double
+    let medianMs: Double
+    let p95Ms: Double
+    let p99Ms: Double
+    let stddevMs: Double
+
+    static func compute(_ samples: [Double]) -> FrameStats {
+        precondition(!samples.isEmpty)
+        let sorted = samples.sorted()
+        let n = sorted.count
+        let mean = sorted.reduce(0, +) / Double(n)
+        let variance = sorted.reduce(0) { $0 + ($1 - mean) * ($1 - mean) } / Double(n)
+        func pct(_ p: Double) -> Double {
+            let idx = min(n - 1, max(0, Int((p * Double(n - 1)).rounded())))
+            return sorted[idx]
+        }
+        return FrameStats(
+            count: n,
+            minMs: sorted.first!,
+            maxMs: sorted.last!,
+            meanMs: mean,
+            medianMs: pct(0.50),
+            p95Ms: pct(0.95),
+            p99Ms: pct(0.99),
+            stddevMs: sqrt(variance)
+        )
+    }
+}
+
+// MARK: - Main
+
+@main
+struct VRMBenchmarkCLI {
+    @MainActor
+    static func main() async {
+        guard let opts = parseArguments() else { exit(0) }
+
+        guard FileManager.default.fileExists(atPath: opts.inputPath) else {
+            print("ERROR: file not found: \(opts.inputPath)")
+            exit(1)
+        }
+
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            print("ERROR: Metal device not available")
+            exit(1)
+        }
+        guard let commandQueue = device.makeCommandQueue() else {
+            print("ERROR: failed to create command queue")
+            exit(1)
+        }
+
+        // Load model
+        let url = URL(fileURLWithPath: opts.inputPath)
+        let loadStart = CFAbsoluteTimeGetCurrent()
+        let model: VRMModel
+        do {
+            model = try await VRMModel.load(from: url, device: device)
+        } catch {
+            print("ERROR: failed to load VRM: \(error)")
+            exit(1)
+        }
+        let loadMs = (CFAbsoluteTimeGetCurrent() - loadStart) * 1000.0
+
+        // Configure renderer
+        var config = RendererConfig()
+        config.sampleCount = opts.sampleCount
+        config.strict = .off
+        let renderer = VRMRenderer(device: device, config: config)
+        renderer.performanceTracker = PerformanceTracker()
+        renderer.loadModel(model)
+        renderer.setLight(0, direction: SIMD3<Float>(-0.2, 0.5, -0.85),
+                          color: SIMD3<Float>(1, 1, 1), intensity: 1.0)
+        renderer.disableLight(1)
+        renderer.setLight(2, direction: SIMD3<Float>(0, 0.2, 1),
+                          color: SIMD3<Float>(1, 1, 1), intensity: 0.3)
+        renderer.setAmbientColor(SIMD3<Float>(0.04, 0.04, 0.04))
+
+        let aspect = Float(opts.width) / Float(opts.height)
+        renderer.projectionMatrix = perspectiveMatrix(
+            fovRadians: 45.0 * .pi / 180.0, aspect: aspect, near: 0.01, far: 100.0)
+        renderer.viewMatrix = lookAtMatrix(
+            eye: SIMD3<Float>(0, 1.3, 1.8),
+            center: SIMD3<Float>(0, 1.3, 0),
+            up: SIMD3<Float>(0, 1, 0))
+
+        // Offscreen targets (reused every frame)
+        let colorDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .rgba8Unorm, width: opts.width, height: opts.height, mipmapped: false)
+        colorDesc.usage = [.renderTarget, .shaderRead]
+        colorDesc.storageMode = .private
+        guard let colorTex = device.makeTexture(descriptor: colorDesc) else {
+            print("ERROR: failed to create color texture"); exit(1)
+        }
+
+        let depthDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .depth32Float, width: opts.width, height: opts.height, mipmapped: false)
+        depthDesc.usage = .renderTarget
+        depthDesc.storageMode = .private
+        guard let depthTex = device.makeTexture(descriptor: depthDesc) else {
+            print("ERROR: failed to create depth texture"); exit(1)
+        }
+
+        func renderOnce(_ cpuTimeMs: inout Double) {
+            let rpd = MTLRenderPassDescriptor()
+            rpd.colorAttachments[0].texture = colorTex
+            rpd.colorAttachments[0].loadAction = .clear
+            rpd.colorAttachments[0].storeAction = .store
+            rpd.colorAttachments[0].clearColor = MTLClearColor(red: 0.12, green: 0.14, blue: 0.18, alpha: 1)
+            rpd.depthAttachment.texture = depthTex
+            rpd.depthAttachment.loadAction = .clear
+            rpd.depthAttachment.storeAction = .dontCare
+            rpd.depthAttachment.clearDepth = 1.0
+
+            guard let cb = commandQueue.makeCommandBuffer() else { return }
+
+            let t0 = CACurrentMediaTime()
+            renderer.drawOffscreenHeadless(
+                to: colorTex, depth: depthTex,
+                commandBuffer: cb, renderPassDescriptor: rpd)
+            cb.commit()
+            cb.waitUntilCompleted()
+            cpuTimeMs = (CACurrentMediaTime() - t0) * 1000.0
+        }
+
+        // Warm-up
+        var discard = 0.0
+        for _ in 0..<opts.warmup {
+            renderOnce(&discard)
+        }
+        renderer.resetPerformanceMetrics()
+
+        // Measure
+        var samples: [Double] = []
+        samples.reserveCapacity(opts.frames)
+        let benchStart = CACurrentMediaTime()
+        for _ in 0..<opts.frames {
+            var ms = 0.0
+            renderOnce(&ms)
+            samples.append(ms)
+        }
+        let wallMs = (CACurrentMediaTime() - benchStart) * 1000.0
+
+        // Report
+        let stats = FrameStats.compute(samples)
+        let rendererMetrics = renderer.getPerformanceMetrics()
+
+        print("""
+
+        ======================================================================
+        VRMMetalKit Render Benchmark — \(opts.label)
+        ======================================================================
+        Model          : \(url.lastPathComponent)
+        Load time      : \(String(format: "%.1f ms", loadMs))
+        Resolution     : \(opts.width)x\(opts.height) (MSAA \(opts.sampleCount)x)
+        Warmup frames  : \(opts.warmup)
+        Measured frames: \(opts.frames)
+        Total wall time: \(String(format: "%.1f ms", wallMs))
+
+        Per-frame CPU time (drawOffscreenHeadless + commit + wait)
+        ----------------------------------------------------------------------
+          min    : \(String(format: "%7.3f ms", stats.minMs))
+          median : \(String(format: "%7.3f ms", stats.medianMs))
+          mean   : \(String(format: "%7.3f ms", stats.meanMs))   (±\(String(format: "%.3f", stats.stddevMs)) stddev)
+          p95    : \(String(format: "%7.3f ms", stats.p95Ms))
+          p99    : \(String(format: "%7.3f ms", stats.p99Ms))
+          max    : \(String(format: "%7.3f ms", stats.maxMs))
+          eff FPS: \(String(format: "%.1f", 1000.0 / max(stats.meanMs, 0.0001)))
+        """)
+
+        if let m = rendererMetrics {
+            // PerformanceTracker counters are cumulative across measured frames.
+            let frames = max(stats.count, 1)
+            let perFrame: (Int) -> String = { total in
+                String(format: "%.1f", Double(total) / Double(frames))
+            }
+            print("""
+
+            Renderer counters (per frame, averaged)
+            ----------------------------------------------------------------------
+              draw calls        : \(perFrame(m.drawCalls))
+              pipeline changes  : \(perFrame(m.pipelineChanges))
+              state changes     : \(perFrame(m.stateChanges))
+              texture bindings  : \(perFrame(m.textureBindings))
+              buffer bindings   : \(perFrame(m.bufferBindings))
+              morph computes    : \(perFrame(m.morphComputes))
+              triangles         : \(perFrame(m.triangleCount))
+              vertices          : \(perFrame(m.vertexCount))
+            """)
+        }
+        print("======================================================================\n")
+    }
+}

--- a/Sources/VRMBenchmark/main.swift
+++ b/Sources/VRMBenchmark/main.swift
@@ -227,25 +227,34 @@ struct VRMBenchmarkCLI {
         }
 
         func renderOnce(_ cpuTimeMs: inout Double) {
-            let rpd = MTLRenderPassDescriptor()
-            rpd.colorAttachments[0].texture = colorTex
-            rpd.colorAttachments[0].loadAction = .clear
-            rpd.colorAttachments[0].storeAction = .store
-            rpd.colorAttachments[0].clearColor = MTLClearColor(red: 0.12, green: 0.14, blue: 0.18, alpha: 1)
-            rpd.depthAttachment.texture = depthTex
-            rpd.depthAttachment.loadAction = .clear
-            rpd.depthAttachment.storeAction = .dontCare
-            rpd.depthAttachment.clearDepth = 1.0
+            // Wrap in autoreleasepool so Metal objects (command buffers, render
+            // pass descriptors, encoders) are released every frame instead of
+            // accumulating until the outer pool drains. Without this, running
+            // 500+ frames in a tight loop leaks driver threads and can trigger
+            // a system watchdog panic.
+            var ms = 0.0
+            autoreleasepool {
+                let rpd = MTLRenderPassDescriptor()
+                rpd.colorAttachments[0].texture = colorTex
+                rpd.colorAttachments[0].loadAction = .clear
+                rpd.colorAttachments[0].storeAction = .store
+                rpd.colorAttachments[0].clearColor = MTLClearColor(red: 0.12, green: 0.14, blue: 0.18, alpha: 1)
+                rpd.depthAttachment.texture = depthTex
+                rpd.depthAttachment.loadAction = .clear
+                rpd.depthAttachment.storeAction = .dontCare
+                rpd.depthAttachment.clearDepth = 1.0
 
-            guard let cb = commandQueue.makeCommandBuffer() else { return }
+                guard let cb = commandQueue.makeCommandBuffer() else { return }
 
-            let t0 = CACurrentMediaTime()
-            renderer.drawOffscreenHeadless(
-                to: colorTex, depth: depthTex,
-                commandBuffer: cb, renderPassDescriptor: rpd)
-            cb.commit()
-            cb.waitUntilCompleted()
-            cpuTimeMs = (CACurrentMediaTime() - t0) * 1000.0
+                let t0 = CACurrentMediaTime()
+                renderer.drawOffscreenHeadless(
+                    to: colorTex, depth: depthTex,
+                    commandBuffer: cb, renderPassDescriptor: rpd)
+                cb.commit()
+                cb.waitUntilCompleted()
+                ms = (CACurrentMediaTime() - t0) * 1000.0
+            }
+            cpuTimeMs = ms
         }
 
         // Warm-up

--- a/Sources/VRMBenchmark/main.swift
+++ b/Sources/VRMBenchmark/main.swift
@@ -65,27 +65,46 @@ func parseArguments() -> BenchmarkOptions? {
     let args = Array(CommandLine.arguments.dropFirst())
 
     var i = 0
+    // Reads the value following a value-flag, returns nil if the flag was
+    // the last token so we fail cleanly instead of index-out-of-range.
+    func nextValue(for flag: String) -> String? {
+        i += 1
+        guard i < args.count else {
+            print("ERROR: missing value for \(flag)")
+            return nil
+        }
+        return args[i]
+    }
+
     while i < args.count {
         let a = args[i]
         switch a {
         case "-h", "--help":
             usage(); return nil
         case "--frames":
-            i += 1; opts.frames = Int(args[i]) ?? opts.frames
+            guard let v = nextValue(for: a) else { return nil }
+            opts.frames = Int(v) ?? opts.frames
         case "--warmup":
-            i += 1; opts.warmup = Int(args[i]) ?? opts.warmup
+            guard let v = nextValue(for: a) else { return nil }
+            opts.warmup = Int(v) ?? opts.warmup
         case "--width":
-            i += 1; opts.width = Int(args[i]) ?? opts.width
+            guard let v = nextValue(for: a) else { return nil }
+            opts.width = Int(v) ?? opts.width
         case "--height":
-            i += 1; opts.height = Int(args[i]) ?? opts.height
+            guard let v = nextValue(for: a) else { return nil }
+            opts.height = Int(v) ?? opts.height
         case "--sample-count":
-            i += 1; opts.sampleCount = Int(args[i]) ?? opts.sampleCount
+            guard let v = nextValue(for: a) else { return nil }
+            opts.sampleCount = Int(v) ?? opts.sampleCount
         case "--vrma":
-            i += 1; opts.vrmaPath = args[i]
+            guard let v = nextValue(for: a) else { return nil }
+            opts.vrmaPath = v
         case "--fps":
-            i += 1; opts.fps = Double(args[i]) ?? opts.fps
+            guard let v = nextValue(for: a) else { return nil }
+            opts.fps = Double(v) ?? opts.fps
         case "--label":
-            i += 1; opts.label = args[i]
+            guard let v = nextValue(for: a) else { return nil }
+            opts.label = v
         default:
             if opts.inputPath.isEmpty && !a.hasPrefix("--") {
                 opts.inputPath = a

--- a/Sources/VRMMetalKit/Animation/VRMSkinning.swift
+++ b/Sources/VRMMetalKit/Animation/VRMSkinning.swift
@@ -32,74 +32,11 @@ public class VRMSkinningSystem {
     private var currentFrameNumber: Int = 0
     private var skinLastUpdatedFrame: [Int: Int] = [:]  // skinIndex -> frameNumber
 
-    // DIFFERENTIAL TRANSFORM ANALYSIS: Clean baseline captures
-    private var cleanWorldMatrices: [ObjectIdentifier: float4x4] = [:]  // nodeID -> clean worldMatrix
-    private var hasCapturedCleanBaseline = false
-
     // A/B Testing: Identity palette override
     public var testIdentityPalette: Int? = nil
 
     public init(device: MTLDevice) {
         self.device = device
-    }
-
-    /// Pre-flight check: Capture clean worldMatrix for each joint in isolation
-    public func captureCleanBaseline(for skin: VRMSkin, skinIndex: Int) {
-        guard !hasCapturedCleanBaseline else { return }
-
-        vrmLog("🔬 [DIFFERENTIAL] Capturing clean baseline for skin \(skinIndex) (\(skin.joints.count) joints)")
-
-        for (index, joint) in skin.joints.enumerated() {
-            // Recursively calculate worldMatrix in isolation (from local transforms only)
-            let cleanWorld = calculateCleanWorldMatrix(for: joint)
-            cleanWorldMatrices[ObjectIdentifier(joint)] = cleanWorld
-
-            if index < 5 {
-                vrmLog("   Joint[\(index)] '\(joint.name ?? "?")': clean translation magnitude = \(length(simd_float3(cleanWorld[3][0], cleanWorld[3][1], cleanWorld[3][2])))")
-            }
-        }
-
-        hasCapturedCleanBaseline = true
-        vrmLog("✅ [DIFFERENTIAL] Baseline captured for \(cleanWorldMatrices.count) joints")
-    }
-
-    /// Calculate worldMatrix in isolation by walking up parent chain
-    private func calculateCleanWorldMatrix(for node: VRMNode) -> float4x4 {
-        var current: VRMNode? = node
-        var matrices: [float4x4] = []
-
-        // Walk up to root, collecting local matrices
-        while let n = current {
-            // Build local matrix from TRS components
-            let translationMatrix = matrix_float4x4(
-                SIMD4<Float>(1, 0, 0, 0),
-                SIMD4<Float>(0, 1, 0, 0),
-                SIMD4<Float>(0, 0, 1, 0),
-                SIMD4<Float>(n.translation.x, n.translation.y, n.translation.z, 1)
-            )
-
-            let rotationMatrix = matrix_float4x4(n.rotation)
-
-            let scaleMatrix = matrix_float4x4(
-                SIMD4<Float>(n.scale.x, 0, 0, 0),
-                SIMD4<Float>(0, n.scale.y, 0, 0),
-                SIMD4<Float>(0, 0, n.scale.z, 0),
-                SIMD4<Float>(0, 0, 0, 1)
-            )
-
-            // Local = T * R * S
-            let localMatrix = translationMatrix * rotationMatrix * scaleMatrix
-            matrices.insert(localMatrix, at: 0)  // Insert at beginning to maintain order
-            current = n.parent
-        }
-
-        // Multiply matrices from root to node
-        var worldMatrix = matrix_identity_float4x4
-        for m in matrices {
-            worldMatrix = worldMatrix * m
-        }
-
-        return worldMatrix
     }
 
     // Initialize the buffer system with all skins to calculate offsets
@@ -143,312 +80,32 @@ public class VRMSkinningSystem {
     public func updateJointMatrices(for skin: VRMSkin, skinIndex: Int) {
         guard let buffer = jointMatricesBuffer else { return }
 
+        let pointer = buffer.contents()
+            .advanced(by: skin.bufferByteOffset)
+            .bindMemory(to: float4x4.self, capacity: skin.joints.count)
+
         // A/B TEST: Use identity matrices if this skin is being tested
         if let testSkin = testIdentityPalette, testSkin == skinIndex {
-            vrmLog("🧪 [IDENTITY TEST] Using identity palette for skin \(skinIndex) (A/B test)")
-
-            // Fill palette with identity matrices
-            var identityMatrices = [float4x4]()
-            for _ in 0..<skin.joints.count {
-                identityMatrices.append(matrix_identity_float4x4)
+            for i in 0..<skin.joints.count {
+                pointer[i] = matrix_identity_float4x4
             }
-
-            // Write to buffer
-            let pointer = buffer.contents().advanced(by: skin.bufferByteOffset).bindMemory(to: float4x4.self, capacity: skin.joints.count)
-            for (i, matrix) in identityMatrices.enumerated() {
-                pointer[i] = matrix
-            }
-
-            vrmLog("✅ [IDENTITY TEST] Written \(skin.joints.count) identity matrices to GPU buffer at offset \(skin.bufferByteOffset)")
             return
         }
 
-        // Skip if we just updated this skin (optimization)
-        // DISABLED: This causes issues when multiple meshes use same skin
-        // if let lastIndex = lastUpdatedSkinIndex, lastIndex == skinIndex {
-        //     return
-        // }
         lastUpdatedSkinIndex = skinIndex
-
-        // Mark this skin as updated for freshness tracking
         markSkinUpdated(skinIndex: skinIndex)
-
-        var matrices = [float4x4]()
-
-        // Debug: Check joints to see if animation is applied
         debugFrameCount += 1
-        if debugFrameCount % 10 == 0 {
-            vrmLog("[UPDATE ORDER] 3. Skinning.updateJointMatrices() - building palette for skin \(skinIndex)")
-            vrmLog("[SKINNING] Updating \(skin.joints.count) joint matrices for skin \(skinIndex) at offset \(skin.matrixOffset)")
-        }
-        if debugFrameCount == 1 {
-            // Log ALL skin joints on first frame to understand mapping
-            vrmLog("[SKIN MAPPING] Skin contains \(skin.joints.count) joints:")
-            for (i, joint) in skin.joints.enumerated().prefix(10) {
-                vrmLog("[SKIN MAPPING] Joint[\(i)]: node \(joint.name ?? "?") rotation=\(joint.rotation)")
-
-                // Trace hierarchy up to root
-                var chain = [String]()
-                var current: VRMNode? = joint
-                while let node = current {
-                    chain.append(node.name ?? "node?")
-                    current = node.parent
-                }
-                vrmLog("[HIERARCHY] Joint[\(i)] chain: \(chain.joined(separator: " → "))")
-            }
-        }
-        if debugFrameCount % 60 == 0 && !skin.joints.isEmpty {
-            // Check multiple joints
-            for i in 0..<min(5, skin.joints.count) {
-                let joint = skin.joints[i]
-                vrmLog("[Skinning] Frame \(debugFrameCount): Joint \(i) (\(joint.name ?? "unnamed")) rotation: \(joint.rotation)")
-            }
-        }
 
         for (index, joint) in skin.joints.enumerated() {
-            // Calculate skinning matrix: joint world matrix * inverse bind matrix
-            // Standard formula: world * inverseBindPose
-            let worldMatrix = joint.worldMatrix
-            let inverseBindMatrix = skin.inverseBindMatrices[index]
+            let skinMatrix = joint.worldMatrix * skin.inverseBindMatrices[index]
 
-            // DIFFERENTIAL TRANSFORM ANALYSIS: Compare live vs clean for skin 4
-            if skinIndex == 4, let cleanWorld = cleanWorldMatrices[ObjectIdentifier(joint)] {
-                // Check for corruption: NaN/Inf or excessive deviation from clean baseline
-                let liveTranslation = simd_float3(worldMatrix[3][0], worldMatrix[3][1], worldMatrix[3][2])
-                let cleanTranslation = simd_float3(cleanWorld[3][0], cleanWorld[3][1], cleanWorld[3][2])
-                let deviation = length(liveTranslation - cleanTranslation)
-
-                let hasNaNLive = !worldMatrix[0][0].isFinite || !worldMatrix[1][1].isFinite || !worldMatrix[2][2].isFinite
-                let hasNaNClean = !cleanWorld[0][0].isFinite || !cleanWorld[1][1].isFinite || !cleanWorld[2][2].isFinite
-
-                // Log first few joints to see actual deviation values
-                if index < 5 {
-                    vrmLog("[DIFFERENTIAL DEBUG] Frame=\(debugFrameCount) Joint[\(index)] '\(joint.name ?? "unnamed")': deviation=\(deviation)")
-
-                    // Also check inverseBindMatrix for corruption
-                    let invBindTrans = simd_float3(inverseBindMatrix[3][0], inverseBindMatrix[3][1], inverseBindMatrix[3][2])
-                    let invBindMag = length(invBindTrans)
-                    let hasNaNInvBind = !inverseBindMatrix[0][0].isFinite || !inverseBindMatrix[1][1].isFinite
-                    vrmLog("   InverseBindMatrix translation mag: \(invBindMag), hasNaN: \(hasNaNInvBind)")
-                }
-
-                // Tolerate small numerical drift; only warn on larger deviation or NaN
-                let deviationThreshold: Float = 0.1
-                if hasNaNLive || deviation > deviationThreshold {
-                    vrmLog("")
-                    vrmLog("🚨 [CORRUPTION DETECTED] Skin[\(skinIndex)] Joint[\(index)] '\(joint.name ?? "unnamed")'")
-                    vrmLog("   Live matrix NaN: \(hasNaNLive), Clean matrix NaN: \(hasNaNClean)")
-                    vrmLog("   Live translation: \(liveTranslation)")
-                    vrmLog("   Clean translation: \(cleanTranslation)")
-                    vrmLog("   Deviation: \(deviation)")
-                    vrmLog("")
-
-                    // Dump entire parent hierarchy
-                    vrmLog("📊 [HIERARCHY DUMP] Tracing corruption source:")
-                    var current: VRMNode? = joint
-                    var level = 0
-                    while let node = current {
-                        let indent = String(repeating: "  ", count: level)
-                        let nodeName = node.name ?? "unnamed"
-                        let localTrans = node.translation
-                        let worldTrans = simd_float3(node.worldMatrix[3][0], node.worldMatrix[3][1], node.worldMatrix[3][2])
-
-                        vrmLog("\(indent)Level \(level): '\(nodeName)'")
-                        vrmLog("\(indent)  Local: t=\(localTrans) r=\(node.rotation) s=\(node.scale)")
-                        vrmLog("\(indent)  World translation: \(worldTrans)")
-
-                        if !node.worldMatrix[0][0].isFinite {
-                            vrmLog("\(indent)  ❌ THIS NODE HAS NaN IN WORLD MATRIX!")
-                        }
-
-                        current = node.parent
-                        level += 1
-                    }
-                    vrmLog("")
-
-                    // Do not crash in production; log only. If needed, tighten via Strict mode later.
-                }
-            }
-
-            // TEST: Try manual multiplication to debug
-            if debugFrameCount == 1 && skinIndex == 0 && index == 0 {
-                // Manual multiplication for debugging
-                let w = worldMatrix
-                let ib = inverseBindMatrix
-
-                // Matrix multiplication: result[i][j] = sum(w[i][k] * ib[k][j])
-                var manual = matrix_identity_float4x4
-                for i in 0..<4 {
-                    for j in 0..<4 {
-                        var sum: Float = 0
-                        for k in 0..<4 {
-                            sum += w[i][k] * ib[k][j]
-                        }
-                        manual[i][j] = sum
-                    }
-                }
-                vrmLog("[DEBUG] Manual multiplication result:")
-                vrmLog("    [\(manual[0][0]), \(manual[0][1]), \(manual[0][2]), \(manual[0][3])]")
-                vrmLog("    [\(manual[1][0]), \(manual[1][1]), \(manual[1][2]), \(manual[1][3])]")
-                vrmLog("    [\(manual[2][0]), \(manual[2][1]), \(manual[2][2]), \(manual[2][3])]")
-                vrmLog("    [\(manual[3][0]), \(manual[3][1]), \(manual[3][2]), \(manual[3][3])]")
-            }
-
-            // Standard skinning formula: worldMatrix * inverseBindMatrix
-            // Now that we're not transposing the inverse bind matrices, try the standard order
-            let skinMatrix = worldMatrix * inverseBindMatrix
-
-            // CORRUPTION GUARD: Comprehensive validation before adding to palette
-            let allComponents = [skinMatrix[0][0], skinMatrix[0][1], skinMatrix[0][2], skinMatrix[0][3],
-                                 skinMatrix[1][0], skinMatrix[1][1], skinMatrix[1][2], skinMatrix[1][3],
-                                 skinMatrix[2][0], skinMatrix[2][1], skinMatrix[2][2], skinMatrix[2][3],
-                                 skinMatrix[3][0], skinMatrix[3][1], skinMatrix[3][2], skinMatrix[3][3]]
-
-            let hasNaN = allComponents.contains { !$0.isFinite }
-            let translation = simd_float3(skinMatrix[3][0], skinMatrix[3][1], skinMatrix[3][2])
-            let translationMag = length(translation)
-            let scale0 = length(simd_float3(skinMatrix[0][0], skinMatrix[0][1], skinMatrix[0][2]))
-            let scale1 = length(simd_float3(skinMatrix[1][0], skinMatrix[1][1], skinMatrix[1][2]))
-            let scale2 = length(simd_float3(skinMatrix[2][0], skinMatrix[2][1], skinMatrix[2][2]))
-
-            if hasNaN || translationMag > 1000.0 || scale0 < 0.001 || scale0 > 1000.0 || scale1 < 0.001 || scale1 > 1000.0 || scale2 < 0.001 || scale2 > 1000.0 {
-                vrmLog("❌ [SKINNING CORRUPTION] Skin[\(skinIndex)] Joint[\(index)] '\(joint.name ?? "unnamed")'")
-                vrmLog("   NaN/Inf: \(hasNaN)")
-                vrmLog("   Translation magnitude: \(translationMag)")
-                vrmLog("   Scale: [\(scale0), \(scale1), \(scale2)]")
-                vrmLog("   WorldMatrix diagonal: [\(worldMatrix[0][0]), \(worldMatrix[1][1]), \(worldMatrix[2][2]), \(worldMatrix[3][3])]")
-                vrmLog("   InverseBindMatrix diagonal: [\(inverseBindMatrix[0][0]), \(inverseBindMatrix[1][1]), \(inverseBindMatrix[2][2]), \(inverseBindMatrix[3][3])]")
-
-                // Use identity matrix as fallback for this frame
-                matrices.append(float4x4(1))
-                continue
-            }
-
-            // SPECIAL LOGGING FOR SKIN 4 (flonthair) - Log all joints
-            if skinIndex == 4 && debugFrameCount <= 2 {
-                vrmLog("[SKIN 4 ANALYSIS] Frame=\(debugFrameCount) Joint[\(index)] '\(joint.name ?? "unnamed")'")
-                vrmLog("   Translation: \(translation), magnitude: \(translationMag)")
-                vrmLog("   Scale: [\(scale0), \(scale1), \(scale2)]")
-                if hasNaN || translationMag > 100.0 {
-                    vrmLog("   ⚠️  SUSPICIOUS VALUES DETECTED")
-                }
-            }
-
-            // AGGRESSIVE MATRIX LOGGING - First frame comparison between models
-            if debugFrameCount == 1 && index < 3 {  // Log first 3 joints of every skin
-                vrmLog("[MATRIX COMPARISON] Skin[\(skinIndex)] Joint[\(index)] (\(joint.name ?? "unnamed"))")
-
-                let w = worldMatrix
-                let ib = inverseBindMatrix
-                let s = skinMatrix
-
-                // Log input matrices
-                vrmLog("  WorldMatrix:")
-                vrmLog("    [\(w[0][0]), \(w[0][1]), \(w[0][2]), \(w[0][3])]")
-                vrmLog("    [\(w[1][0]), \(w[1][1]), \(w[1][2]), \(w[1][3])]")
-                vrmLog("    [\(w[2][0]), \(w[2][1]), \(w[2][2]), \(w[2][3])]")
-                vrmLog("    [\(w[3][0]), \(w[3][1]), \(w[3][2]), \(w[3][3])]")
-
-                vrmLog("  InverseBindMatrix:")
-                vrmLog("    [\(ib[0][0]), \(ib[0][1]), \(ib[0][2]), \(ib[0][3])]")
-                vrmLog("    [\(ib[1][0]), \(ib[1][1]), \(ib[1][2]), \(ib[1][3])]")
-                vrmLog("    [\(ib[2][0]), \(ib[2][1]), \(ib[2][2]), \(ib[2][3])]")
-                vrmLog("    [\(ib[3][0]), \(ib[3][1]), \(ib[3][2]), \(ib[3][3])]")
-
-                vrmLog("  ResultingSkinMatrix (world * inverseBind):")
-                vrmLog("    [\(s[0][0]), \(s[0][1]), \(s[0][2]), \(s[0][3])]")
-                vrmLog("    [\(s[1][0]), \(s[1][1]), \(s[1][2]), \(s[1][3])]")
-                vrmLog("    [\(s[2][0]), \(s[2][1]), \(s[2][2]), \(s[2][3])]")
-                vrmLog("    [\(s[3][0]), \(s[3][1]), \(s[3][2]), \(s[3][3])]")
-
-                // NaN/Inf detection
-                let hasNaN = [s[0][0], s[0][1], s[0][2], s[0][3],
-                             s[1][0], s[1][1], s[1][2], s[1][3],
-                             s[2][0], s[2][1], s[2][2], s[2][3],
-                             s[3][0], s[3][1], s[3][2], s[3][3]].contains { !$0.isFinite }
-
-                if hasNaN {
-                    vrmLog("  ❌ ERROR: Matrix contains NaN or Inf values!")
-                    // Log error instead of crashing - this allows recovery/debugging
-                    let error = VRMSkinningError.matrixContainsNaN(
-                        skinIndex: skinIndex,
-                        jointIndex: index,
-                        jointName: joint.name
-                    )
-                    vrmLog("❌ [VRMSkinning] \(error.localizedDescription)")
-                    // Continue to allow investigation of other joints
-                }
-
-                // Check if it's roughly identity (for bind pose verification)
-                let isIdentity = abs(s[0][0] - 1) < 0.001 && abs(s[1][1] - 1) < 0.001 &&
-                                abs(s[2][2] - 1) < 0.001 && abs(s[3][3] - 1) < 0.001 &&
-                                abs(s[0][3]) < 0.001 && abs(s[1][3]) < 0.001 && abs(s[2][3]) < 0.001
-                vrmLog("  Is Identity? \(isIdentity) (expected for bind pose)")
-
-                // Additional validation
-                let translation = simd_float3(s[3][0], s[3][1], s[3][2])
-                let scale = simd_float3(length(simd_float3(s[0][0], s[0][1], s[0][2])),
-                                       length(simd_float3(s[1][0], s[1][1], s[1][2])),
-                                       length(simd_float3(s[2][0], s[2][1], s[2][2])))
-                vrmLog("  Translation: \(translation)")
-                vrmLog("  Scale: \(scale)")
-            }
-
-            // Validate the matrix - check for NaN or infinity
-            let isValid = skinMatrix[0][0].isFinite && skinMatrix[1][1].isFinite &&
-                         skinMatrix[2][2].isFinite && skinMatrix[3][3].isFinite
-
-            if !isValid {
-                vrmLog("[SKINNING ERROR] Invalid matrix for joint \(index) (\(joint.name ?? "?"))")
-                vrmLog("  World matrix diagonal: [\(worldMatrix[0][0]), \(worldMatrix[1][1]), \(worldMatrix[2][2]), \(worldMatrix[3][3])]")
-                vrmLog("  InverseBind diagonal: [\(inverseBindMatrix[0][0]), \(inverseBindMatrix[1][1]), \(inverseBindMatrix[2][2]), \(inverseBindMatrix[3][3])]")
-                // Use identity matrix as fallback
-                matrices.append(float4x4(1))
-            } else {
-                matrices.append(skinMatrix)
-            }
-
-            // Debug first joint in detail on first frame
-            if debugFrameCount == 1 && index == 0 {
-                vrmLog("[SKIN MATRIX DEBUG] Joint 0 (\(joint.name ?? "?")):")
-                let w = joint.worldMatrix
-                vrmLog("  World Matrix:")
-                vrmLog("    [\(w[0][0]), \(w[0][1]), \(w[0][2]), \(w[0][3])]")
-                vrmLog("    [\(w[1][0]), \(w[1][1]), \(w[1][2]), \(w[1][3])]")
-                vrmLog("    [\(w[2][0]), \(w[2][1]), \(w[2][2]), \(w[2][3])]")
-                vrmLog("    [\(w[3][0]), \(w[3][1]), \(w[3][2]), \(w[3][3])]")
-
-                let ib = skin.inverseBindMatrices[index]
-                vrmLog("  Inverse Bind Matrix:")
-                vrmLog("    [\(ib[0][0]), \(ib[0][1]), \(ib[0][2]), \(ib[0][3])]")
-                vrmLog("    [\(ib[1][0]), \(ib[1][1]), \(ib[1][2]), \(ib[1][3])]")
-                vrmLog("    [\(ib[2][0]), \(ib[2][1]), \(ib[2][2]), \(ib[2][3])]")
-                vrmLog("    [\(ib[3][0]), \(ib[3][1]), \(ib[3][2]), \(ib[3][3])]")
-
-                let s = skinMatrix
-                vrmLog("  Skin Matrix (Result):")
-                vrmLog("    [\(s[0][0]), \(s[0][1]), \(s[0][2]), \(s[0][3])]")
-                vrmLog("    [\(s[1][0]), \(s[1][1]), \(s[1][2]), \(s[1][3])]")
-                vrmLog("    [\(s[2][0]), \(s[2][1]), \(s[2][2]), \(s[2][3])]")
-                vrmLog("    [\(s[3][0]), \(s[3][1]), \(s[3][2]), \(s[3][3])]")
-            }
-
-            // Debug: Check if the palette has non-identity transforms
-            if debugFrameCount % 60 == 0 && index < 5 {
-                // Check if world matrix is identity (no animation)
-                let m = joint.worldMatrix
-                let isIdentity = (m[0][0] == 1 && m[1][1] == 1 && m[2][2] == 1 && m[3][3] == 1 &&
-                                 m[0][3] == 0 && m[1][3] == 0 && m[2][3] == 0)
-                vrmLog("[PALETTE] Joint \(index) (\(joint.name ?? "?")): worldMatrix diagonal=[\(m[0][0]), \(m[1][1]), \(m[2][2])], identity=\(isIdentity)")
-            }
-        }
-
-        // Update buffer at the correct offset for this skin
-        let pointer = buffer.contents().advanced(by: skin.bufferByteOffset).bindMemory(to: float4x4.self, capacity: skin.joints.count)
-
-        // Copy matrices to the correct location
-        for (index, matrix) in matrices.enumerated() {
-            pointer[index] = matrix
+            // Diagonal-only NaN/Inf guard. Sufficient to catch garbage without
+            // allocating a per-joint validation array.
+            let diagValid = skinMatrix[0][0].isFinite
+                && skinMatrix[1][1].isFinite
+                && skinMatrix[2][2].isFinite
+                && skinMatrix[3][3].isFinite
+            pointer[index] = diagValid ? skinMatrix : matrix_identity_float4x4
         }
     }
 

--- a/Sources/VRMMetalKit/Animation/VRMSkinning.swift
+++ b/Sources/VRMMetalKit/Animation/VRMSkinning.swift
@@ -96,16 +96,24 @@ public class VRMSkinningSystem {
         markSkinUpdated(skinIndex: skinIndex)
         debugFrameCount += 1
 
-        for (index, joint) in skin.joints.enumerated() {
-            let skinMatrix = joint.worldMatrix * skin.inverseBindMatrices[index]
-
-            // Diagonal-only NaN/Inf guard. Sufficient to catch garbage without
-            // allocating a per-joint validation array.
-            let diagValid = skinMatrix[0][0].isFinite
-                && skinMatrix[1][1].isFinite
-                && skinMatrix[2][2].isFinite
-                && skinMatrix[3][3].isFinite
-            pointer[index] = diagValid ? skinMatrix : matrix_identity_float4x4
+        // Iterate via unsafe buffer pointers so the hot loop doesn't
+        // retain/release each VRMNode reference or the array containers on
+        // every element. Profile sampling showed ARC traffic in this loop
+        // was the dominant non-GPU cost per frame.
+        skin.joints.withUnsafeBufferPointer { joints in
+            skin.inverseBindMatrices.withUnsafeBufferPointer { ibms in
+                let count = joints.count
+                for index in 0..<count {
+                    let skinMatrix = joints[index].worldMatrix * ibms[index]
+                    // Diagonal-only NaN/Inf guard. Sufficient to catch garbage
+                    // without allocating a per-joint validation array.
+                    let diagValid = skinMatrix[0][0].isFinite
+                        && skinMatrix[1][1].isFinite
+                        && skinMatrix[2][2].isFinite
+                        && skinMatrix[3][3].isFinite
+                    pointer[index] = diagValid ? skinMatrix : matrix_identity_float4x4
+                }
+            }
         }
     }
 

--- a/Sources/VRMMetalKit/Core/VRMLogger.swift
+++ b/Sources/VRMMetalKit/Core/VRMLogger.swift
@@ -59,7 +59,7 @@ func vrmLog(
     function: StaticString = #function,
     line: UInt = #line
 ) {
-#if true  // FORCE LOGGING ALWAYS for debugging
+#if VRM_METALKIT_ENABLE_LOGS
     let categoryDescription = String(describing: category)
     let functionDescription = String(describing: function)
     let prefix = "[VRMMetalKit][\(level.rawValue)][\(categoryDescription).\(functionDescription)#\(line)]"

--- a/Sources/VRMMetalKit/Core/VRMModel.swift
+++ b/Sources/VRMMetalKit/Core/VRMModel.swift
@@ -906,7 +906,7 @@ public class VRMModel: @unchecked Sendable {
     }
 
     public func initializeSpringBoneGPUSystem(device: MTLDevice) throws {
-        guard let springBone = springBone else {
+        guard springBone != nil else {
             return // No SpringBone data in this model
         }
 

--- a/Sources/VRMMetalKit/Renderer/VRMGeometry.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMGeometry.swift
@@ -1384,10 +1384,6 @@ extension float4x4 {
         columns.3.z = t.z
     }
 
-    init(_ quaternion: simd_quatf) {
-        self = simd_matrix4x4(quaternion)
-    }
-
     init(scaling s: SIMD3<Float>) {
         self = matrix_identity_float4x4
         columns.0.x = s.x

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -3551,8 +3551,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
     
     /// Returns pipeline descriptor for MASK materials with alpha-to-coverage
     public func getMASKPipelineDescriptor() -> MTLRenderPipelineDescriptor? {
-        // Use the existing A2C pipeline if available
-        guard let a2cPipeline = maskAlphaToCoveragePipelineState else {
+        guard maskAlphaToCoveragePipelineState != nil else {
             return nil
         }
         

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -492,6 +492,10 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
     private var cachedRenderItems: [RenderItem]?
     private var cacheNeedsRebuild = true
 
+    // Scratch dictionary reused by the transparency-sort pass to avoid a
+    // per-frame dictionary allocation. Keys are primitiveIndex.
+    private var viewZByIndex: [Int: Float] = [:]
+
     // RENDER ITEM: Structure for sorting and rendering primitives
     private struct RenderItem {
         let node: VRMNode
@@ -1607,7 +1611,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
         vrmLog("[VRMRenderer] 🎨 Alpha queuing: opaque=\(opaqueCount), mask=\(maskCount), blend=\(blendCount)")
 
         // Pre-compute view-space Z for transparent items to avoid redundant matrix multiplies in comparator
-        var viewZByIndex = [Int: Float]()
+        viewZByIndex.removeAll(keepingCapacity: true)
         viewZByIndex.reserveCapacity(blendCount)
         for item in allItems where item.materialRenderQueue >= 2500 {
             let worldPos = item.node.worldMatrix.columns.3

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -633,11 +633,6 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
         // Initialize skinning system with all skins for proper offset allocation
         if !model.skins.isEmpty {
             skinningSystem?.setupForSkins(model.skins)
-
-            // DIFFERENTIAL TRANSFORM ANALYSIS: Capture clean baseline for skin 4
-            if model.skins.count > 4 {
-                skinningSystem?.captureCleanBaseline(for: model.skins[4], skinIndex: 4)
-            }
         }
 
         // Load expressions if available

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -984,10 +984,27 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
     ///   - renderPassDescriptor: Render pass configuration with attachments.
     @MainActor
     public func drawOffscreenHeadless(to colorTexture: MTLTexture, depth: MTLTexture, commandBuffer: MTLCommandBuffer, renderPassDescriptor: MTLRenderPassDescriptor) {
-        let dummyView = DummyView(size: CGSize(width: colorTexture.width, height: colorTexture.height))
-        vrmLog("[VRMRenderer] drawOffscreenHeadless called - size: \(colorTexture.width)x\(colorTexture.height)")
-        drawCore(in: dummyView, commandBuffer: commandBuffer, renderPassDescriptor: renderPassDescriptor)
+        // MTKView.init() runs __initCommon which builds a CVDisplayLink; that's
+        // multiple milliseconds of work per call. drawCore() only needs the
+        // view for its drawableSize, so reuse a single DummyView keyed by
+        // size rather than allocating one per frame.
+        let w = colorTexture.width, h = colorTexture.height
+        let view: DummyView
+        if let cached = cachedDummyView,
+           let cachedSize = cachedDummyViewSize,
+           cachedSize == (w, h) {
+            view = cached
+        } else {
+            view = DummyView(size: CGSize(width: w, height: h))
+            cachedDummyView = view
+            cachedDummyViewSize = (w, h)
+        }
+        vrmLog("[VRMRenderer] drawOffscreenHeadless called - size: \(w)x\(h)")
+        drawCore(in: view, commandBuffer: commandBuffer, renderPassDescriptor: renderPassDescriptor)
     }
+
+    private var cachedDummyView: DummyView?
+    private var cachedDummyViewSize: (Int, Int)?
 
     /// Renders the VRM model to the view.
     ///

--- a/Sources/VRMMetalKit/SpringBoneComputeSystem.swift
+++ b/Sources/VRMMetalKit/SpringBoneComputeSystem.swift
@@ -667,6 +667,10 @@ final class SpringBoneComputeSystem: @unchecked Sendable {
         cpuRestLengths = restLengths
         cpuParentIndices = parentIndices
 
+        // cpuRestLengths is immutable after setup, so the scale derived from
+        // it is constant for the model's lifetime — compute once here.
+        cachedModelScale = calculateModelScaleFromRestLengths()
+
         if !sphereColliders.isEmpty {
             buffers.updateSphereColliders(sphereColliders)
         }
@@ -1269,9 +1273,6 @@ final class SpringBoneComputeSystem: @unchecked Sendable {
 
         // 3. Capture collider transforms
         captureTargetColliderTransforms(model: model, springBone: springBone)
-
-        // Cache model scale for scale-aware thresholds
-        cachedModelScale = calculateModelScaleFromRestLengths()
     }
 
     /// Captures world-space bind directions based on current animated parent orientations

--- a/Sources/VRMMetalKit/SpringBoneComputeSystem.swift
+++ b/Sources/VRMMetalKit/SpringBoneComputeSystem.swift
@@ -104,6 +104,10 @@ final class SpringBoneComputeSystem: @unchecked Sendable {
     // Cached model scale for scale-aware thresholds
     private var cachedModelScale: Float = 1.0
 
+    // Reused buffer for writeBonesToNodes() chain walks; keeps capacity
+    // across frames so springs don't each allocate their own tuple array.
+    private var chainNodePositions: [(VRMNode, SIMD3<Float>, Int)] = []
+
     /// Flag to request physics state reset on next update (e.g., when returning to idle)
     var requestPhysicsReset = false
 
@@ -1003,28 +1007,26 @@ final class SpringBoneComputeSystem: @unchecked Sendable {
         }
         skippedReadbacks = 0
 
-        // Check if positions have extreme values
-        let maxMagnitude = positions.prefix(buffers.numBones).map { simd_length($0) }.max() ?? 0
-        vrmLog("[SpringBone] Read \(positions.count) positions. Max magnitude: \(maxMagnitude)")
-
-        // Map bone index to spring/joint for node updates
+        // Map bone index to spring/joint for node updates. Reuse a single
+        // nodePositions buffer across all springs instead of allocating per
+        // spring per frame; springs typically hold 5-30 joints.
         var globalBoneIndex = 0
+        chainNodePositions.reserveCapacity(32)
         for spring in springBone.springs {
             guard globalBoneIndex < positions.count else { break }
 
-            // Build array of (node, position, globalIndex) tuples for this chain
-            var nodePositions: [(VRMNode, SIMD3<Float>, Int)] = []
+            chainNodePositions.removeAll(keepingCapacity: true)
             for joint in spring.joints {
                 guard let node = model.nodes[safe: joint.node],
                       globalBoneIndex < positions.count else { continue }
 
-                nodePositions.append((node, positions[globalBoneIndex], globalBoneIndex))
+                chainNodePositions.append((node, positions[globalBoneIndex], globalBoneIndex))
                 globalBoneIndex += 1
             }
 
             // Update node transforms based on GPU-computed positions
-            if nodePositions.count >= 2 {
-                updateNodeTransformsForChain(nodePositions: nodePositions)
+            if chainNodePositions.count >= 2 {
+                updateNodeTransformsForChain(nodePositions: chainNodePositions)
             }
         }
     }

--- a/Sources/VRMMetalKit/SpringBoneComputeSystem.swift
+++ b/Sources/VRMMetalKit/SpringBoneComputeSystem.swift
@@ -1251,7 +1251,7 @@ final class SpringBoneComputeSystem: @unchecked Sendable {
         guard let springBone = model.springBone else { return }
 
         // 1. Capture root positions
-        targetRootPositions = []
+        targetRootPositions.removeAll(keepingCapacity: true)
         for spring in springBone.springs {
             if let firstJoint = spring.joints.first,
                let node = model.nodes[safe: firstJoint.node] {
@@ -1276,7 +1276,7 @@ final class SpringBoneComputeSystem: @unchecked Sendable {
 
     /// Captures world-space bind directions based on current animated parent orientations
     private func captureTargetWorldBindDirections(model: VRMModel, springBone: VRMSpringBone) {
-        targetWorldBindDirections = []
+        targetWorldBindDirections.removeAll(keepingCapacity: true)
 
         var boneIndex = 0
         for spring in springBone.springs {
@@ -1321,9 +1321,9 @@ final class SpringBoneComputeSystem: @unchecked Sendable {
             }
         }
 
-        targetSphereColliders = []
-        targetCapsuleColliders = []
-        targetPlaneColliders = []
+        targetSphereColliders.removeAll(keepingCapacity: true)
+        targetCapsuleColliders.removeAll(keepingCapacity: true)
+        targetPlaneColliders.removeAll(keepingCapacity: true)
 
         for (colliderIndex, collider) in springBone.colliders.enumerated() {
             guard let colliderNode = model.nodes[safe: collider.node] else { continue }
@@ -1488,13 +1488,15 @@ final class SpringBoneComputeSystem: @unchecked Sendable {
         }
     }
 
-    /// Stores current target transforms as previous for next frame's interpolation
+    /// Stores current target transforms as previous for next frame's interpolation.
+    /// Uses swap instead of assignment so both arrays retain their backing storage
+    /// across frames; the next capture overwrites in place via removeAll+append.
     private func commitAllTransforms() {
-        previousRootPositions = targetRootPositions
-        previousWorldBindDirections = targetWorldBindDirections
-        previousSphereColliders = targetSphereColliders
-        previousCapsuleColliders = targetCapsuleColliders
-        previousPlaneColliders = targetPlaneColliders
+        swap(&previousRootPositions, &targetRootPositions)
+        swap(&previousWorldBindDirections, &targetWorldBindDirections)
+        swap(&previousSphereColliders, &targetSphereColliders)
+        swap(&previousCapsuleColliders, &targetCapsuleColliders)
+        swap(&previousPlaneColliders, &targetPlaneColliders)
     }
 
     // MARK: - Teleportation Detection

--- a/Sources/VRMMetalKit/Utilities/DepthBiasCalculator.swift
+++ b/Sources/VRMMetalKit/Utilities/DepthBiasCalculator.swift
@@ -29,10 +29,17 @@ import Metal
 /// let bias = calculator.depthBias(for: "FaceMouth", isOverlay: true)
 /// renderEncoder.setDepthBias(bias, slopeScale: 2.0, clamp: 0.1)
 /// ```
-public struct DepthBiasCalculator {
-    
+public final class DepthBiasCalculator {
+
     /// Global scale factor applied to all depth bias values
     public var scale: Float = 1.0
+
+    /// Memoized results of lookupBias. Material names repeat across every
+    /// frame (same primitives) but the lookup path does multiple substring
+    /// scans against a ~20-entry keyword table, which profiling showed as
+    /// the dominant CPU cost in the post-MTKView-cache render loop. Caching
+    /// the resolved Float turns each subsequent call into a dictionary hit.
+    private var biasCache: [String: Float] = [:]
     
     /// Base depth bias values by material category
     private let baseBiasValues: [String: Float] = [
@@ -131,8 +138,17 @@ public struct DepthBiasCalculator {
     // MARK: - Private Methods
     
     private func lookupBias(for materialName: String) -> Float {
+        if let cached = biasCache[materialName] {
+            return cached
+        }
+        let result = computeBias(for: materialName)
+        biasCache[materialName] = result
+        return result
+    }
+
+    private func computeBias(for materialName: String) -> Float {
         let lowercased = materialName.lowercased()
-        
+
         // Try exact match first
         if let exactMatch = baseBiasValues[materialName] {
             return exactMatch

--- a/Sources/VRMMetalKit/Utilities/DepthBiasCalculator.swift
+++ b/Sources/VRMMetalKit/Utilities/DepthBiasCalculator.swift
@@ -23,6 +23,12 @@ import Metal
 /// ensuring they pass depth tests against coplanar surfaces. This resolves true Z-fighting
 /// between overlapping geometry.
 ///
+/// ## Thread safety
+/// This class caches resolved bias values in a non-synchronised dictionary.
+/// It is intended to be used from a single context (typically the main actor
+/// via `VRMRenderer.drawCore`). Calling from multiple threads concurrently
+/// is a data race.
+///
 /// ## Usage
 /// ```swift
 /// let calculator = DepthBiasCalculator()

--- a/Sources/VRMRender/main.swift
+++ b/Sources/VRMRender/main.swift
@@ -368,8 +368,7 @@ struct VRMRenderCLI {
             let (minBounds, maxBounds) = model.calculateBoundingBox()
             let center = (minBounds + maxBounds) / 2
             let size = maxBounds - minBounds
-            let maxDimension = max(size.x, max(size.y, size.z))
-            
+
             print("  ✓ Model bounds: \(size)")
             print("  ✓ Center: \(center)")
 

--- a/Sources/VRMVideoRenderer/main.swift
+++ b/Sources/VRMVideoRenderer/main.swift
@@ -28,7 +28,7 @@ enum VideoRenderError: Error {
     case failedToCreateRenderer
     case failedToLoadModel
     case failedToLoadAnimation
-    case failedToCreateCommandBuffer
+    case failedToCreateCommandQueue
     case videoEncodingFailed
     case missingArguments
     case fileNotFound(String)
@@ -424,7 +424,7 @@ struct VRMVideoRendererCLI {
         // frame spawns a Metal driver thread per iteration, which accumulates
         // until the OS watchdog kills the process on long videos.
         guard let sharedCommandQueue = device.makeCommandQueue() else {
-            throw VideoRenderError.failedToCreateCommandBuffer
+            throw VideoRenderError.failedToCreateCommandQueue
         }
 
             for frameIndex in 0..<totalFrames {

--- a/Sources/VRMVideoRenderer/main.swift
+++ b/Sources/VRMVideoRenderer/main.swift
@@ -28,6 +28,7 @@ enum VideoRenderError: Error {
     case failedToCreateRenderer
     case failedToLoadModel
     case failedToLoadAnimation
+    case failedToCreateCommandBuffer
     case videoEncodingFailed
     case missingArguments
     case fileNotFound(String)
@@ -418,7 +419,14 @@ struct VRMVideoRendererCLI {
         let startTime = Date()
         let frameDuration = CMTime(value: 1, timescale: CMTimeScale(options.fps))
         let totalFrames = Int(options.duration * Double(options.fps))
-            
+
+        // Reuse a single command queue across the whole run. Creating one per
+        // frame spawns a Metal driver thread per iteration, which accumulates
+        // until the OS watchdog kills the process on long videos.
+        guard let sharedCommandQueue = device.makeCommandQueue() else {
+            throw VideoRenderError.failedToCreateCommandBuffer
+        }
+
             for frameIndex in 0..<totalFrames {
                 // Update animation
                 player.update(deltaTime: 1.0 / Float(options.fps), model: model)
@@ -451,10 +459,9 @@ struct VRMVideoRendererCLI {
                     renderer.projectionMatrix = perspective(fovRadians: Float.pi / 4, aspect: aspectRatio, near: 0.1, far: 100)
                 }
                 
-                // Create pixel buffer
+                // Create pixel buffer (command queue hoisted above loop)
                 guard let pixelBuffer = createPixelBuffer(width: options.width, height: options.height),
-                      let commandQueue = device.makeCommandQueue(),
-                      let commandBuffer = commandQueue.makeCommandBuffer() else {
+                      let commandBuffer = sharedCommandQueue.makeCommandBuffer() else {
                     continue
                 }
                 

--- a/Tests/VRMMetalKitTests/FuzzingTests.swift
+++ b/Tests/VRMMetalKitTests/FuzzingTests.swift
@@ -316,7 +316,7 @@ final class FuzzingTests: XCTestCase {
         let collector = FuzzingResultCollector()
 
         for i in 0..<50 {
-            let uniforms = generator.randomMToonUniforms()
+            _ = generator.randomMToonUniforms()
 
             // Check that the uniforms struct has valid layout
             let size = MemoryLayout<MToonMaterialUniforms>.size
@@ -545,7 +545,6 @@ final class FuzzingTests: XCTestCase {
         let collector = FuzzingResultCollector()
 
         // Simulate renderer state
-        var isModelLoaded = false
         var viewportWidth: Float = 1920
         var viewportHeight: Float = 1080
         var expressionWeights: [String: Float] = [:]
@@ -565,10 +564,9 @@ final class FuzzingTests: XCTestCase {
 
             switch action {
             case .loadModel:
-                isModelLoaded = true
+                break
 
             case .unloadModel:
-                isModelLoaded = false
                 expressionWeights.removeAll()
 
             case .setExpression:
@@ -783,7 +781,7 @@ extension FuzzingTests {
 
         // Test subset of combinations (full matrix is large)
         for alpha in AlphaMode.allCases {
-            for cull in CullMode.allCases {
+            for _ in CullMode.allCases {
                 for outline in OutlineMode.allCases {
                     combinations += 1
 

--- a/Tests/VRMMetalKitTests/RenderSafetyTests.swift
+++ b/Tests/VRMMetalKitTests/RenderSafetyTests.swift
@@ -824,11 +824,9 @@ final class RenderSafetyTests: XCTestCase {
         for (meshIndex, mesh) in model.meshes.enumerated() {
             // Find the skin for this mesh
             var skin: VRMSkin?
-            var meshNode: VRMNode?
             var skinIndex: Int?
             for node in model.nodes {
                 if let nodeMeshIndex = node.mesh, nodeMeshIndex == meshIndex {
-                    meshNode = node
                     if let si = node.skin, si < model.skins.count {
                         skin = model.skins[si]
                         skinIndex = si
@@ -1242,12 +1240,10 @@ final class RenderSafetyTests: XCTestCase {
         // List which mesh uses which skin
         print("\n--- MESH-SKIN MAPPING ---")
         for (meshIndex, mesh) in model.meshes.enumerated() {
-            var foundNode: VRMNode?
             var foundSkinIndex: Int?
 
             for node in model.nodes {
                 if let nodeMeshIndex = node.mesh, nodeMeshIndex == meshIndex {
-                    foundNode = node
                     foundSkinIndex = node.skin
                     break
                 }

--- a/Tests/VRMMetalKitTests/SpriteCacheSystemTests.swift
+++ b/Tests/VRMMetalKitTests/SpriteCacheSystemTests.swift
@@ -28,7 +28,6 @@ final class SpriteCacheSystemTests: XCTestCase {
 
         let characterID = "testCharacter"
         let poseCount = 10
-        let threadCount = 4
 
         // Generate unique pose hashes
         let poseHashes: [UInt64] = (0..<poseCount).map { UInt64($0) }
@@ -60,7 +59,7 @@ final class SpriteCacheSystemTests: XCTestCase {
         DispatchQueue.concurrentPerform(iterations: poseCount) { index in
             let poseHash = poseHashes[index]
 
-            cache.renderToCache(
+            _ = cache.renderToCache(
                 characterID: characterID,
                 poseHash: poseHash,
                 completion: { cachedPose in
@@ -71,13 +70,6 @@ final class SpriteCacheSystemTests: XCTestCase {
                     completionExpectation.fulfill()
                 }
             ) { encoder, texture in
-                // Simple rendering: clear to unique color based on pose index
-                let color = MTLClearColor(
-                    red: Double(index) / Double(poseCount),
-                    green: 0.5,
-                    blue: 0.5,
-                    alpha: 1.0
-                )
                 // Encoding is already set up by renderToCache
             }
         }
@@ -122,7 +114,7 @@ final class SpriteCacheSystemTests: XCTestCase {
 
         // Attempt to render the same pose 5 times simultaneously
         DispatchQueue.concurrentPerform(iterations: 5) { _ in
-            cache.renderToCache(
+            _ = cache.renderToCache(
                 characterID: "char1",
                 poseHash: poseHash,
                 completion: { cachedPose in
@@ -174,7 +166,7 @@ final class SpriteCacheSystemTests: XCTestCase {
 
         // First render (cache miss)
         let firstExpectation = XCTestExpectation(description: "First render")
-        cache.renderToCache(
+        _ = cache.renderToCache(
             characterID: "char1",
             poseHash: poseHash,
             waitUntilCompleted: true
@@ -209,7 +201,7 @@ final class SpriteCacheSystemTests: XCTestCase {
 
         let expectation = XCTestExpectation(description: "Render completes")
 
-        cache.renderToCache(
+        _ = cache.renderToCache(
             characterID: "errorTest",
             poseHash: 777,
             completion: { cachedPose in
@@ -233,7 +225,7 @@ final class SpriteCacheSystemTests: XCTestCase {
 
         // Populate cache
         for i in 0..<poseCount {
-            cache.renderToCache(
+            _ = cache.renderToCache(
                 characterID: "char1",
                 poseHash: UInt64(i),
                 waitUntilCompleted: true
@@ -259,7 +251,7 @@ final class SpriteCacheSystemTests: XCTestCase {
 
         // Add some entries
         for i in 0..<5 {
-            cache.renderToCache(
+            _ = cache.renderToCache(
                 characterID: "char1",
                 poseHash: UInt64(i),
                 waitUntilCompleted: true
@@ -282,13 +274,13 @@ final class SpriteCacheSystemTests: XCTestCase {
 
         // Add entries for two characters
         for i in 0..<3 {
-            cache.renderToCache(
+            _ = cache.renderToCache(
                 characterID: "char1",
                 poseHash: UInt64(i),
                 waitUntilCompleted: true
             ) { encoder, texture in }
 
-            cache.renderToCache(
+            _ = cache.renderToCache(
                 characterID: "char2",
                 poseHash: UInt64(i + 100),
                 waitUntilCompleted: true


### PR DESCRIPTION
## Summary

- Adds a `VRMBenchmark` executable target for measuring per-frame CPU cost against a VRM model, with optional `--vrma` playback so skinning and spring-physics paths get exercised.
- Fixes a latent crash-class bug in `VRMVideoRenderer` (creating a fresh `MTLCommandQueue` per frame — spawns a driver thread each iteration, eventually triggering the macOS watchdog). While investigating I also found and fixed the same class of bug in the new benchmark (missing per-frame `autoreleasepool`).
- Works through a set of per-frame render-path wins guided by first static audit then Time Profiler sampling: gate the force-on logger, reuse SpringBone capture buffers, strip dev scaffolding from the skinning hot path, pre-compute the SpringBone model scale, remove per-frame allocations in the spring writeback and Z-sort paths, cache the offscreen `DummyView` (Metal's MTKView init builds a CVDisplayLink — 55% of CPU per frame!), cut ARC traffic in the skinning loop with `withUnsafeBufferPointer`, and memoize `DepthBiasCalculator` lookups keyed by material name.
- Drops the unconditional `VRM_METALKIT_ENABLE_DEBUG_ANIMATION` define from `Package.swift` so the debug flag is opt-in at build time, matching the documented flags in CLAUDE.md.

### Benchmark deltas (AvatarSample_A + CoolWalk.vrma, 500 frames @ 1024², release)

| metric | baseline | final | delta |
|--------|----------|-------|-------|
| median | 1.508 ms | 0.517 ms | **−66%** |
| mean   | 1.685 ms | 0.518 ms | **−69%** |
| p95    | 3.125 ms | 0.552 ms | **−82%** |
| p99    | 5.077 ms | 0.599 ms | **−88%** |
| max    | 7.096 ms | 0.657 ms | **−91%** |
| stddev | 0.695    | 0.024    | **−97%** |
| FPS    | ~594     | ~1931    | **+225%** |

Biggest single win: caching the `DummyView` inside `drawOffscreenHeadless` — `MTKView.__initCommon` was building a fresh `CVDisplayLink` every frame and swallowing the majority of CPU time.

## Commits

- `c438645` chore: Fix Swift 6.3 SDK compat, clean warnings, add render benchmark
- `ccd81c8` perf: Gate `vrmLog` behind flag and reuse SpringBone capture buffers
- `754c53e` perf: Simplify `updateJointMatrices` hot path; remove dev scaffolding
- `1ec73cd` fix: Wrap benchmark frames in autoreleasepool; hoist video renderer CQ
- `a81c69e` perf: Compute SpringBone model scale once at setup, not per frame
- `9d37e92` perf: Eliminate per-frame allocations in spring writeback and Z sort
- `d4e1f55` feat(bench): Support VRMA animation playback in VRMBenchmark
- `db554ac` perf: Stop rebuilding the offscreen DummyView every frame
- `0f7fcd5` perf: Cut ARC traffic in skinning loop; memoize depth-bias lookups

## Test plan

- [x] `swift build` clean, no warnings
- [x] `swift build --build-tests` clean, no warnings
- [x] `swift test --parallel --num-workers 14 -j 16 --disable-sandbox` — all 1179 tests pass
- [x] `swift run -c release VRMBenchmark <vrm> --vrma <vrma> --frames 500` — stable output, large improvement vs baseline
- [ ] Sanity-render an avatar via `VRMRender` (recommended to verify no visual regression)
- [ ] Render a short clip via `VRMVideoRenderer` to confirm the command-queue hoist doesn't change output

🤖 Generated with [Claude Code](https://claude.com/claude-code)