### PR TITLE
fix(model): make modelLocalBounds thread-safe and pre-compute at load (#153)

### DIFF
--- a/Sources/VRMMetalKit/Core/VRMModel.swift
+++ b/Sources/VRMMetalKit/Core/VRMModel.swift
@@ -173,13 +173,38 @@ public class VRMModel: @unchecked Sendable {
 
     // MARK: - Bounding Box Calculation
 
-    /// Cached union of all primitive local-space AABBs. Populated lazily on first
-    /// access from already-computed `VRMPrimitive.localMin/localMax`. Used by
-    /// the renderer for whole-model frustum culling without touching GPU buffers.
+    /// Union of all primitive local-space AABBs, computed from
+    /// `VRMPrimitive.localMin/localMax`. Used by the renderer for whole-model
+    /// frustum culling without touching GPU buffers.
+    ///
+    /// Populated lazily on first access, or eagerly via
+    /// `finalizeModelLocalBounds()` which `VRMModel.load(...)` calls once all
+    /// primitives are populated. Access is guarded by `_boundsLock` so reads
+    /// from any thread are safe (the model is `@unchecked Sendable`).
     private var _cachedLocalBounds: (min: SIMD3<Float>, max: SIMD3<Float>)?
+    private let _boundsLock = NSLock()
 
     public var modelLocalBounds: (min: SIMD3<Float>, max: SIMD3<Float>) {
+        _boundsLock.lock()
+        defer { _boundsLock.unlock() }
         if let b = _cachedLocalBounds { return b }
+        let bounds = computeModelLocalBoundsLocked()
+        _cachedLocalBounds = bounds
+        return bounds
+    }
+
+    /// Eagerly computes and caches `modelLocalBounds`. Call this once after
+    /// the model's meshes are populated (e.g. at the end of `load(...)`) so
+    /// subsequent concurrent reads from any thread hit the cached value
+    /// without contending on the lazy-compute path.
+    public func finalizeModelLocalBounds() {
+        _boundsLock.lock()
+        defer { _boundsLock.unlock() }
+        _cachedLocalBounds = computeModelLocalBoundsLocked()
+    }
+
+    /// Caller must hold `_boundsLock`.
+    private func computeModelLocalBoundsLocked() -> (min: SIMD3<Float>, max: SIMD3<Float>) {
         var lo = SIMD3<Float>(repeating: Float.infinity)
         var hi = SIMD3<Float>(repeating: -Float.infinity)
         var found = false
@@ -194,9 +219,7 @@ public class VRMModel: @unchecked Sendable {
             lo = SIMD3<Float>(-0.5, 0, -0.5)
             hi = SIMD3<Float>(0.5, 1.8, 0.5)
         }
-        let bounds = (min: lo, max: hi)
-        _cachedLocalBounds = bounds
-        return bounds
+        return (min: lo, max: hi)
     }
 
     /// Whole-model frustum cull. Returns `true` when the model's bind-pose
@@ -494,7 +517,11 @@ public class VRMModel: @unchecked Sendable {
             try model.initializeSpringBoneGPUSystem(device: device)
             await context?.updatePhase(.initializingPhysics, progress: 1.0)
         }
-        
+
+        // All meshes/primitives are now populated; pre-compute the model AABB so
+        // subsequent reads from any thread hit the cached value (#153).
+        model.finalizeModelLocalBounds()
+
         await context?.updatePhase(.complete, progress: 1.0)
 
         return model

--- a/Tests/VRMMetalKitTests/ModelLocalBoundsThreadSafetyTests.swift
+++ b/Tests/VRMMetalKitTests/ModelLocalBoundsThreadSafetyTests.swift
@@ -1,0 +1,114 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+
+import XCTest
+import simd
+@testable import VRMMetalKit
+
+/// Tests for `VRMModel.modelLocalBounds` thread safety + eager-compute (#153).
+///
+/// `VRMModel` is `@unchecked Sendable`, so its public read-only properties must
+/// be safe to access concurrently from any thread. Previously
+/// `modelLocalBounds` was a lazy read-modify-write of `_cachedLocalBounds`
+/// without synchronization — racy by construction.
+final class ModelLocalBoundsThreadSafetyTests: XCTestCase {
+
+    private func makeMinimalGLTF() -> GLTFDocument {
+        let json: [String: Any] = [
+            "asset": ["version": "2.0", "generator": "Test"]
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return try! JSONDecoder().decode(GLTFDocument.self, from: data)
+    }
+
+    /// Build a minimal model with a single mesh + primitive at known extents.
+    private func makeFixtureModel(min: SIMD3<Float>, max: SIMD3<Float>) -> VRMModel {
+        let model = VRMModel(
+            specVersion: .v1_0,
+            meta: VRMMeta(licenseUrl: ""),
+            humanoid: nil,
+            gltf: makeMinimalGLTF()
+        )
+        let primitive = VRMPrimitive()
+        primitive.vertexCount = 8
+        primitive.localMin = min
+        primitive.localMax = max
+        let mesh = VRMMesh(name: "fixture")
+        mesh.primitives = [primitive]
+        model.meshes = [mesh]
+        return model
+    }
+
+    /// 1,000 concurrent reads of `modelLocalBounds` must all observe the same
+    /// value. Under the previous racy implementation, multiple threads could
+    /// each enter the lazy-compute path and race on the optional write.
+    func testConcurrentReadsAreConsistent() {
+        let lo = SIMD3<Float>(-1, -2, -3)
+        let hi = SIMD3<Float>( 4,  5,  6)
+        let model = makeFixtureModel(min: lo, max: hi)
+
+        let iterations = 1000
+        let mins = UnsafeMutableBufferPointer<SIMD3<Float>>.allocate(capacity: iterations)
+        let maxs = UnsafeMutableBufferPointer<SIMD3<Float>>.allocate(capacity: iterations)
+        defer { mins.deallocate(); maxs.deallocate() }
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            let b = model.modelLocalBounds
+            mins[i] = b.min
+            maxs[i] = b.max
+        }
+
+        for i in 0..<iterations {
+            XCTAssertEqual(mins[i], lo, "concurrent read #\(i) saw inconsistent min")
+            XCTAssertEqual(maxs[i], hi, "concurrent read #\(i) saw inconsistent max")
+        }
+    }
+
+    /// After `finalizeModelLocalBounds()`, the bounds are precomputed and a
+    /// subsequent read does not enter the compute path. Validates the
+    /// "compute eagerly at end of load" design from the issue. Verified
+    /// behaviorally by mutating `meshes` *after* finalize and confirming the
+    /// returned bounds reflect the pre-finalize state.
+    func testFinalizePrecomputesBounds() {
+        let lo = SIMD3<Float>(-1, -1, -1)
+        let hi = SIMD3<Float>( 1,  1,  1)
+        let model = makeFixtureModel(min: lo, max: hi)
+
+        model.finalizeModelLocalBounds()
+
+        // After finalize, mutating meshes should NOT change the returned
+        // bounds — they are frozen at finalize time.
+        let mutatedPrimitive = VRMPrimitive()
+        mutatedPrimitive.vertexCount = 8
+        mutatedPrimitive.localMin = SIMD3<Float>(-100, -100, -100)
+        mutatedPrimitive.localMax = SIMD3<Float>( 100,  100,  100)
+        let mutatedMesh = VRMMesh(name: "mutated")
+        mutatedMesh.primitives = [mutatedPrimitive]
+        model.meshes.append(mutatedMesh)
+
+        let b = model.modelLocalBounds
+        XCTAssertEqual(b.min, lo, "finalize must freeze bounds; post-mutation read should ignore later meshes")
+        XCTAssertEqual(b.max, hi, "finalize must freeze bounds; post-mutation read should ignore later meshes")
+    }
+
+    /// Repeated reads return the same tuple (no recompute, no jitter).
+    func testRepeatedReadsReturnIdenticalBounds() {
+        let lo = SIMD3<Float>(0, 0, 0)
+        let hi = SIMD3<Float>(2, 3, 4)
+        let model = makeFixtureModel(min: lo, max: hi)
+
+        let first = model.modelLocalBounds
+        for _ in 0..<10 {
+            let next = model.modelLocalBounds
+            XCTAssertEqual(next.min, first.min)
+            XCTAssertEqual(next.max, first.max)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #153 by combining options 1 + 2 from the issue: lock-guarded lazy compute *plus* eager pre-computation at the end of \`VRMModel.load(...)\`.
- 1.0 RC blocker per milestone #1.

## Why

\`VRMModel\` is declared \`@unchecked Sendable\`, but \`modelLocalBounds\` was a lazy read-modify-write of \`_cachedLocalBounds\` with no synchronization. Any background-thread access (spatial broadphase, debug tooling, parallel cull pass) racing against the first foreground access could:

- Tear the optional read.
- Have multiple threads each enter the compute path and write the cache.
- TSan would (correctly) flag this as a data race on the optional storage.

## Approach

Combined two fixes from the issue rather than either alone:

1. **NSLock around the lazy compute** — strict correctness even if a caller mutates \`meshes\` and a finalize step has not yet run.
2. **Eager finalize at end of \`load(...)\`** — primitives' \`localMin/localMax\` are populated by the time \`loadResources\` returns, so we can pre-warm the cache and turn all subsequent reads into uncontended fast-path returns.

A future follow-up could go further (\`let meshes\` to enforce immutability), but that's a structural change beyond this RC blocker.

## API change

Adds one public method:

\`\`\`swift
extension VRMModel {
    /// Eagerly compute and cache \`modelLocalBounds\`. Called automatically by
    /// \`load(...)\` once meshes are populated.
    public func finalizeModelLocalBounds()
}
\`\`\`

Test helpers and other code paths that construct \`VRMModel\` outside \`load()\` can call this explicitly. Existing call sites are unchanged — \`modelLocalBounds\` still works as a computed property.

## Test plan

- [x] 3 new tests in \`ModelLocalBoundsThreadSafetyTests\`:
  - \`testConcurrentReadsAreConsistent\` — 1,000 concurrent reads, all observe the same bounds.
  - \`testFinalizePrecomputesBounds\` — after \`finalizeModelLocalBounds()\`, mutating meshes does not change the returned bounds (cache is frozen at finalize time).
  - \`testRepeatedReadsReturnIdenticalBounds\` — repeated reads return the same tuple.
- [x] Full suite: 1,357 tests, 0 failures (\`swift test --parallel --num-workers 14 -j 16 --disable-sandbox\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)