### PR TITLE
ci(shaders): add Metal compile gate (#171)

### DIFF
--- a/.github/workflows/shaders.yaml
+++ b/.github/workflows/shaders.yaml
@@ -1,0 +1,61 @@
+name: Shaders
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  metal:
+    name: Compile + freshness check
+    runs-on: macos-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Probe runner toolchains
+        run: |
+          echo "::group::Installed Xcode versions"
+          ls /Applications | grep -i Xcode || true
+          echo "::endgroup::"
+          xcrun metal --version || true
+
+      - name: Select Xcode with Metal compiler
+        run: |
+          # Metal compiler ships with every Xcode; pick the same one the
+          # rest of the build uses (Xcode 26+ for Swift 6.2).
+          XCODE=$(ls -d /Applications/Xcode_26* /Applications/Xcode_27* 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE" ]; then
+            echo "::error::No Xcode 26 (or newer) found"
+            ls /Applications | grep -i Xcode || true
+            exit 1
+          fi
+          sudo xcode-select -s "$XCODE/Contents/Developer"
+
+      - name: Compile Metal shaders
+        # `make shaders` compiles each .metal file with `xcrun metal -c`
+        # and packs them into the metallib. Any compile error fails this
+        # step (warnings are not errors today; see #171 follow-up).
+        run: make shaders
+
+      - name: Verify committed metallib is fresh
+        # Metal compilation is byte-deterministic on identical Xcode
+        # versions, so a non-empty diff means the committed metallib
+        # is out-of-date relative to the .metal sources. Fail with a
+        # clear remediation hint.
+        run: |
+          if ! git diff --quiet Sources/VRMMetalKit/Resources/VRMMetalKitShaders.metallib; then
+            echo "::error::Committed VRMMetalKitShaders.metallib is stale relative to .metal sources."
+            echo ""
+            echo "Run 'make shaders' locally and commit the updated metallib."
+            echo "Diff summary:"
+            git diff --stat Sources/VRMMetalKit/Resources/VRMMetalKitShaders.metallib
+            exit 1
+          fi
+          echo "Committed metallib matches a fresh compile."

--- a/.github/workflows/shaders.yaml
+++ b/.github/workflows/shaders.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   metal:
-    name: Compile + freshness check
+    name: Compile
     runs-on: macos-latest
     timeout-minutes: 15
 
@@ -42,20 +42,12 @@ jobs:
         # `make shaders` compiles each .metal file with `xcrun metal -c`
         # and packs them into the metallib. Any compile error fails this
         # step (warnings are not errors today; see #171 follow-up).
+        #
+        # Freshness note: Metal compilation is byte-deterministic only
+        # for identical Xcode/Metal compiler versions. A byte-equality
+        # check against the committed metallib false-positives whenever
+        # local vs. CI Xcode differ (observed: 240164 vs 240196 bytes
+        # for the same sources). Real freshness needs a content-
+        # equivalence check via `xcrun metal-objdump` function-list
+        # comparison — tracked separately as a #171 follow-up.
         run: make shaders
-
-      - name: Verify committed metallib is fresh
-        # Metal compilation is byte-deterministic on identical Xcode
-        # versions, so a non-empty diff means the committed metallib
-        # is out-of-date relative to the .metal sources. Fail with a
-        # clear remediation hint.
-        run: |
-          if ! git diff --quiet Sources/VRMMetalKit/Resources/VRMMetalKitShaders.metallib; then
-            echo "::error::Committed VRMMetalKitShaders.metallib is stale relative to .metal sources."
-            echo ""
-            echo "Run 'make shaders' locally and commit the updated metallib."
-            echo "Diff summary:"
-            git diff --stat Sources/VRMMetalKit/Resources/VRMMetalKitShaders.metallib
-            exit 1
-          fi
-          echo "Committed metallib matches a fresh compile."


### PR DESCRIPTION
## Summary

Closes #171 by adding a \`Shaders\` CI workflow that compiles every \`.metal\` source on every PR + push to \`main\`. Any \`xcrun metal\` compile error now fails CI immediately, instead of being hidden behind the prebuilt metallib.

## Why now

Per #171, the security/quality posture had a real gap:

- CodeQL Swift extractor doesn't see \`.metal\` files.
- \`swift build\` deliberately excludes shaders.
- Net: zero static analysis or build gate on the shader sources.

That gap has already produced real bugs — #122 (MToon Block 12 layout mismatch) is the textbook case. The review of PR #168 surfaced the same class (m4: duplicated MToon material size constant). This gate doesn't catch every layout-equivalence issue, but it catches *every* Metal compile error, which is the cheap, high-value 80%.

## Implementation

| Aspect | Choice |
|---|---|
| Runner | \`macos-latest\` (Metal compiler is macOS-only) |
| Xcode | \`Xcode_26*\` / \`Xcode_27*\`, matching the CodeQL Swift job pattern |
| Tooling | \`make shaders\` (existing target) |
| Triggers | PR + push to main |

Expected runtime: ~1 min.

## What was dropped (and why)

The first version (commit \`5821d96\`) included a metallib freshness check via \`git diff --quiet\`. CI run showed this false-positives across Xcode/Metal compiler versions — local builds produced 240164 bytes, the runner produced 240196 bytes for the same sources. Metal compilation is byte-deterministic only on identical compiler versions. Real freshness detection needs content-equivalence (function-list + signatures via \`xcrun metal-objdump\`), filed as a #171 follow-up.

Compile gate alone is still the high-value win.

## Out of scope (deferred per #171)

- **Content-equivalence freshness check:** Tracked as a follow-up to this PR.
- **Approach B (clang-tidy on .metal):** Noisy without curated check list; deferred.
- **Approach C (runtime struct-layout tests):** Higher value, needs design alongside #121 (shared shader header extraction); deferred.
- **\`-Werror\`:** Two benign existing warnings (\`unused function animateUV\`; \`morphedPositions\` aliasing) would block this PR; cleaning those is separate work.

## Test plan

- [x] Local \`make shaders\` succeeds (1 file shows benign warnings; none are errors).
- [x] CI run on this PR exercises the compile step — first attempt's compile step passed, only the dropped freshness check failed.

## Related

- Closes #171
- Refs #121 (root-cause mitigation — shared shader header)
- Refs #122 (a concrete past instance of the bug class this gate guards against)

🤖 Generated with [Claude Code](https://claude.com/claude-code)