### PR TITLE
test(springbone): TDD audit — 4 critical physics bugs (RED phase)

### DIFF
--- a/Tests/VRMMetalKitTests/SpringBoneBugAuditTDDBatch2Tests.swift
+++ b/Tests/VRMMetalKitTests/SpringBoneBugAuditTDDBatch2Tests.swift
@@ -1,0 +1,336 @@
+// Copyright 2025 Arkavo Inc. and contributors
+// Licensed under the Apache License, Version 2.0
+
+import XCTest
+import Metal
+import simd
+@testable import VRMMetalKit
+
+/// TDD-style tests for SpringBone bugs identified in issue #138 that PR #139
+/// (the first RED batch) does not cover. This is the second RED batch and asserts
+/// CORRECT behavior — these tests are expected to FAIL until the bugs are fixed.
+///
+/// Coverage:
+///   - Bug #4: Kinematic kernel uses bonePosCurr as previous-position history.
+///   - Bug #6: Inertia compensation block is commented out in SpringBonePredict.metal.
+///   - Bug #7: Collider groupIndex >= 32 triggers bit-shift undefined behavior.
+///
+/// Bug #11 (externalVelocity never populated) is intentionally not in this batch:
+/// its fix requires API design, not just a behavioral assertion. Once an API for
+/// feeding character velocity into the spring system exists, a follow-up test
+/// should assert it propagates into globalParams.externalVelocity.
+///
+/// GPU synchronization: tests pass a host-owned MTLCommandBuffer to
+/// `SpringBoneComputeSystem.update(...)` so the system encodes work without
+/// committing, and the test commits + `waitUntilCompleted()` for deterministic
+/// readback — no `Thread.sleep`.
+final class SpringBoneBugAuditTDDBatch2Tests: XCTestCase {
+
+    private var device: MTLDevice!
+    private var commandQueue: MTLCommandQueue!
+
+    override func setUpWithError() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw XCTSkip("Metal not available")
+        }
+        guard let queue = device.makeCommandQueue() else {
+            throw XCTSkip("Could not create Metal command queue")
+        }
+        self.device = device
+        self.commandQueue = queue
+    }
+
+    // MARK: - Helpers
+
+    private func createGLTFNode(name: String, translation: SIMD3<Float>) throws -> GLTFNode {
+        let json = """
+        {
+            "name": "\(name)",
+            "translation": [\(translation.x), \(translation.y), \(translation.z)],
+            "rotation": [0.0, 0.0, 0.0, 1.0],
+            "scale": [1.0, 1.0, 1.0]
+        }
+        """
+        let data = json.data(using: .utf8)!
+        return try JSONDecoder().decode(GLTFNode.self, from: data)
+    }
+
+    /// Build a minimal model whose `nodes` are exactly the names/translations supplied.
+    /// Each node `i` is parented to node `i-1` (single chain) and gets its world transform
+    /// computed. Returns the model with `device` set.
+    private func makeChainModel(names: [String], translations: [SIMD3<Float>]) throws -> VRMModel {
+        precondition(names.count == translations.count, "names and translations must match")
+        let model = try VRMBuilder().setSkeleton(.defaultHumanoid).build()
+        model.nodes.removeAll()
+        var previous: VRMNode?
+        for (i, name) in names.enumerated() {
+            let gltf = try createGLTFNode(name: name, translation: translations[i])
+            let node = VRMNode(index: i, gltfNode: gltf)
+            if let prev = previous {
+                node.parent = prev
+                prev.children.append(node)
+            }
+            model.nodes.append(node)
+            previous = node
+        }
+        for n in model.nodes { n.updateWorldTransform() }
+        model.device = device
+        return model
+    }
+
+    private func readBonePosition(model: VRMModel, boneIndex: Int) -> SIMD3<Float> {
+        guard let buffers = model.springBoneBuffers,
+              boneIndex < buffers.numBones,
+              let buf = buffers.bonePosCurr else { return .zero }
+        let ptr = buf.contents().bindMemory(to: SIMD3<Float>.self, capacity: buffers.numBones)
+        return ptr[boneIndex]
+    }
+
+    private func readBonePrevPosition(model: VRMModel, boneIndex: Int) -> SIMD3<Float> {
+        guard let buffers = model.springBoneBuffers,
+              boneIndex < buffers.numBones,
+              let buf = buffers.bonePosPrev else { return .zero }
+        let ptr = buf.contents().bindMemory(to: SIMD3<Float>.self, capacity: buffers.numBones)
+        return ptr[boneIndex]
+    }
+
+    /// Note: `substeps` and `numSpheres` here populate `SpringBoneGlobalParams` for the
+    /// shaders, but the runtime substep count actually comes from `update(deltaTime:)`
+    /// against `quality.substepRateHz`. With `deltaTime = 1/60` and the default 120Hz
+    /// rate, each `update()` runs ~2 substeps — enough to expose Bug #4's stomping.
+    private func makeGlobalParams(numBones: Int, numSpheres: UInt32 = 0) -> SpringBoneGlobalParams {
+        SpringBoneGlobalParams(
+            gravity: SIMD3<Float>(0, -9.8, 0),
+            dtSub: Float(1.0 / 120.0),
+            windAmplitude: 0.0,
+            windFrequency: 0.0,
+            windPhase: 0.0,
+            windDirection: SIMD3<Float>(1, 0, 0),
+            substeps: 1,
+            numBones: UInt32(numBones),
+            numSpheres: numSpheres,
+            numCapsules: 0,
+            numPlanes: 0,
+            settlingFrames: 0
+        )
+    }
+
+    /// Drive the compute system through one frame using a host-owned command buffer
+    /// and block until the GPU has finished. Replaces `Thread.sleep` with deterministic
+    /// synchronization.
+    private func runFrame(system: SpringBoneComputeSystem, model: VRMModel,
+                          deltaTime: TimeInterval = 1.0 / 60.0) throws {
+        guard let cb = commandQueue.makeCommandBuffer() else {
+            throw XCTSkip("Could not create command buffer")
+        }
+        system.update(model: model, deltaTime: deltaTime, commandBuffer: cb)
+        cb.commit()
+        cb.waitUntilCompleted()
+    }
+
+    // MARK: - Bug #4: Kinematic kernel uses bonePosCurr as previous-position history
+
+    /// `SpringBoneKinematic.metal` reads `previousPos = bonePosCurr[boneIndex]` and
+    /// writes that into `bonePosPrev[boneIndex]`. Because the kernel runs once per
+    /// substep and writes `bonePosCurr = animatedPos`, every substep after the first
+    /// stomps `bonePosPrev` with the *current* animated position, destroying the
+    /// previous-frame velocity history.
+    ///
+    /// Correct behavior: `bonePosPrev[root]` must reflect the **previous frame's**
+    /// animated position so velocity = curr - prev is meaningful for downstream
+    /// inertia compensation (Bug #6) and any future child-bone effects that read
+    /// root velocity.
+    ///
+    /// Architecturally, this requires a separate animated-position history buffer
+    /// (per the issue #138 fix recommendation), not just relying on Bug #3 to keep
+    /// `bonePosCurr[root]` clean.
+    func testRootBonePrevPositionTracksPreviousAnimatedFrameNotCurrentSubstep() throws {
+        let model = try makeChainModel(
+            names: ["A", "B"],
+            translations: [SIMD3<Float>(0, 0, 0), SIMD3<Float>(0, -1, 0)]
+        )
+
+        var joints: [VRMSpringJoint] = []
+        for i in 0..<2 {
+            var j = VRMSpringJoint(node: i)
+            j.hitRadius = 0.02
+            j.stiffness = 0.0
+            j.gravityPower = 0.0
+            j.dragForce = 0.0
+            joints.append(j)
+        }
+        var spring = VRMSpring(name: "Test")
+        spring.joints = joints
+        var sb = VRMSpringBone()
+        sb.springs = [spring]
+        model.springBone = sb
+
+        let buffers = SpringBoneBuffers(device: device)
+        buffers.allocateBuffers(numBones: 2, numSpheres: 0, numCapsules: 0)
+        model.springBoneBuffers = buffers
+        model.springBoneGlobalParams = makeGlobalParams(numBones: 2)
+
+        let system = try SpringBoneComputeSystem(device: device)
+        try system.populateSpringBoneData(model: model)
+
+        // Establish a clean baseline before frame 1 so the test isn't sensitive to
+        // whatever populateSpringBoneData left in bonePosCurr/bonePosPrev.
+        if let curr = buffers.bonePosCurr, let prev = buffers.bonePosPrev,
+           let rest = buffers.restLengths {
+            let c = curr.contents().bindMemory(to: SIMD3<Float>.self, capacity: 2)
+            let p = prev.contents().bindMemory(to: SIMD3<Float>.self, capacity: 2)
+            let r = rest.contents().bindMemory(to: Float.self, capacity: 2)
+            c[0] = SIMD3<Float>(0, 0, 0); p[0] = c[0]
+            c[1] = SIMD3<Float>(0, -1, 0); p[1] = c[1]
+            r[1] = 1.0
+        }
+
+        let nodeA = model.nodes[0]
+
+        // Frame 1: root at (0, 0, 0). Settle history.
+        nodeA.translation = SIMD3<Float>(0, 0, 0)
+        nodeA.updateLocalMatrix()
+        nodeA.updateWorldTransform()
+        try runFrame(system: system, model: model)
+
+        // Frame 2: root jumps to (1, 0, 0). Animated delta = (1, 0, 0).
+        nodeA.translation = SIMD3<Float>(1, 0, 0)
+        nodeA.updateLocalMatrix()
+        nodeA.updateWorldTransform()
+        try runFrame(system: system, model: model)
+
+        let curr = readBonePosition(model: model, boneIndex: 0)
+        let prev = readBonePrevPosition(model: model, boneIndex: 0)
+        let velocity = curr - prev
+
+        // Correct: prev[0] = previous frame's animated (0,0,0) → velocity ≈ (1,0,0).
+        // Buggy: prev[0] stomped to current animated (1,0,0) → velocity ≈ 0.
+        XCTAssertGreaterThan(simd_length(velocity), 0.5,
+            "Root bone velocity (curr - prev) should be ~1 m/frame after the root " +
+            "moves from (0,0,0) to (1,0,0) between two frames. " +
+            "Got curr=\(curr), prev=\(prev), velocity=\(velocity). " +
+            "Bug #4: SpringBoneKinematic.metal reads previousPos from bonePosCurr, " +
+            "which it then overwrites — and because the kernel runs every substep, " +
+            "after substep 2+ bonePosPrev is stomped with the *current* animated " +
+            "position. Fix: maintain a separate animated-position history buffer " +
+            "for root bones so bonePosPrev[root] tracks the previous frame.")
+    }
+
+    // MARK: - Bug #6: Inertia compensation block is commented out
+
+    /// `SpringBonePredict.metal` lines 121–141 contain a block of inertia-compensation
+    /// logic wrapped in `/* ... */` behind a "INERTIA COMPENSATION DISABLED FOR DEBUGGING"
+    /// marker. Without it, child bones rigidly follow the parent during fast motion
+    /// (e.g. head turns, jumps) instead of trailing naturally.
+    ///
+    /// The spec is unambiguous: re-enable the block. A behavioral test of trailing is
+    /// hard to write robustly because hard distance constraints partially mask the
+    /// effect; the source-level invariant — "the disabled marker must be gone" — is
+    /// the cleanest guarantee that the fix actually shipped.
+    func testInertiaCompensationBlockIsLiveCodeNotCommentedOut() throws {
+        let shaderURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // VRMMetalKitTests/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // repo root
+            .appendingPathComponent("Sources/VRMMetalKit/Shaders/SpringBonePredict.metal")
+
+        let source = try String(contentsOf: shaderURL, encoding: .utf8)
+
+        XCTAssertFalse(source.contains("INERTIA COMPENSATION DISABLED FOR DEBUGGING"),
+            "Bug #6: SpringBonePredict.metal still contains the 'INERTIA COMPENSATION " +
+            "DISABLED FOR DEBUGGING' marker. The block at lines ~121-141 (currently " +
+            "wrapped in /* */) must be re-enabled so long bone chains trail behind " +
+            "fast parent movement instead of rigidly following. The original disable " +
+            "was reportedly to debug flutter — re-evaluate after Bugs #3/#4 are fixed " +
+            "(per issue #138, those may have been the underlying cause of the flutter).")
+    }
+
+    // MARK: - Bug #7: Collider groupIndex >= 32 triggers bit-shift undefined behavior
+
+    /// `SpringBoneCollision.metal` does `1u << sphere.groupIndex` to build a per-collider
+    /// group bitmask. Per Metal C++ (and the underlying SPIR-V/MSL semantics), shifting
+    /// a 32-bit value by 32 or more is undefined behavior. The collider's `groupIndex`
+    /// is plumbed through unclamped from Swift, so a model with 33 or more collider
+    /// groups silently corrupts collision filtering.
+    ///
+    /// Both candidate fixes (Swift-side clamp to `0...31`, or shader-side
+    /// `if (groupIndex >= 32) continue;`) leave a bone in group 0 unaffected by an
+    /// out-of-range collider whose group bit cannot fit in the bone's mask. This test
+    /// asserts that observable invariant.
+    func testBoneInGroup0NotAffectedByColliderWithGroupIndexAbove31() throws {
+        let model = try makeChainModel(
+            names: ["A", "B"],
+            translations: [SIMD3<Float>(0, 0, 0), SIMD3<Float>(0, 1, 0)]
+        )
+
+        // 33 colliders. Indices 0..31 are placed far away (irrelevant). Index 32 is
+        // placed overlapping bone B — this is the out-of-range one whose `1u << 32`
+        // shift is UB. The sphere is offset along +X from the bone so the collision
+        // normal has a defined direction (a sphere centered exactly on the bone yields
+        // zero push because `toCenter / |toCenter|` is undefined at the center).
+        let groupCount = 33
+        var colliders: [VRMCollider] = []
+        for i in 0..<groupCount {
+            let offset: SIMD3<Float> = (i == 32)
+                ? SIMD3<Float>(0.1, 1, 0)            // overlap B with defined normal
+                : SIMD3<Float>(100, 100, 100)         // far away
+            colliders.append(VRMCollider(node: 0, shape: .sphere(offset: offset, radius: 0.3)))
+        }
+        let groups: [VRMColliderGroup] = (0..<groupCount).map { i in
+            VRMColliderGroup(name: "Group_\(i)", colliders: [i])
+        }
+
+        var joints: [VRMSpringJoint] = []
+        for i in 0..<2 {
+            var j = VRMSpringJoint(node: i)
+            j.hitRadius = 0.1
+            j.stiffness = 0.0
+            j.gravityPower = 0.0
+            j.dragForce = 0.0
+            joints.append(j)
+        }
+        var spring = VRMSpring(name: "Test")
+        spring.joints = joints
+        // Bone collides ONLY with group index 0 of the spring's known groups, so its
+        // bone-mask bit is `1 << 0 = 1` and an in-bounds collider in any other group
+        // would not touch it. The bug is that `1u << 32` is UB, so the sphere in
+        // group 32 may slip through anyway.
+        spring.colliderGroups = [0]
+
+        var sb = VRMSpringBone()
+        sb.springs = [spring]
+        sb.colliders = colliders
+        sb.colliderGroups = groups
+        model.springBone = sb
+
+        let buffers = SpringBoneBuffers(device: device)
+        buffers.allocateBuffers(numBones: 2, numSpheres: groupCount, numCapsules: 0)
+        model.springBoneBuffers = buffers
+        model.springBoneGlobalParams = makeGlobalParams(numBones: 2, numSpheres: UInt32(groupCount))
+
+        let system = try SpringBoneComputeSystem(device: device)
+        try system.populateSpringBoneData(model: model)
+
+        if let rest = buffers.restLengths {
+            let r = rest.contents().bindMemory(to: Float.self, capacity: 2)
+            r[1] = 1.0
+        }
+
+        let initialB = readBonePosition(model: model, boneIndex: 1)
+        try runFrame(system: system, model: model)
+        let finalB = readBonePosition(model: model, boneIndex: 1)
+        let displacement = simd_length(finalB - initialB)
+
+        XCTAssertLessThan(displacement, 0.05,
+            "Bone whose collider mask contains only group 0 must not be displaced " +
+            "by an overlapping collider in group 32. " +
+            "Initial: \(initialB), final: \(finalB), displacement: \(displacement). " +
+            "Bug #7: `1u << 32` is undefined behavior in Metal C++; on Apple GPUs " +
+            "the LSL instruction takes the low 5 bits of the shift amount, so the " +
+            "out-of-range bit collides with the bone's group-0 bit and the sphere " +
+            "leaks through the filter. Fix: clamp groupIndex to 0...31 in Swift " +
+            "before populating colliders, OR add `if (groupIndex >= 32) continue;` " +
+            "at the top of each collide* helper in SpringBoneCollision.metal before " +
+            "the shift.")
+    }
+}

--- a/Tests/VRMMetalKitTests/SpringBoneBugAuditTDDTests.swift
+++ b/Tests/VRMMetalKitTests/SpringBoneBugAuditTDDTests.swift
@@ -1,0 +1,411 @@
+// Copyright 2025 Arkavo Inc. and contributors
+// Licensed under the Apache License, Version 2.0
+
+import XCTest
+import Metal
+import simd
+@testable import VRMMetalKit
+
+/// TDD-style tests for SpringBone bugs identified in the physics audit.
+/// These tests assert CORRECT behavior and are expected to FAIL (RED phase)
+/// until the corresponding production bugs are fixed.
+final class SpringBoneBugAuditTDDTests: XCTestCase {
+
+    var device: MTLDevice!
+
+    override func setUp() async throws {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw XCTSkip("Metal not available")
+        }
+        self.device = device
+    }
+
+    // MARK: - Helpers
+
+    private func createGLTFNode(name: String, translation: SIMD3<Float>) throws -> GLTFNode {
+        let json = """
+        {
+            "name": "\(name)",
+            "translation": [\(translation.x), \(translation.y), \(translation.z)],
+            "rotation": [0.0, 0.0, 0.0, 1.0],
+            "scale": [1.0, 1.0, 1.0]
+        }
+        """
+        let data = json.data(using: .utf8)!
+        return try JSONDecoder().decode(GLTFNode.self, from: data)
+    }
+
+    private func readBonePosition(model: VRMModel, boneIndex: Int) -> SIMD3<Float> {
+        guard let buffers = model.springBoneBuffers,
+              boneIndex < buffers.numBones else { return .zero }
+        let ptr = buffers.bonePosCurr!.contents().bindMemory(to: SIMD3<Float>.self, capacity: buffers.numBones)
+        return ptr[boneIndex]
+    }
+
+    private func readAllBonePositions(model: VRMModel) -> [SIMD3<Float>] {
+        guard let buffers = model.springBoneBuffers else { return [] }
+        let ptr = buffers.bonePosCurr!.contents().bindMemory(to: SIMD3<Float>.self, capacity: buffers.numBones)
+        return (0..<buffers.numBones).map { ptr[$0] }
+    }
+
+    private func makeGlobalParams(numBones: Int) -> SpringBoneGlobalParams {
+        SpringBoneGlobalParams(
+            gravity: SIMD3<Float>(0, -9.8, 0),
+            dtSub: Float(1.0 / 120.0),
+            windAmplitude: 0.0,
+            windFrequency: 0.0,
+            windPhase: 0.0,
+            windDirection: SIMD3<Float>(1, 0, 0),
+            substeps: 1,
+            numBones: UInt32(numBones),
+            numSpheres: 0,
+            numCapsules: 0,
+            numPlanes: 0,
+            settlingFrames: 0
+        )
+    }
+
+    // MARK: - Bug #1: writeBonesToNodes index desync with nil node
+
+    /// When a spring joint references a missing node, subsequent valid joints
+    /// must still map to their correct GPU bone indices. Currently globalBoneIndex
+    /// fails to increment for nil nodes, shifting every later joint.
+    func testNilNodeDoesNotDesyncSubsequentJointMapping() throws {
+        let builder = VRMBuilder()
+        let model = try builder.setSkeleton(.defaultHumanoid).build()
+        model.nodes.removeAll()
+
+        // Skeleton: A(0)→B(1)→C(2).  Spring chain: A, nil(missing), B, C.
+        let nodeA = VRMNode(index: 0, gltfNode: try createGLTFNode(name: "A", translation: SIMD3<Float>(0, 0, 0)))
+        let nodeB = VRMNode(index: 1, gltfNode: try createGLTFNode(name: "B", translation: SIMD3<Float>(1, 1, 0)))
+        let nodeC = VRMNode(index: 2, gltfNode: try createGLTFNode(name: "C", translation: SIMD3<Float>(2, 1, 0)))
+        nodeB.parent = nodeA; nodeA.children.append(nodeB)
+        nodeC.parent = nodeB; nodeB.children.append(nodeC)
+        model.nodes = [nodeA, nodeB, nodeC]
+        for node in model.nodes {
+            node.updateWorldTransform()
+        }
+
+        var joints: [VRMSpringJoint] = []
+        for nodeIdx in [0, 999, 1, 2] {
+            var j = VRMSpringJoint(node: nodeIdx)
+            j.hitRadius = 0.02
+            j.stiffness = 0.0
+            j.gravityPower = 0.0
+            j.dragForce = 0.0
+            joints.append(j)
+        }
+
+        var springBone = VRMSpringBone()
+        var spring = VRMSpring(name: "Test")
+        spring.joints = joints
+        springBone.springs = [spring]
+        model.springBone = springBone
+
+        model.device = device
+        let buffers = SpringBoneBuffers(device: device)
+        buffers.allocateBuffers(numBones: 4, numSpheres: 0, numCapsules: 0)
+        model.springBoneBuffers = buffers
+        model.springBoneGlobalParams = makeGlobalParams(numBones: 4)
+
+        let system = try SpringBoneComputeSystem(device: device)
+        try system.populateSpringBoneData(model: model)
+
+        // Fix GPU state so physics is stable (populate gives restLength=0 for nil joints)
+        if let restLengths = buffers.restLengths {
+            let r = restLengths.contents().bindMemory(to: Float.self, capacity: 4)
+            r[1] = 1.0 // A → nil
+            r[2] = 1.0 // nil → B
+            r[3] = 1.0 // B → C
+        }
+        if let curr = buffers.bonePosCurr, let prev = buffers.bonePosPrev {
+            let c = curr.contents().bindMemory(to: SIMD3<Float>.self, capacity: 4)
+            let p = prev.contents().bindMemory(to: SIMD3<Float>.self, capacity: 4)
+            c[0] = SIMD3<Float>(0, 0, 0)
+            c[1] = SIMD3<Float>(1, 0, 0) // nil
+            c[2] = SIMD3<Float>(1, 1, 0) // B
+            c[3] = SIMD3<Float>(2, 1, 0) // C
+            for i in 0..<4 { p[i] = c[i] }
+        }
+
+        // One frame with no forces should preserve positions
+        system.update(model: model, deltaTime: 1.0 / 60.0)
+        Thread.sleep(forTimeInterval: 0.2)
+        system.writeBonesToNodes(model: model)
+
+        // With correct mapping, B should see target direction (1,0,0) which aligns
+        // with its bind direction (1,0,0) → near-identity rotation.
+        // With the bug, B is mapped to bone index 1 and sees target (0,1,0) while
+        // using bind direction (0.707,0.707,0) → ~45° rotation.
+        let bRotation = nodeB.localRotation
+        let angle = 2.0 * acos(min(abs(bRotation.real), 1.0))
+        XCTAssertLessThan(angle, 0.2,
+            "Node B rotation should be near identity (bind pose aligned with target). " +
+            "Actual angle: \(angle * 180 / Float.pi)°. Bug: nil node desynced mapping.")
+    }
+
+    // MARK: - Bug #2: Distance constraint uses wrong bind direction index
+
+    /// When a bone collapses onto its parent, the distance-constraint fallback
+    /// must use bindDirections[parentIndex], not bindDirections[id].
+    func testDistanceConstraintRecoversCollapsedBoneUsingParentDirection() throws {
+        let builder = VRMBuilder()
+        let model = try builder.setSkeleton(.defaultHumanoid).build()
+        model.nodes.removeAll()
+
+        let nodeA = VRMNode(index: 0, gltfNode: try createGLTFNode(name: "A", translation: SIMD3<Float>(0, 0, 0)))
+        let nodeB = VRMNode(index: 1, gltfNode: try createGLTFNode(name: "B", translation: SIMD3<Float>(1, 0, 0)))
+        nodeB.parent = nodeA; nodeA.children.append(nodeB)
+        model.nodes = [nodeA, nodeB]
+        for node in model.nodes {
+            node.updateWorldTransform()
+        }
+
+        var joints: [VRMSpringJoint] = []
+        for i in 0..<2 {
+            var j = VRMSpringJoint(node: i)
+            j.hitRadius = 0.02
+            j.stiffness = 0.0
+            j.gravityPower = 0.0
+            j.dragForce = 0.0
+            joints.append(j)
+        }
+
+        var springBone = VRMSpringBone()
+        var spring = VRMSpring(name: "Test")
+        spring.joints = joints
+        springBone.springs = [spring]
+        model.springBone = springBone
+
+        model.device = device
+        let buffers = SpringBoneBuffers(device: device)
+        buffers.allocateBuffers(numBones: 2, numSpheres: 0, numCapsules: 0)
+        model.springBoneBuffers = buffers
+        model.springBoneGlobalParams = makeGlobalParams(numBones: 2)
+
+        let system = try SpringBoneComputeSystem(device: device)
+        try system.populateSpringBoneData(model: model)
+
+        // Collapse B onto A and set restLength > 0 to trigger fallback
+        if let curr = buffers.bonePosCurr, let prev = buffers.bonePosPrev,
+           let rest = buffers.restLengths {
+            let c = curr.contents().bindMemory(to: SIMD3<Float>.self, capacity: 2)
+            let p = prev.contents().bindMemory(to: SIMD3<Float>.self, capacity: 2)
+            let r = rest.contents().bindMemory(to: Float.self, capacity: 2)
+            c[1] = c[0]          // collapse
+            p[1] = c[1]
+            r[1] = 1.0           // trigger fallback
+        }
+
+        system.update(model: model, deltaTime: 1.0 / 60.0)
+        Thread.sleep(forTimeInterval: 0.2)
+
+        let bPos = readBonePosition(model: model, boneIndex: 1)
+        // Correct: pushed along bindDirections[0] = (1,0,0) → x should be ~1.0
+        // Bug: pushed along bindDirections[1] = (0,1,0) → x stays ~0.0, y rises
+        XCTAssertGreaterThan(bPos.x, 0.5,
+            "Collapsed bone should recover along parent's bind direction (+X). " +
+            "Got \(bPos). Bug: distance.metal uses bindDirections[id] instead of bindDirections[parentIndex].")
+        XCTAssertLessThan(abs(bPos.y), 0.5,
+            "Collapsed bone should not recover along bone's own fallback direction. Got \(bPos).")
+    }
+
+    // MARK: - Bug #3+4: Collision kernels affect root bones
+
+    /// Root bones are kinematic and must not be pushed by colliders.
+    func testRootBonePositionUnchangedAfterCollision() throws {
+        let builder = VRMBuilder()
+        let model = try builder.setSkeleton(.defaultHumanoid).build()
+        model.nodes.removeAll()
+
+        let nodeA = VRMNode(index: 0, gltfNode: try createGLTFNode(name: "A", translation: SIMD3<Float>(0, 0, 0)))
+        let nodeB = VRMNode(index: 1, gltfNode: try createGLTFNode(name: "B", translation: SIMD3<Float>(0, 1, 0)))
+        nodeB.parent = nodeA; nodeA.children.append(nodeB)
+        model.nodes = [nodeA, nodeB]
+        for node in model.nodes {
+            node.updateWorldTransform()
+        }
+
+        var joints: [VRMSpringJoint] = []
+        for i in 0..<2 {
+            var j = VRMSpringJoint(node: i)
+            j.hitRadius = 0.1 // large so root intersects collider
+            j.stiffness = 0.0
+            j.gravityPower = 0.0
+            j.dragForce = 0.0
+            joints.append(j)
+        }
+
+        var springBone = VRMSpringBone()
+        var spring = VRMSpring(name: "Test")
+        spring.joints = joints
+        spring.colliderGroups = [0]
+        springBone.springs = [spring]
+
+        // Sphere collider offset so penetration has a defined normal
+        let collider = VRMCollider(node: 0, shape: .sphere(offset: SIMD3<Float>(0.1, 0, 0), radius: 0.2))
+        springBone.colliders = [collider]
+        let group = VRMColliderGroup(name: "Body", colliders: [0])
+        springBone.colliderGroups = [group]
+        model.springBone = springBone
+
+        model.device = device
+        let buffers = SpringBoneBuffers(device: device)
+        buffers.allocateBuffers(numBones: 2, numSpheres: 1, numCapsules: 0)
+        model.springBoneBuffers = buffers
+
+        var globalParams = makeGlobalParams(numBones: 2)
+        globalParams.numSpheres = 1 // CRITICAL: enable sphere collision kernel
+        model.springBoneGlobalParams = globalParams
+
+        let system = try SpringBoneComputeSystem(device: device)
+        try system.populateSpringBoneData(model: model)
+
+        // Fix rest length so child doesn't collapse
+        if let rest = buffers.restLengths {
+            let r = rest.contents().bindMemory(to: Float.self, capacity: 2)
+            r[1] = 1.0
+        }
+
+        // Root animated position
+        nodeA.translation = SIMD3<Float>(0, 0, 0)
+        nodeA.updateLocalMatrix()
+        nodeA.updateWorldTransform()
+
+        system.update(model: model, deltaTime: 1.0 / 60.0)
+        Thread.sleep(forTimeInterval: 0.2)
+
+        let rootPos = readBonePosition(model: model, boneIndex: 0)
+        XCTAssertEqual(rootPos.x, 0.0, accuracy: 0.001,
+            "Root bone should remain at animated position (0,0,0) despite collider intersection. " +
+            "Got \(rootPos). Bug: collision kernels do not skip root bones.")
+    }
+
+    // MARK: - Bug #5: Bind-direction count mismatch leaves buffer uninitialized
+
+    /// If a joint references a missing node, populateSpringBoneData must still
+    /// produce exactly numBones entries for the bindDirections buffer.
+    func testBindDirectionsBufferInitializedDespiteNilNode() throws {
+        let builder = VRMBuilder()
+        let model = try builder.setSkeleton(.defaultHumanoid).build()
+        model.nodes.removeAll()
+
+        let nodeA = VRMNode(index: 0, gltfNode: try createGLTFNode(name: "A", translation: SIMD3<Float>(0, 0, 0)))
+        let nodeB = VRMNode(index: 1, gltfNode: try createGLTFNode(name: "B", translation: SIMD3<Float>(0, 1, 0)))
+        nodeB.parent = nodeA; nodeA.children.append(nodeB)
+        model.nodes = [nodeA, nodeB]
+        for node in model.nodes {
+            node.updateWorldTransform()
+        }
+
+        var joints: [VRMSpringJoint] = []
+        for nodeIdx in [0, 999, 1] {
+            var j = VRMSpringJoint(node: nodeIdx)
+            j.hitRadius = 0.02
+            j.stiffness = 1.0 // stiffness requires bind directions
+            j.gravityPower = 0.0
+            j.dragForce = 0.0
+            joints.append(j)
+        }
+
+        var springBone = VRMSpringBone()
+        var spring = VRMSpring(name: "Test")
+        spring.joints = joints
+        springBone.springs = [spring]
+        model.springBone = springBone
+
+        model.device = device
+        let buffers = SpringBoneBuffers(device: device)
+        buffers.allocateBuffers(numBones: 3, numSpheres: 0, numCapsules: 0)
+        model.springBoneBuffers = buffers
+        model.springBoneGlobalParams = makeGlobalParams(numBones: 3)
+
+        let system = try SpringBoneComputeSystem(device: device)
+        try system.populateSpringBoneData(model: model)
+
+        // The bindDirections buffer must have been updated for all 3 bones.
+        // With the bug, initialWorldBindDirections has < 3 entries and
+        // updateBindDirections returns early, leaving uninitialized (zero) memory.
+        guard let bindBuf = buffers.bindDirections else {
+            XCTFail("bindDirections buffer missing")
+            return
+        }
+        let ptr = bindBuf.contents().bindMemory(to: SIMD3<Float>.self, capacity: 3)
+        for i in 0..<3 {
+            let dir = ptr[i]
+            let len = simd_length(dir)
+            XCTAssertGreaterThan(len, 0.001,
+                "Bind direction [\(i)] has zero length — buffer was not initialized. " +
+                "Bug: nil node causes count mismatch in updateBindDirections.")
+            XCTAssertFalse(dir.x.isNaN || dir.y.isNaN || dir.z.isNaN,
+                "Bind direction [\(i)] contains NaN.")
+        }
+    }
+
+    // MARK: - Horizontal chain helper (copied from SpringBonePhysicsSpecTests)
+
+    private func buildHorizontalChain(boneCount: Int, gravityPower: Float, drag: Float = 0.4) throws -> VRMModel {
+        let builder = VRMBuilder()
+        let model = try builder.setSkeleton(.defaultHumanoid).build()
+        model.nodes.removeAll()
+
+        let boneLength: Float = 0.1
+        var previousNode: VRMNode? = nil
+        for i in 0..<boneCount {
+            let localX: Float = (i == 0) ? 0 : boneLength
+            let localY: Float = (i == 0) ? 1.0 : 0
+            let gltfNode = try createGLTFNode(
+                name: "spring_bone_\(i)",
+                translation: SIMD3<Float>(localX, localY, 0)
+            )
+            let node = VRMNode(index: i, gltfNode: gltfNode)
+            if let parent = previousNode {
+                node.parent = parent
+                parent.children.append(node)
+            }
+            model.nodes.append(node)
+            previousNode = node
+        }
+        for node in model.nodes {
+            node.updateWorldTransform()
+        }
+
+        var joints: [VRMSpringJoint] = []
+        for i in 0..<boneCount {
+            var joint = VRMSpringJoint(node: i)
+            joint.hitRadius = 0.02
+            joint.stiffness = 0.0
+            joint.gravityPower = gravityPower
+            joint.gravityDir = SIMD3<Float>(0, -1, 0)
+            joint.dragForce = drag
+            joints.append(joint)
+        }
+
+        var springBone = VRMSpringBone()
+        var spring = VRMSpring(name: "HorizontalChain")
+        spring.joints = joints
+        springBone.springs = [spring]
+        model.springBone = springBone
+
+        model.device = device
+        let buffers = SpringBoneBuffers(device: device)
+        buffers.allocateBuffers(numBones: boneCount, numSpheres: 0, numCapsules: 0)
+        model.springBoneBuffers = buffers
+
+        model.springBoneGlobalParams = SpringBoneGlobalParams(
+            gravity: SIMD3<Float>(0, -9.8, 0),
+            dtSub: Float(1.0 / 120.0),
+            windAmplitude: 0.0,
+            windFrequency: 0.0,
+            windPhase: 0.0,
+            windDirection: SIMD3<Float>(1, 0, 0),
+            substeps: 1,
+            numBones: UInt32(boneCount),
+            numSpheres: 0,
+            numCapsules: 0,
+            numPlanes: 0,
+            settlingFrames: 0
+        )
+        return model
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds **failing tests** (RED phase) that document and reproduce four critical SpringBone physics bugs found during a full code audit. No production code is changed — this is purely the test suite that the fixes must satisfy.

## Bugs Covered

| # | Test | Bug | Failure Mode |
|---|------|-----|--------------|
| 1 |  |  index desync | Missing node causes \+globalBoneIndex\+ to fall behind; subsequent joints read wrong GPU positions and get wrong rotations (45° instead of identity). |
| 2 |  | Wrong bind direction in distance fallback |  line 72 uses  instead of ; collapsed bone recovers along its own fallback  instead of parent’s . |
| 3+4 |  | Collision kernels affect roots | No  guard in sphere/capsule/plane collision kernels; kinematic roots get pushed by colliders. |
| 5 |  | Bind-direction count mismatch | Nil node causes ;  returns early, leaving GPU buffer uninitialized (zeros). |

## How to run

Test Suite 'Selected tests' started at 2026-05-03 20:48:02.577.
Test Suite 'VRMMetalKitPackageTests.xctest' started at 2026-05-03 20:48:02.577.
Test Suite 'SpringBoneBugAuditTDDTests' started at 2026-05-03 20:48:02.577.
Test Case '-[VRMMetalKitTests.SpringBoneBugAuditTDDTests testBindDirectionsBufferInitializedDespiteNilNode]' started.
/Users/arkavo/Projects/VRMMetalKit/Tests/VRMMetalKitTests/SpringBoneBugAuditTDDTests.swift:337: error: -[VRMMetalKitTests.SpringBoneBugAuditTDDTests testBindDirectionsBufferInitializedDespiteNilNode] : XCTAssertGreaterThan failed: ("0.0") is not greater than ("0.001") - Bind direction [0] has zero length — buffer was not initialized. Bug: nil node causes count mismatch in updateBindDirections.
/Users/arkavo/Projects/VRMMetalKit/Tests/VRMMetalKitTests/SpringBoneBugAuditTDDTests.swift:337: error: -[VRMMetalKitTests.SpringBoneBugAuditTDDTests testBindDirectionsBufferInitializedDespiteNilNode] : XCTAssertGreaterThan failed: ("0.0") is not greater than ("0.001") - Bind direction [1] has zero length — buffer was not initialized. Bug: nil node causes count mismatch in updateBindDirections.
/Users/arkavo/Projects/VRMMetalKit/Tests/VRMMetalKitTests/SpringBoneBugAuditTDDTests.swift:337: error: -[VRMMetalKitTests.SpringBoneBugAuditTDDTests testBindDirectionsBufferInitializedDespiteNilNode] : XCTAssertGreaterThan failed: ("0.0") is not greater than ("0.001") - Bind direction [2] has zero length — buffer was not initialized. Bug: nil node causes count mismatch in updateBindDirections.
Test Case '-[VRMMetalKitTests.SpringBoneBugAuditTDDTests testBindDirectionsBufferInitializedDespiteNilNode]' failed (0.027 seconds).
Test Case '-[VRMMetalKitTests.SpringBoneBugAuditTDDTests testDistanceConstraintRecoversCollapsedBoneUsingParentDirection]' started.
/Users/arkavo/Projects/VRMMetalKit/Tests/VRMMetalKitTests/SpringBoneBugAuditTDDTests.swift:206: error: -[VRMMetalKitTests.SpringBoneBugAuditTDDTests testDistanceConstraintRecoversCollapsedBoneUsingParentDirection] : XCTAssertGreaterThan failed: ("0.0") is not greater than ("0.5") - Collapsed bone should recover along parent's bind direction (+X). Got SIMD3<Float>(0.0, -1.0, 0.0). Bug: distance.metal uses bindDirections[id] instead of bindDirections[parentIndex].
/Users/arkavo/Projects/VRMMetalKit/Tests/VRMMetalKitTests/SpringBoneBugAuditTDDTests.swift:209: error: -[VRMMetalKitTests.SpringBoneBugAuditTDDTests testDistanceConstraintRecoversCollapsedBoneUsingParentDirection] : XCTAssertLessThan failed: ("1.0") is not less than ("0.5") - Collapsed bone should not recover along bone's own fallback direction. Got SIMD3<Float>(0.0, -1.0, 0.0).
Test Case '-[VRMMetalKitTests.SpringBoneBugAuditTDDTests testDistanceConstraintRecoversCollapsedBoneUsingParentDirection]' failed (0.213 seconds).
Test Case '-[VRMMetalKitTests.SpringBoneBugAuditTDDTests testNilNodeDoesNotDesyncSubsequentJointMapping]' started.
/Users/arkavo/Projects/VRMMetalKit/Tests/VRMMetalKitTests/SpringBoneBugAuditTDDTests.swift:142: error: -[VRMMetalKitTests.SpringBoneBugAuditTDDTests testNilNodeDoesNotDesyncSubsequentJointMapping] : XCTAssertLessThan failed: ("0.7853986") is not less than ("0.2") - Node B rotation should be near identity (bind pose aligned with target). Actual angle: 45.000027°. Bug: nil node desynced mapping.
Test Case '-[VRMMetalKitTests.SpringBoneBugAuditTDDTests testNilNodeDoesNotDesyncSubsequentJointMapping]' failed (0.217 seconds).
Test Case '-[VRMMetalKitTests.SpringBoneBugAuditTDDTests testRootBonePositionUnchangedAfterCollision]' started.
/Users/arkavo/Projects/VRMMetalKit/Tests/VRMMetalKitTests/SpringBoneBugAuditTDDTests.swift:279: error: -[VRMMetalKitTests.SpringBoneBugAuditTDDTests testRootBonePositionUnchangedAfterCollision] : XCTAssertEqualWithAccuracy failed: ("-0.19999999") is not equal to ("0.0") +/- ("0.001") - Root bone should remain at animated position (0,0,0) despite collider intersection. Got SIMD3<Float>(-0.19999999, 0.0, 0.0). Bug: collision kernels do not skip root bones.
Test Case '-[VRMMetalKitTests.SpringBoneBugAuditTDDTests testRootBonePositionUnchangedAfterCollision]' failed (0.220 seconds).
Test Suite 'SpringBoneBugAuditTDDTests' failed at 2026-05-03 20:48:03.255.
	 Executed 4 tests, with 7 failures (0 unexpected) in 0.678 (0.678) seconds
Test Suite 'VRMMetalKitPackageTests.xctest' failed at 2026-05-03 20:48:03.255.
	 Executed 4 tests, with 7 failures (0 unexpected) in 0.678 (0.678) seconds
Test Suite 'Selected tests' failed at 2026-05-03 20:48:03.255.
	 Executed 4 tests, with 7 failures (0 unexpected) in 0.678 (0.679) seconds
◇ Test run started.
↳ Testing Library Version: 1743
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.

Expected: 4 tests, all failing (7 assertion failures total).

## Next Step (GREEN phase)

A follow-up PR will fix the 4 minimal production changes needed to turn these tests green:

1. **Bug #1** — : move  outside the .
2. **Bug #2** — : change  → .
3. **Bug #3+4** — : add root-bone exclusion to all three collision entry kernels.
4. **Bug #5** — : ensure  appends exactly one entry per joint, even for nil nodes.

## Checklist

- [x] Tests only — no production code changed
- [x] Tests assert correct behavior (not current buggy behavior)
- [x] All new tests compile and run
- [x] Existing test suite still passes