### PR TITLE
fix(loader): map VRM 0.x _BlendMode to alphaMode + handle Int JSON arrays

### DIFF
--- a/Sources/VRMMetalKit/Renderer/VRMGeometry.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMGeometry.swift
@@ -1262,6 +1262,16 @@ public class VRMMaterial {
             // _BlendMode: 0=Opaque, 1=Cutout, 2=Transparent, 3=TransparentWithZWrite
             if let bm = vrm0Prop.floatProperties["_BlendMode"] {
                 blendMode = Int(bm)
+                // Map VRM 0.x _BlendMode to glTF alphaMode for pipeline selection.
+                // Without this, materials authored as Transparent (e.g.
+                // AliciaSolid's bangs at _BlendMode=3) stay as glTF "OPAQUE" and
+                // render without alpha blending.
+                switch blendMode {
+                case 0: alphaMode = "OPAQUE"
+                case 1: alphaMode = "MASK"
+                case 2, 3: alphaMode = "BLEND"
+                default: alphaMode = "OPAQUE"
+                }
             }
         }
     }
@@ -1271,14 +1281,29 @@ public class VRMMaterial {
         return value <= 0.04045 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
     }
 
+    /// Extract a `[Float]` from an MToon JSON value where AnyCodable may have
+    /// decoded array elements as `Int` rather than `Double` (e.g. `[1, 1, 1]`
+    /// in the JSON literal). The `as? [Double]` cast at the call sites was
+    /// silently failing for spec-conformant integer-valued vectors.
+    private func floatArray(from value: Any?, count: Int) -> [Float]? {
+        guard let array = value as? [Any], array.count >= count else { return nil }
+        let parsed: [Float] = array.compactMap {
+            if let intVal = $0 as? Int { return Float(intVal) }
+            if let doubleVal = $0 as? Double { return Float(doubleVal) }
+            if let floatVal = $0 as? Float { return floatVal }
+            return nil
+        }
+        return parsed.count >= count ? parsed : nil
+    }
+
     private func parseMToonExtension(_ mtoonExt: [String: Any], textures: [VRMTexture]) -> VRMMToonMaterial {
         var mtoon = VRMMToonMaterial()
 
         // Shade color factor
-        if let shadeColorFactor = mtoonExt["shadeColorFactor"] as? [Double], shadeColorFactor.count >= 3 {
-            mtoon.shadeColorFactor = SIMD3<Float>(Float(shadeColorFactor[0]),
-                                                  Float(shadeColorFactor[1]),
-                                                  Float(shadeColorFactor[2]))
+        if let shadeColorFactor = floatArray(from: mtoonExt["shadeColorFactor"], count: 3) {
+            mtoon.shadeColorFactor = SIMD3<Float>(shadeColorFactor[0],
+                                                  shadeColorFactor[1],
+                                                  shadeColorFactor[2])
         }
 
         // Shading properties
@@ -1295,17 +1320,17 @@ public class VRMMaterial {
         }
 
         // MatCap properties
-        if let matcapFactor = mtoonExt["matcapFactor"] as? [Double], matcapFactor.count >= 3 {
-            mtoon.matcapFactor = SIMD3<Float>(Float(matcapFactor[0]),
-                                              Float(matcapFactor[1]),
-                                              Float(matcapFactor[2]))
+        if let matcapFactor = floatArray(from: mtoonExt["matcapFactor"], count: 3) {
+            mtoon.matcapFactor = SIMD3<Float>(matcapFactor[0],
+                                              matcapFactor[1],
+                                              matcapFactor[2])
         }
 
         // Parametric rim lighting
-        if let parametricRimColorFactor = mtoonExt["parametricRimColorFactor"] as? [Double], parametricRimColorFactor.count >= 3 {
-            mtoon.parametricRimColorFactor = SIMD3<Float>(Float(parametricRimColorFactor[0]),
-                                                          Float(parametricRimColorFactor[1]),
-                                                          Float(parametricRimColorFactor[2]))
+        if let parametricRimColorFactor = floatArray(from: mtoonExt["parametricRimColorFactor"], count: 3) {
+            mtoon.parametricRimColorFactor = SIMD3<Float>(parametricRimColorFactor[0],
+                                                          parametricRimColorFactor[1],
+                                                          parametricRimColorFactor[2])
         }
         if let parametricRimFresnelPowerFactor = mtoonExt["parametricRimFresnelPowerFactor"] as? Double {
             mtoon.parametricRimFresnelPowerFactor = Float(parametricRimFresnelPowerFactor)
@@ -1324,10 +1349,10 @@ public class VRMMaterial {
         if let outlineWidthFactor = mtoonExt["outlineWidthFactor"] as? Double {
             mtoon.outlineWidthFactor = Float(outlineWidthFactor)
         }
-        if let outlineColorFactor = mtoonExt["outlineColorFactor"] as? [Double], outlineColorFactor.count >= 3 {
-            mtoon.outlineColorFactor = SIMD3<Float>(Float(outlineColorFactor[0]),
-                                                    Float(outlineColorFactor[1]),
-                                                    Float(outlineColorFactor[2]))
+        if let outlineColorFactor = floatArray(from: mtoonExt["outlineColorFactor"], count: 3) {
+            mtoon.outlineColorFactor = SIMD3<Float>(outlineColorFactor[0],
+                                                    outlineColorFactor[1],
+                                                    outlineColorFactor[2])
         }
         if let outlineLightingMixFactor = mtoonExt["outlineLightingMixFactor"] as? Double {
             mtoon.outlineLightingMixFactor = Float(outlineLightingMixFactor)


### PR DESCRIPTION
## Summary

Two latent loader bugs salvaged from PR #148 (which was forked from a pre-#143 base and could not be rebased — see closing note on #148).

### 1. VRM 0.x \`_BlendMode\` was parsed but never mapped to \`alphaMode\`

\`VRMGeometry.swift:1262\` reads \`_BlendMode\` into the internal \`blendMode\` field but the glTF \`alphaMode\` stays at the spec default \`\"OPAQUE\"\`. Pipeline selection keys off \`alphaMode\`, so VRM 0.x materials authored as Transparent (e.g. AliciaSolid's bangs at \`_BlendMode=3\`) routed through the opaque pass and rendered without alpha blending.

Fix: switch on \`blendMode\` after parsing it and set the corresponding \`alphaMode\`:

| \`_BlendMode\` | Mapped to |
|---|---|
| 0 | \`OPAQUE\` |
| 1 | \`MASK\` |
| 2 | \`BLEND\` |
| 3 | \`BLEND\` (\`transparentWithZWrite\` already tracked separately via \`zWriteEnabled\`) |

### 2. \`as? [Double]\` failed on Int-typed JSON arrays

AnyCodable decodes \`[1, 1, 1]\` from JSON as \`[Int]\`, not \`[Double]\`. Several MToon factor parsers (\`shadeColorFactor\`, \`matcapFactor\`, \`parametricRimColorFactor\`, \`outlineColorFactor\`) used \`as? [Double]\` and silently dropped the value when the JSON happened to use integer literals.

Fix: \`floatArray(from:count:)\` helper that accepts \`Int\`, \`Double\`, and \`Float\` element types. Routes the four call sites through it.

## Test plan

- [x] \`swift build\` clean
- [x] \`swift test --parallel --num-workers 14 -j 16 --disable-sandbox\` — exit 0

## Provenance

Salvaged from PR #148. Other claimed fixes in #148 (color mismatch, lighting, sRGB output) were already addressed by PR #158 (\`fix/renderer-lighting-correctness\`) using different (now-merged) implementations. PR #148 is being closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)