### PR TITLE
docs(spec): correct stale deviation entries + amend dead TODO

### DIFF
--- a/Sources/VRMMetalKit/Core/VRMModel.swift
+++ b/Sources/VRMMetalKit/Core/VRMModel.swift
@@ -1003,8 +1003,11 @@ public class VRMModel: @unchecked Sendable {
             settlingFrames: 120
         )
 
-        // TODO: Populate bone parameters, rest lengths, and colliders
-        // This will be implemented in the compute system
+        // Bone parameters, rest lengths, and collider data are populated
+        // separately by `SpringBoneComputeSystem.populateSpringBoneData(model:)`,
+        // which is called by the renderer (see `VRMRenderer.swift` ~770) after
+        // the renderer's compute system is created. This function only
+        // allocates the GPU buffers and seeds the global params.
     }
 
     // MARK: - Floor Plane Colliders

--- a/docs/COMPARISON_UNIVRM.md
+++ b/docs/COMPARISON_UNIVRM.md
@@ -123,11 +123,12 @@ public enum VRMExpressionPreset: String, CaseIterable, Sendable {
     case blink, blinkLeft, blinkRight           // Blink (3)
     case lookUp, lookDown, lookLeft, lookRight  // Gaze (4)
     case neutral                                 // Neutral (1)
+    case custom                                  // User-defined (1)
 }
-// Total: 18 presets (no custom enum)
+// Total: 19 presets
 ```
 
-**⚠️ ISSUE IDENTIFIED:**
+**Analysis:**
 
 | Feature | UniVRM | VRMMetalKit | Status |
 |---------|--------|-------------|--------|
@@ -136,13 +137,11 @@ public enum VRMExpressionPreset: String, CaseIterable, Sendable {
 | **Blink Expressions** | 3 | 3 | ✅ Match |
 | **Gaze Expressions** | 4 | 4 | ✅ Match |
 | **Neutral Expression** | ✅ | ✅ | ✅ Match |
-| **Custom Expression Enum** | ✅ | ❌ | ⚠️ **Missing** |
+| **Custom Expression Enum** | ✅ | ✅ | ✅ Match |
 
-**Analysis:**
-- ✅ All 18 standard VRM 1.0 expressions are present
-- ⚠️ **VRMMetalKit missing `custom` enum case** (though custom expressions are supported via name-based lookup)
-- ✅ Both support custom expressions through string-based names
-- ✅ Expression structure matches VRM 1.0 specification
+- All 19 VRM 1.0 expression presets (including `custom`) are represented in `VRMExpressionPreset`.
+- Both UniVRM and VRMMetalKit also support custom expressions via string-based names.
+- Expression structure matches VRM 1.0 specification.
 
 **Recommendation:**
 ```swift
@@ -567,7 +566,7 @@ case .missingRequiredBone(let bone, let available):
 |----------|--------|-------------|---------|
 | **VRM 1.0 Core** | ✅ 100% | ✅ 100% | ✅ Both correct |
 | **Humanoid Bones** | ✅ 55/55 | ✅ 55/55 | ✅ Both correct |
-| **Expressions** | ✅ 19/19 | ⚠️ 18/19 (missing custom enum) | ⚠️ Minor issue |
+| **Expressions** | ✅ 19/19 | ✅ 19/19 | ✅ Both correct |
 | **MToon Shader** | ✅ Full | ✅ Full | ✅ Both correct |
 | **SpringBone** | ✅ Spec-compliant | ✅ Spec-compliant (XPBD variant) | ✅ Both correct |
 | **First-Person** | ✅ Full | ✅ Core features | ✅ Both correct |
@@ -590,16 +589,7 @@ case .missingRequiredBone(let bone, let available):
 
 ### 7.1 Critical Issues (Must Fix)
 
-1. **Add `custom` to VRMExpressionPreset enum**
-   ```swift
-   public enum VRMExpressionPreset: String, CaseIterable, Sendable {
-       case custom  // Add this
-       case happy, angry, sad, relaxed, surprised
-       // ... rest
-   }
-   ```
-   **Impact:** Specification compliance
-   **Effort:** Low
+_(none currently — see §7.2 for nice-to-have improvements)_
 
 ### 7.2 High Priority (Should Fix)
 
@@ -655,7 +645,6 @@ case .missingRequiredBone(let bone, let available):
 - Robust validation system (StrictMode)
 
 ⚠️ **Minor Issues:**
-- Missing `custom` expression preset enum (easy fix)
 - No runtime export (feature gap)
 - Less comprehensive VRM 0.x migration than UniVRM
 

--- a/docs/VRM_SPEC_VERIFICATION.md
+++ b/docs/VRM_SPEC_VERIFICATION.md
@@ -235,7 +235,8 @@ VRM 0.0 stores spring bone data in `secondaryAnimation` instead of the `VRMC_spr
 | Spec Property | Default | Implementation | Status |
 |---------------|---------|----------------|--------|
 | `transparentWithZWrite` | false | ✅ `MToonMaterialUniforms` | **PASS** |
-| `renderQueueOffsetNumber` | 0 | ⚠️ Not yet implemented | **PENDING** |
+| `renderQueueOffsetNumber` | 0 | ✅ `VRMGeometry.swift:1218-1221` parses, base queue (OPAQUE=2000, MASK=2450, BLEND=3000) + offset stored in `renderQueueOffset`, used by `VRMRenderItemBuilder` for sorting | **PASS** |
+| `giEqualizationFactor` | 0.9 | ⚠️ Parsed; current shader is a non-spec lit/shade albedo mix instead of the spec's `lerp(rawGi(n), uniformedGi, factor)`. See `docs/MTOON_GI_SPEC.md` for the verbatim spec excerpt and the deviation rationale (no IBL/SH plumbing yet) | **NON-SPEC (DOCUMENTED)** |
 
 ### 5.3 Lighting Properties
 
@@ -377,9 +378,11 @@ VRM 0.0 stores spring bone data in `secondaryAnimation` instead of the `VRMC_spr
 
 | Feature | Specification | Priority | Notes |
 |---------|---------------|----------|-------|
-| `renderQueueOffsetNumber` | MToon | Low | Render ordering offset |
-| `lookAt` in VRMA | VRMC_vrm_animation | Medium | Eye gaze animation |
-| `VRMC_node_constraint` | VRM 1.0 | Low | Constraint system |
+| `lookAt` in VRMA (animation channels) | VRMC_vrm_animation | Medium | `VRMLookAtController` exists for runtime gaze targeting, but `VRMAnimationLoader` does not parse the lookAt channel. Tracking issue filed. |
+| `VRMC_node_constraint` aim + rotation | VRM 1.0 | Low | `roll` constraint (twist bones) is fully implemented; `aim` and `rotation` constraints are parsed but `solve()` no-ops both. Tracking issue filed. |
+| MToon `giEqualizationFactor` spec compliance | MToon 1.0 | Low (artistic mix proxy in place) | See `docs/MTOON_GI_SPEC.md`. Current shader is a non-spec lit/shade mix; spec implementation requires IBL/SH plumbing. |
+
+`renderQueueOffsetNumber` and the `custom` expression preset enum, formerly listed here, are implemented (see §5.2 / §3 respectively).
 
 ### 8.3 Conclusion
 


### PR DESCRIPTION
## Summary

Acts on a VRM 1.0 spec deviation audit. The audit identified three cosmetic doc errors plus three real gaps; this PR fixes the doc errors and files tracking issues for the real gaps.

## Cosmetic doc fixes (this PR)

| Site | Before | After |
|---|---|---|
| \`docs/VRM_SPEC_VERIFICATION.md\` §5.2 | \`renderQueueOffsetNumber\` marked PENDING | PASS with code reference (parsed at \`VRMGeometry.swift:1218-1221\`, routed through \`VRMRenderItemBuilder\`) |
| \`docs/VRM_SPEC_VERIFICATION.md\` §8.2 | Lists three pending items, two of which ship | Replaced with current real gaps: VRMA lookAt (#165), node constraints aim+rotation (#166), giEqualizationFactor IBL gap (already documented at \`docs/MTOON_GI_SPEC.md\`) |
| \`docs/COMPARISON_UNIVRM.md\` §2.2 / §6.1 / §7.1 / §7.4 | Claims \"missing \`custom\` enum case\" | Updated to ✅; \`case custom\` exists at \`VRMTypes.swift:152\` and is used throughout the expression system |
| \`Sources/VRMMetalKit/Core/VRMModel.swift:1006\` | TODO: \"populate bone parameters, rest lengths, and colliders\" | Forwarding comment pointing at \`SpringBoneComputeSystem.populateSpringBoneData(model:)\`, where the actual population happens |

Also adds a \`giEqualizationFactor\` row to §5.2 marked NON-SPEC (DOCUMENTED) cross-referencing \`docs/MTOON_GI_SPEC.md\` (the deviation rationale shipped in #160).

## Real gaps tracked elsewhere

- **#165** — VRMA \`lookAt\` animation channel parsing/playback (medium severity).
- **#166** — Node constraint \`aim\` + \`rotation\` solvers (low severity; \`roll\` is fully implemented).

## Audit corrections

The audit also flagged the stale TODO at \`VRMModel.swift:1006\` as PARTIAL implementation. On verification, the TODO is in dead code; the function correctly factors buffer allocation (here) from buffer population (in \`SpringBoneComputeSystem.populateSpringBoneData\`, called from the renderer after the compute system is created). No real gap; comment amended.

## Test plan

- [x] \`swift build\` clean — no source behavior change beyond a comment edit.
- [x] Filtered smoke test (\`VRMExtensionParserTests\`) passes.

## Notes

No follow-on work in this PR. Real gaps tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)