### PR TITLE
fix(renderer): bind identity joint matrices in rigid-skinned fallback (#161)

### DIFF
--- a/Sources/VRMMetalKit/Animation/VRMSkinning.swift
+++ b/Sources/VRMMetalKit/Animation/VRMSkinning.swift
@@ -24,6 +24,11 @@ import simd
 public class VRMSkinningSystem {
     private let device: MTLDevice
     public var jointMatricesBuffer: MTLBuffer?  // Made public for debugging/validation
+    /// Dedicated read-only buffer of identity matrices. Bound at the joint
+    /// matrices slot when the skinned pipeline draws a primitive whose owning
+    /// node has `skin == nil` (issue #161). Distinct from `jointMatricesBuffer`
+    /// so live updates cannot corrupt the identities.
+    public private(set) var identityJointMatricesBuffer: MTLBuffer?
     private var totalMatrixCount = 0
     private var lastUpdatedSkinIndex: Int? = nil  // Cache to avoid redundant updates
     private var debugFrameCount = 0
@@ -75,6 +80,22 @@ public class VRMSkinningSystem {
                 pointer[i] = float4x4(1)  // Identity matrix
             }
         }
+
+        allocateIdentityJointMatricesBuffer(matrixCount: paddedMatrixCount, matrixSize: matrixSize)
+    }
+
+    /// Allocate (once) the dedicated identity-matrix buffer used as the
+    /// rigid-fallback joint binding. Sized to match the live joint buffer's
+    /// padded matrix count so the shader can clamp/read any joint index safely.
+    private func allocateIdentityJointMatricesBuffer(matrixCount: Int, matrixSize: Int) {
+        guard identityJointMatricesBuffer == nil else { return }
+        let length = matrixCount * matrixSize
+        guard let buffer = device.makeBuffer(length: length, options: .storageModeShared) else { return }
+        let pointer = buffer.contents().bindMemory(to: float4x4.self, capacity: matrixCount)
+        for i in 0..<matrixCount {
+            pointer[i] = matrix_identity_float4x4
+        }
+        identityJointMatricesBuffer = buffer
     }
 
     public func updateJointMatrices(for skin: VRMSkin, skinIndex: Int) {

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -2410,11 +2410,16 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
                     vrmLog("[SKIN ERROR] Node '\(item.node.name ?? "unnamed")' has invalid skin index \(skinIndex) (max: \(model.skins.count - 1))")
                 }
             } else if hasSkinning {
-                // This node doesn't have a skin but we're in skinned pipeline
-                // This means it's a rigid mesh that should use the regular (non-skinned) pipeline
-                // For now, just pass identity matrices
+                // Rigid mesh in the skinned pipeline (node.skin == nil and the mesh
+                // doesn't carry usable JOINTS_0/WEIGHTS_0). Bind a dedicated
+                // identity-matrix buffer at the joint slot so this draw does NOT
+                // inherit whichever skin's joint palette was bound by the previous
+                // skinned draw (issue #161).
+                if let identityJoints = skinningSystem?.identityJointMatricesBuffer {
+                    encoderStateCache.setVertexBuffer(encoder, identityJoints, offset: 0, index: ResourceIndices.jointMatricesBuffer)
+                }
                 if frameCounter % 60 == 0 && primitive === item.mesh.primitives.first {
-                    vrmLog("[SKIN DEBUG] Node '\(item.node.name ?? "unnamed")' mesh \(item.meshIndex) has NO skin - using rigid transform")
+                    vrmLog("[SKIN DEBUG] Node '\(item.node.name ?? "unnamed")' mesh \(item.meshIndex) has NO skin - bound identity joint matrices")
                 }
             }
 

--- a/Tests/VRMMetalKitTests/SkinningIdentityFallbackTests.swift
+++ b/Tests/VRMMetalKitTests/SkinningIdentityFallbackTests.swift
@@ -1,0 +1,98 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+
+import XCTest
+import Metal
+import simd
+@testable import VRMMetalKit
+
+/// Tests for the rigid-fallback joint binding (#161).
+///
+/// When the renderer is using the skinned pipeline but encounters a node where
+/// `node.skin == nil`, it must bind a buffer of identity matrices at the joint
+/// matrices slot so the next draw does NOT inherit the previous draw's joint
+/// palette. Previously the `else if hasSkinning` branch logged "using rigid
+/// transform" but did not bind any joint buffer at all.
+final class SkinningIdentityFallbackTests: XCTestCase {
+
+    private var device: MTLDevice!
+
+    override func setUp() async throws {
+        device = MTLCreateSystemDefaultDevice()
+        guard device != nil else {
+            throw XCTSkip("Metal device not available")
+        }
+    }
+
+    /// The skinning system must expose an identity-matrix buffer suitable for
+    /// binding at `ResourceIndices.jointMatricesBuffer` when a skinned-pipeline
+    /// draw has no actual skin to use.
+    func testIdentityJointBufferExposedAfterSetup() {
+        let system = VRMSkinningSystem(device: device)
+        system.setupForSkins([])
+
+        guard let buffer = system.identityJointMatricesBuffer else {
+            return XCTFail("VRMSkinningSystem must expose an identity-matrix buffer for the rigid-fallback path")
+        }
+
+        // The buffer must be large enough to satisfy the same shader read pattern
+        // as the live joint buffer — at least 256 matrices (matches the existing
+        // padding floor in setupForSkins).
+        let stride = MemoryLayout<float4x4>.stride
+        XCTAssertGreaterThanOrEqual(buffer.length, 256 * stride,
+                                    "Identity joint buffer must hold at least 256 matrices to match shader clamp range")
+    }
+
+    /// Every matrix in the identity buffer must be the identity transform.
+    func testIdentityJointBufferContainsOnlyIdentities() {
+        let system = VRMSkinningSystem(device: device)
+        system.setupForSkins([])
+
+        guard let buffer = system.identityJointMatricesBuffer else {
+            return XCTFail("identityJointMatricesBuffer must be allocated even when no skins are present")
+        }
+
+        let count = buffer.length / MemoryLayout<float4x4>.stride
+        let ptr = buffer.contents().bindMemory(to: float4x4.self, capacity: count)
+        for i in 0..<count {
+            let m = ptr[i]
+            XCTAssertEqual(m, matrix_identity_float4x4,
+                           "Matrix \(i) of identity joint buffer is not identity: \(m)")
+        }
+    }
+
+    /// The accessor must be idempotent — calling it twice returns the same buffer
+    /// (no per-call allocation, no reset of contents).
+    func testIdentityJointBufferIsIdempotent() {
+        let system = VRMSkinningSystem(device: device)
+        system.setupForSkins([])
+
+        let first = system.identityJointMatricesBuffer
+        let second = system.identityJointMatricesBuffer
+        XCTAssertNotNil(first)
+        XCTAssertTrue(first === second,
+                      "identityJointMatricesBuffer must return the same MTLBuffer instance on repeated access")
+    }
+
+    /// The identity buffer must NOT alias the live joint buffer — otherwise an
+    /// updateJointMatrices call would overwrite the identities and reintroduce
+    /// the original bug.
+    func testIdentityJointBufferIsDistinctFromLiveJointBuffer() {
+        let system = VRMSkinningSystem(device: device)
+        system.setupForSkins([])
+
+        guard let identity = system.identityJointMatricesBuffer,
+              let live = system.getJointMatricesBuffer() else {
+            return XCTFail("Both buffers must be allocated after setupForSkins")
+        }
+        XCTAssertFalse(identity === live,
+                       "Identity buffer must be a separate allocation so live updates cannot corrupt it")
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes the latent stale-buffer bug from #161: skinned-pipeline draws of nodes where \`node.skin == nil\` no longer inherit the previous draw's joint palette.
- Adds a dedicated read-only \`identityJointMatricesBuffer\` to \`VRMSkinningSystem\`, distinct from the live \`jointMatricesBuffer\` so live updates cannot corrupt the identities.
- 1.0 RC blocker per milestone #1.

## Why

The bug, per #161:

> when a node is being rendered through the skinned pipeline (because the model has skinning) but the node itself has \`skin == nil\` and the primitive doesn't carry JOINTS_0/WEIGHTS_0 attributes, the code logs \"using rigid transform\" and falls through **without rebinding the joint-matrices vertex buffer**

The bundled fixture (\`AvatarSample_A\`) has every node referencing a skin, so the faulty branch never fires there. The bug surfaces on common content patterns: VRoid exports with floor accessories or hand-held props, head ornaments, hats, VRM 0.x outputs from older exporters that omit skin references on cosmetic meshes.

## Approach

Took option (A) from the issue's suggested fixes — \"bind a small buffer of identity matrices before the rigid draw\" — over option (B) (pipeline-switch mid-loop) because it's a smaller, lower-risk diff for an RC blocker. The identity buffer is sized to match the live joint buffer's padded matrix count (≥ 256 matrices) so the shader's clamp-to-255 read pattern is safe regardless of what joint indices the rigid mesh's vertex buffer happens to carry.

## Test plan

- [x] 4 new tests in \`SkinningIdentityFallbackTests\`: buffer existence, identity-only contents, accessor idempotence, distinct allocation from live buffer.
- [x] Full suite: 1,358 tests, 0 failures (\`swift test --parallel --num-workers 14 -j 16 --disable-sandbox\`).
- [ ] Smoke test against a VRM with mixed rigid+skinned meshes (e.g. an avatar with an unskinned hat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)