### PR TITLE
fix(renderer): preserve framebuffer alpha when BLEND draws over opaque

### DIFF
--- a/Sources/VRMMetalKit/Renderer/VRMRenderer+Pipeline.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer+Pipeline.swift
@@ -234,7 +234,10 @@ extension VRMRenderer {
             blendColorAttachment?.sourceRGBBlendFactor = .sourceAlpha
             blendColorAttachment?.destinationRGBBlendFactor = .oneMinusSourceAlpha
             blendColorAttachment?.rgbBlendOperation = .add
-            blendColorAttachment?.sourceAlphaBlendFactor = .sourceAlpha
+            // Alpha union: final.a = src.a + dst.a*(1-src.a). `.one` (not `.sourceAlpha`)
+            // keeps dst.a=1 when src draws over an already-opaque pixel, so transparent
+            // MTKView compositing doesn't bleed background through stacked BLEND layers.
+            blendColorAttachment?.sourceAlphaBlendFactor = .one
             blendColorAttachment?.destinationAlphaBlendFactor = .oneMinusSourceAlpha
             blendColorAttachment?.alphaBlendOperation = .add
 
@@ -449,7 +452,8 @@ extension VRMRenderer {
             skinnedBlendColorAttachment?.sourceRGBBlendFactor = .sourceAlpha
             skinnedBlendColorAttachment?.destinationRGBBlendFactor = .oneMinusSourceAlpha
             skinnedBlendColorAttachment?.rgbBlendOperation = .add
-            skinnedBlendColorAttachment?.sourceAlphaBlendFactor = .sourceAlpha
+            // See comment on the non-skinned BLEND pipeline above.
+            skinnedBlendColorAttachment?.sourceAlphaBlendFactor = .one
             skinnedBlendColorAttachment?.destinationAlphaBlendFactor = .oneMinusSourceAlpha
             skinnedBlendColorAttachment?.alphaBlendOperation = .add
 

--- a/Tests/VRMMetalKitTests/BlendAlphaPreservationTests.swift
+++ b/Tests/VRMMetalKitTests/BlendAlphaPreservationTests.swift
@@ -1,0 +1,212 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+import Metal
+import simd
+@testable import VRMMetalKit
+
+/// Regression test for VRMHost see-through-eye-whites bug.
+///
+/// When VRMMetalKit renders into a transparent MTKView (clearColor.alpha=0,
+/// isOpaque=false), the framebuffer alpha at every drawn pixel must remain 1.0
+/// so SwiftUI/AppKit content underneath does not bleed through.
+///
+/// The bug: the BLEND pipeline used `sourceAlphaBlendFactor = .sourceAlpha`,
+/// which squared the source alpha when computing destination alpha. A BLEND
+/// material drawing over an opaque destination eroded its alpha (e.g.
+/// 0.22^2 + 0.78 = 0.83). Stacked BLEND layers compounded the erosion.
+@MainActor
+final class BlendAlphaPreservationTests: XCTestCase {
+
+    private var device: MTLDevice!
+
+    override func setUp() async throws {
+        device = MTLCreateSystemDefaultDevice()
+        guard device != nil else {
+            throw XCTSkip("Metal device not available")
+        }
+    }
+
+    /// Renders AvatarSample_A with a fully transparent clear color and
+    /// asserts that all drawn pixels write fully-opaque alpha. AvatarSample_A
+    /// has BLEND-mode `EyeIris` (routed to opaque) plus BLEND-mode
+    /// `EyeHighlight` rendered on top, which is the configuration that
+    /// triggers the bug.
+    func testBlendOverOpaqueRegionsPreservesFramebufferAlpha() async throws {
+        guard let modelPath = locateAvatarSampleA() else {
+            throw XCTSkip("AvatarSample_A.vrm.glb not found (set MUSE_RESOURCES_PATH)")
+        }
+
+        let model = try await VRMModel.load(
+            from: URL(fileURLWithPath: modelPath),
+            device: device
+        )
+
+        let width = 256
+        let height = 256
+        let pixels = try renderToTransparentTarget(
+            model: model,
+            width: width,
+            height: height
+        )
+
+        // Count pixels where the framebuffer was drawn to (alpha > 0) but the
+        // destination alpha was visibly eroded. Texture-side anti-aliasing in
+        // MASK materials can legitimately produce alpha in the 248-254 range
+        // (imperceptible to the user). The bug we are guarding against erodes
+        // alpha far further (typically 0.83 per BLEND pass, compounding with
+        // stacked layers); we threshold at 240/255 (~6% transparency), which
+        // is well above texture-AA noise and well below the buggy values.
+        // Inspect only the face interior where stacked BLEND layers (eye iris,
+        // eye highlight, eyeline, eyelash) overlap opaque face geometry. The
+        // silhouette edges (face profile, hair ends) legitimately have
+        // partial alpha — those pixels are anti-aliased into the menu beneath
+        // and should not be flagged as "erosion".
+        //
+        // For AvatarSample_A at 256x256 with the camera defined above, the
+        // face profile spans roughly x=85..170. Inset by 8 px to clear the
+        // edge AA, then constrain Y to the eye band where the bug manifests.
+        // Inspect the face/head INTERIOR (excluding silhouette edges where
+        // partial alpha is legitimate face-meets-background anti-aliasing).
+        // For AvatarSample_A at 256x256 with this camera, the silhouette runs
+        // at roughly x≤91 and x≥168; insetting by 5 px clears it. The bug
+        // produces interior erosion clusters where stacked BLEND layers
+        // (highlight, eyeline, eyelash, brow) draw over opaque face geometry.
+        // Threshold 200 (~22% transparency): well below the worst-case
+        // texture-edge α≈237 stragglers seen post-fix, well above the buggy
+        // values which routinely fell to 130-200 from a single BLEND pass
+        // (and worse with stacks). Pre-fix produces interior pixels in this
+        // range; post-fix produces zero.
+        let interiorXMin = 96
+        let interiorXMax = 163
+        let visibleErosionThreshold: UInt8 = 200
+        var interiorEroded = 0
+        var interiorDrawn = 0
+        for y in 0..<height {
+            for x in interiorXMin..<interiorXMax {
+                let i = (y * width + x) * 4
+                let a = pixels[i + 3]
+                if a == 0 { continue }
+                interiorDrawn += 1
+                if a < visibleErosionThreshold { interiorEroded += 1 }
+            }
+        }
+
+        XCTAssertGreaterThan(interiorDrawn, 100, "Interior sample is empty — fixture/camera setup wrong")
+        XCTAssertEqual(
+            interiorEroded, 0,
+            "BLEND pipeline eroded destination alpha at \(interiorEroded)/\(interiorDrawn) pixels in the face interior (alpha < \(visibleErosionThreshold)/255) — menu would bleed through these pixels in a transparent MTKView"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func locateAvatarSampleA() -> String? {
+        if let envPath = ProcessInfo.processInfo.environment["MUSE_RESOURCES_PATH"] {
+            let p = "\(envPath)/AvatarSample_A.vrm.glb"
+            if FileManager.default.fileExists(atPath: p) { return p }
+        }
+        let fallback = "../Muse/Resources/VRM/AvatarSample_A.vrm.glb"
+        if FileManager.default.fileExists(atPath: fallback) { return fallback }
+        return nil
+    }
+
+    private func renderToTransparentTarget(
+        model: VRMModel,
+        width: Int,
+        height: Int
+    ) throws -> [UInt8] {
+        var config = RendererConfig()
+        config.sampleCount = 1
+        config.strict = .off
+        let renderer = VRMRenderer(device: device, config: config)
+        renderer.loadModel(model)
+
+        let aspect = Float(width) / Float(height)
+        renderer.projectionMatrix = makePerspectiveProjection(
+            fovY: Float.pi / 4,
+            aspectRatio: aspect,
+            nearZ: 0.01,
+            farZ: 100.0
+        )
+        renderer.viewMatrix = makeLookAt(
+            eye: SIMD3<Float>(0, 1.4, 0.6),
+            target: SIMD3<Float>(0, 1.4, 0),
+            up: SIMD3<Float>(0, 1, 0)
+        )
+
+        let colorDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm,
+            width: width,
+            height: height,
+            mipmapped: false
+        )
+        colorDesc.usage = [.renderTarget, .shaderRead]
+        colorDesc.storageMode = .shared
+        guard let colorTex = device.makeTexture(descriptor: colorDesc) else {
+            throw NSError(domain: "BlendAlphaPreservationTests", code: 1)
+        }
+
+        let depthDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .depth32Float,
+            width: width,
+            height: height,
+            mipmapped: false
+        )
+        depthDesc.usage = [.renderTarget]
+        depthDesc.storageMode = .private
+        guard let depthTex = device.makeTexture(descriptor: depthDesc) else {
+            throw NSError(domain: "BlendAlphaPreservationTests", code: 2)
+        }
+
+        let pass = MTLRenderPassDescriptor()
+        pass.colorAttachments[0].texture = colorTex
+        pass.colorAttachments[0].loadAction = .clear
+        pass.colorAttachments[0].storeAction = .store
+        pass.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+        pass.depthAttachment.texture = depthTex
+        pass.depthAttachment.loadAction = .clear
+        pass.depthAttachment.clearDepth = 1.0
+        pass.depthAttachment.storeAction = .dontCare
+
+        guard let queue = device.makeCommandQueue(),
+              let commandBuffer = queue.makeCommandBuffer() else {
+            throw NSError(domain: "BlendAlphaPreservationTests", code: 3)
+        }
+
+        renderer.drawOffscreenHeadless(
+            to: colorTex,
+            depth: depthTex,
+            commandBuffer: commandBuffer,
+            renderPassDescriptor: pass
+        )
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+
+        let bytesPerRow = width * 4
+        var pixels = [UInt8](repeating: 0, count: bytesPerRow * height)
+        pixels.withUnsafeMutableBytes { buf in
+            colorTex.getBytes(
+                buf.baseAddress!,
+                bytesPerRow: bytesPerRow,
+                from: MTLRegionMake2D(0, 0, width, height),
+                mipmapLevel: 0
+            )
+        }
+        return pixels
+    }
+}


### PR DESCRIPTION
## Summary

Patch release candidate from tag \`0.11.0\` (cherry-pick of one fix, no other changes).

Fixes a long-standing bug in the BLEND and skinned-BLEND pipelines that erodes the framebuffer alpha channel when a partially-transparent material draws over an opaque destination. Invisible when rendering to a clear-color with α=1.0, but **visible to any consumer that composites the avatar over a transparent surface** — notably an \`MTKView\` with \`isOpaque = false\` and \`clearColor.alpha = 0\`. Reported in VRMHost (GameOfMods app, pinned to \`0.11.0\`) as menu items showing through the white of an avatar's eyes.

## Root cause

\`Sources/VRMMetalKit/Renderer/VRMRenderer+Pipeline.swift:237\` and \`:452\` set:

\`\`\`swift
sourceAlphaBlendFactor = .sourceAlpha
destinationAlphaBlendFactor = .oneMinusSourceAlpha
\`\`\`

which computes \`final.a = src.a² + dst.a·(1-src.a)\`. With \`src.a ≈ 0.22\` over an opaque \`dst.a = 1\`, that drops the framebuffer alpha to \`~0.83\`. Stacked BLEND layers (highlight → eyeline → eyelash) compounded the erosion.

The third blend pipeline at line 570 was already correct (\`.one\`) — this PR brings the main two into line and matches standard Porter-Duff *src-over* compositing math:

\`final.a = 1·src.a + dst.a·(1-src.a)\` — preserves dst opacity.

## Fix

Two-line change at the two BLEND descriptors (regular + skinned). Plus inline comment explaining why \`.one\` is correct.

## Test

\`Tests/VRMMetalKitTests/BlendAlphaPreservationTests.swift\` — renders \`AvatarSample_A.vrm.glb\` with \`clearColor.alpha = 0\`, asserts no face-interior pixel ends up at α<200/255.
- Pre-fix: 9 interior eroded pixels.
- Post-fix: 0.

Skips cleanly with \`XCTSkip\` when no Metal device is available or when \`MUSE_RESOURCES_PATH\` is unset.

## Empirical confirmation on the originally-reported asset

Rendered \`Ao_dress.vrm.glb\` at 1024×1024 with \`clearColor.alpha = 0\` (matching VRMHost's transparent compositing):

| Region | Pre-fix avg α | Post-fix avg α |
|---|---|---|
| Left iris (sclera+iris) | 247.8 / 255 | **255.00 / 255** |
| Right iris | 246.5 / 255 | **255.00 / 255** |
| Total whole-image eroded pixels | 17,354 | 4,682 (silhouette / hair / lash edges only — correct AA) |

## Verification on 0.11.0

\`git show 0.11.0:Sources/VRMMetalKit/Renderer/VRMRenderer+Pipeline.swift\` shows the buggy lines 237 and 452 both have \`sourceAlphaBlendFactor = .sourceAlpha\`. The bug exists byte-identically on \`0.11.0\`. The 9 commits between \`0.11.0\` and the springbone audit branch (#143) only touched SpringBone shaders + Swift glue and did not change any rendering behavior, so this fix applies cleanly to \`0.11.0\`.

## Test plan

- [x] \`swift test --filter BlendAlphaPreservationTests\` — GREEN; verified RED→GREEN cycle pre/post the alpha-factor change.
- [x] \`swift build\` clean.
- [x] Visual confirmation on Ao_dress and AvatarSample_A.
- [ ] Rebuild VRMHost (GameOfMods) against this branch and confirm menu no longer bleeds through eye whites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)