### PR TITLE
ci(codeql): skip Analyze (swift) on pull_request events

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -39,6 +39,13 @@ jobs:
 
   swift:
     name: Analyze (swift)
+    # CodeQL Swift extraction takes ~20 min and has produced 0 findings against
+    # this codebase (a Metal rendering library — outside the query pack's
+    # web/mobile threat model). Run only on push to `main` and the weekly cron
+    # so security-event archaeology is preserved without blocking PR merges
+    # for 20 min after every push. Anything CodeQL would have caught at PR
+    # review surfaces at merge — within the same human's session.
+    if: github.event_name != 'pull_request'
     runs-on: macos-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
## Summary

Drops the \`pull_request\` trigger from the \`Analyze (swift)\` CodeQL job so it no longer runs on every PR push. Keeps the existing \`push: main\` and weekly cron triggers intact.

## Why

| Metric | Value |
|---|---|
| Average run time | ~19–22 min |
| Today's runs | 9 (≈ 3 h CI compute) |
| Per-PR merge-block | ~19 min after every push |
| Swift findings ever | **0** |
| All CodeQL findings ever | 2, both from \`Analyze (actions)\` (already fixed) |

The Swift CodeQL query pack targets web/mobile threat models — untrusted input, auth, network handlers, SQL, URL parsing, predictable RNG. VRMMetalKit is a Metal rendering library that processes \`.vrm\`/\`.glb\` files locally; almost none of the query bundle applies. The most relevant query class (file-parser robustness) isn't covered by CodeQL Swift.

## What changes

- \`Analyze (swift)\` runs on push-to-main and the Monday cron. Stops running on PR open/sync.
- \`Analyze (actions)\` is **unchanged** — it's a 3-second job and has caught real workflow-permission findings (alerts #1, #2, both already fixed).
- No change to the security event store; the post-merge run picks up everything the PR run would have covered, within ~20 min of the same human reviewer's session.

## Implementation

One-line job-level conditional: \`if: github.event_name != 'pull_request'\`. The trigger config (\`on:\`) is untouched so the \`actions\` job still fires on PRs.

## Test plan

- [x] Workflow syntax is valid (job-level \`if:\` is a documented field).
- [ ] After merge, verify next PR's checks list does NOT include \`Analyze (swift)\`.
- [ ] After next push to \`main\`, verify \`Analyze (swift)\` does still run.

## Related

- Reduces CI cost on every open PR (incl. milestone #1 work in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)