### PR TITLE
test(zfighting): tighten collar/neck threshold to enforce #109 target

### DIFF
--- a/Tests/VRMMetalKitTests/ZFightingRegressionTests.swift
+++ b/Tests/VRMMetalKitTests/ZFightingRegressionTests.swift
@@ -156,13 +156,23 @@ final class ZFightingRegressionTests: XCTestCase {
 
     // MARK: - Neck/Collar Tests
 
-    /// Regression test: Collar/Neck area Z-fighting
+    /// Regression test: Collar/Neck area Z-fighting (issue #109).
+    ///
+    /// At issue-filing the collar/neck region exhibited 13.45% flicker — the
+    /// worst region in the cluster. PR #113 (depth-bias mitigation) and
+    /// subsequent renderer work brought it under the issue's 3% target;
+    /// AvatarSample_A_1.0 currently produces a deterministic 2.69% (verified
+    /// byte-identical across 5 back-to-back runs).
+    ///
+    /// Threshold is set to the issue's stated 3% target — any future regression
+    /// above that will fail the test, signaling that something has reintroduced
+    /// the pre-#113 behavior on this region.
     func testCollarNeckZFighting() async throws {
         let model = try await loadAvatarSampleA()
         helper.loadModel(model)
 
-        // Use higher threshold for collar/neck (known high-artifact region: ~17%)
-        let threshold: Float = 20.0
+        // Issue #109 target: ≤ 3.0% flicker rate.
+        let threshold: Float = 3.0
 
         helper.setViewMatrix(makeLookAt(
             eye: SIMD3<Float>(0, 1.35, 0.4),
@@ -182,7 +192,7 @@ final class ZFightingRegressionTests: XCTestCase {
         XCTAssertLessThan(
             result.flickerRate,
             threshold,
-            "REGRESSION: Collar/Neck Z-fighting (\(result.flickerRate)%) exceeds model-specific threshold (\(threshold)%)"
+            "REGRESSION: Collar/Neck Z-fighting (\(result.flickerRate)%) exceeds the #109 target (\(threshold)%). Pre-#113 behavior was 13.45%."
         )
     }
 


### PR DESCRIPTION
## Summary

Closes #109 — but not by fixing anything. The collar/neck z-fighting was already resolved by PR #113 + subsequent renderer work; the issue had been silently met. This PR makes that visible by tightening the test threshold from 20% (loose) to 3% (the issue's stated target), converting it into a real regression gate.

## Why this works

- Issue #109 filing: collar/neck = 13.45% flicker, target ≤ 3%.
- After PR #113 (depth-bias mitigation) + later renderer work: 2.69%.
- Verified byte-identical (\`2.6916504%\`) across 5 back-to-back runs on Apple Silicon.

The test's threshold was 20% — "loose enough to pass" rather than "enforce the goal". So #109 was technically green but the gate didn't actually defend the spec. Now it does.

## What's NOT in scope

The other z-fighting cluster issues (#107 tracker, #108 face, #110 hip/skirt) are NOT closed by this PR. Their actual rates have improved but are still above the original aspirational targets:

| Region | Issue claimed | Now | #107 target |
|---|---|---|---|
| Face Front | 9.29% | 6.69% | 2% (still over) |
| Face Side | 9.41% | 6.64% | 2% (still over) |
| **Collar/Neck** | **13.45%** | **2.69%** | **3% ✓ (this PR)** |
| Eye Detail | 5.30% | 0.33% | 2% ✓ |
| Hip/Skirt | 9.48% | 7.81% | 2% (still over) |

Eye Detail also passes its target now and could be closed, but it's part of #108 and addressing that issue cleanly needs deciding whether to lower the face-region targets (currently 2%) or do further work on Face Front/Side. That's a separate PR.

## Test plan

- [x] \`swift test --filter testCollarNeckZFighting --disable-sandbox\` — passes at 3% threshold.
- [x] 5 back-to-back runs all produce identical \`2.6916504%\` — fully deterministic.
- [x] Full \`ZFightingRegressionTests\` suite still passes (\`swift test --filter ZFightingRegressionTests --disable-sandbox\`).
- [x] Production code unchanged; this is a test-only adjustment.

## Files

- \`Tests/VRMMetalKitTests/ZFightingRegressionTests.swift\` — \`testCollarNeckZFighting\` threshold 20.0 → 3.0; doc comment updated to record the resolution path.

## Related

- Closes #109
- Refs #107 (tracker — partial progress on the cluster)
- Milestone #1 (1.0 RC blockers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)