### PR TITLE
fix(animation): Convert animation rest pose for VRM 0.0 retargeting

### DIFF
--- a/Sources/VRMMetalKit/Animation/VRMAnimationLoader.swift
+++ b/Sources/VRMMetalKit/Animation/VRMAnimationLoader.swift
@@ -524,7 +524,15 @@ private func makeRotationSampler(track: KeyTrack,
                                  modelRestRotation: simd_quatf?,
                                  convertForVRM0: Bool = false) -> ((Float) -> simd_quatf)? {
     let modelRest = modelRestRotation
-    let rotationRest = simd_normalize(animationRestRotation)
+    // Convert the rest rotation into the same coordinate space the per-frame
+    // rotations will be expressed in. Without this, delta = inverse(restA) *
+    // rotationB mixes spaces and produces a residual frame rotation that is
+    // identity for pure-Y axis rotations but visible (e.g., 180° X) on idle
+    // hips/root tracks — exactly the upside-down VRM 0.0 + VRMA symptom.
+    let restForDelta: simd_quatf = convertForVRM0
+        ? convertRotationForVRM0(animationRestRotation)
+        : animationRestRotation
+    let rotationRest = simd_normalize(restForDelta)
 
     // No model rest data available - just apply animation directly with optional VRM 0.0 conversion
     if modelRest == nil {
@@ -586,6 +594,13 @@ private func makeTranslationSampler(track: KeyTrack,
                                     animationRestTranslation: SIMD3<Float>,
                                     modelRestTranslation: SIMD3<Float>?,
                                     convertForVRM0: Bool = false) -> ((Float) -> SIMD3<Float>)? {
+    // Convert the rest translation into the same space the per-frame
+    // translations will be in. Symmetry fix: delta = animT - restT must
+    // subtract values from the same coordinate frame.
+    let restForDelta: SIMD3<Float> = convertForVRM0
+        ? convertTranslationForVRM0(animationRestTranslation)
+        : animationRestTranslation
+
     guard let modelRest = modelRestTranslation else {
         return { t in
             var result = sampleVector3(track, at: t)
@@ -604,7 +619,7 @@ private func makeTranslationSampler(track: KeyTrack,
             animTranslation = convertTranslationForVRM0(animTranslation)
         }
 
-        let delta = animTranslation - animationRestTranslation
+        let delta = animTranslation - restForDelta
         return modelRest + delta
     }
 }


### PR DESCRIPTION
## Screenshots

**Before / after on the same VRM 0.0 + VRMA case** (AliciaSolid + Idle.vrma, frame 0):

| Before — upside-down | After — upright |
|:---:|:---:|
| <img src="https://github.com/arkavo-org/VRMMetalKit/releases/download/pr-screenshots-2026-05-03/before-vrm0-upside-down.png" width="380"> | <img src="https://github.com/arkavo-org/VRMMetalKit/releases/download/pr-screenshots-2026-05-03/after-vrm0-upright.png" width="380"> |

**Regression checks** — VRM 1.0 unchanged, and the fix composes with the silhouette feature in #137:

| VRM 1.0 + VRMA (no regression) | VRM 0.0 + VRMA + `--silhouette` |
|:---:|:---:|
| <img src="https://github.com/arkavo-org/VRMMetalKit/releases/download/pr-screenshots-2026-05-03/after-vrm1-unchanged.png" width="380"> | <img src="https://github.com/arkavo-org/VRMMetalKit/releases/download/pr-screenshots-2026-05-03/after-vrm0-silhouette-upright.png" width="380"> |

## Summary
Applies the existing `convertForVRM0` coordinate transform to `animationRestRotation` and `animationRestTranslation` in `VRMAnimationLoader.swift` so the delta-retargeting computation `delta = inverse(rest) * rotation` no longer mixes coordinate frames.

## The bug
For VRM 0.0 models with a VRMA animation, the avatar rendered upside-down once playback started — but rendered correctly when no animation played, and VRM 1.0 + VRMA was unaffected. Triangulating the symptoms pointed to the retargeting layer:

In `makeRotationSampler`, the per-frame rotation was being converted into the model's coordinate frame via `convertRotationForVRM0`, but the rest rotation it was being subtracted against (`rotationRest`) was **not** converted. The delta was therefore expressed in a hybrid frame. For pure Y-axis rotations the conversion is a no-op (Y stays positive), so the bug was invisible there; X- and Z-axis rotations (which is what an idle-hips track contains) accumulated a residual frame rotation that, combined with the renderer's `vrmVersionRotation` at draw time, manifested as a 180° X flip.

## The fix
Symmetry: convert the rest rotation/translation with the same `convertForVRM0` transform before computing deltas. Translation gets the same treatment (`convertTranslationForVRM0` applied to `animationRestTranslation`).

19 lines added / 2 removed across one file. `convertForVRM0=false` (VRM 1.0) is bit-identical.

## Verification
| Case | Before | After |
|---|---|---|
| AliciaSolid (VRM 0.0) + Idle.vrma | upside-down | ✅ upright in idle pose |
| AliciaSolid (VRM 0.0) + Idle.vrma + `--silhouette` | upside-down | ✅ upright black silhouette |
| VRM1_Constraint_Twist_Sample (VRM 1.0) + Idle.vrma | upright | ✅ unchanged, upright |
| `swift test --parallel` | n/a | ✅ exit 0, 1188 tests |

## Background — and what NOT to pull forward
There is a stale local branch (now `archive/animation-coordinate-fix-jan2026`, ex `feature/animation-coordinate-fix`, Jan 19) that addressed a related symptom with a different mental model: it negated quaternion X+Y at the parser level on every glTF animation, framed as "RH→LH conversion." That premise doesn't match this codebase — the renderer doesn't flip handedness, and applying that conversion universally would break VRM 1.0 + VRMA renders. The salvageable part of that branch is the bone-name heuristic improvements (Mixamo, Blender, namespace prefixes), filed as #135.

## Test plan
- [x] `swift build` clean
- [x] `swift test --parallel --num-workers 14 -j 16 --disable-sandbox` — 1188 tests, exit 0
- [x] Visually verified VRM 0.0 + VRMA renders upright (still + animated frames)
- [x] Visually verified VRM 1.0 + VRMA unchanged
- [ ] If you have a regression model that exercised the original "lying down" symptom, please verify it stays fixed

## Notes
Branch is named `spike/` because it was developed as a focused experimental fix; it is now verified and ready to land. If you'd prefer a renamed branch for tidiness happy to push to a `fix/` name and update this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
