### PR TITLE
feat(animation): wire VRMA lookAt sampler into AnimationPlayer (#165)

### DIFF
--- a/Sources/VRMMetalKit/Animation/AnimationPlayer.swift
+++ b/Sources/VRMMetalKit/Animation/AnimationPlayer.swift
@@ -48,6 +48,13 @@ public final class AnimationPlayer: @unchecked Sendable {
     public var isLooping = true
     public var applyRootMotion = false
 
+    /// Optional controller driven by the loaded clip's `lookAtTargetSampler`.
+    /// When both are non-nil, each `update(deltaTime:model:)` call sets
+    /// `controller.target = .point(sampler(currentTime))` so VRMA-authored
+    /// look-at data drives the eyes end-to-end. Held weakly to avoid a
+    /// retain cycle if the controller's owner also holds the player.
+    public weak var lookAtController: VRMLookAtController?
+
     private var currentTime: Float = 0
     private var clip: AnimationClip?
     private var isPlaying = false
@@ -172,7 +179,16 @@ public final class AnimationPlayer: @unchecked Sendable {
                 }
             }
 
-            // 4. Propagate world transforms once so aim/rotation constraints see this
+            // 4. VRMA-driven lookAt: if a controller is attached and the clip
+            //    has a lookAtTargetSampler (VRMC_vrm_animation §lookAt), set
+            //    the controller's target to the sampled world position.
+            //    Skipped when sampler is nil so user-set targets (.camera /
+            //    .user / .forward) are preserved.
+            if let controller = lookAtController, let sampler = clip.lookAtTargetSampler {
+                controller.target = .point(sampler(localTime))
+            }
+
+            // 5. Propagate world transforms once so aim/rotation constraints see this
             //    frame's animated source-node poses, not last frame's stale world matrices.
             model.updateNodeTransforms()
 
@@ -202,6 +218,14 @@ public final class AnimationPlayer: @unchecked Sendable {
                 controller.setCustomExpressionWeight(key, weight: weight)
             }
         }
+    }
+
+    /// Current playback time in seconds. Reflects accumulated `deltaTime` from
+    /// `update(deltaTime:model:)` and is reset by `seek(to:)` / `stop()` /
+    /// `load(_:)`. Useful when consumers want to drive their own samplers
+    /// alongside the player.
+    public var time: Float {
+        playerLock.withLock { currentTime }
     }
 
     public var progress: Float {

--- a/Tests/VRMMetalKitTests/VRMALookAtIntegrationTests.swift
+++ b/Tests/VRMMetalKitTests/VRMALookAtIntegrationTests.swift
@@ -1,0 +1,122 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+
+import XCTest
+import simd
+@testable import VRMMetalKit
+
+/// Tests for VRMA `lookAt` channel → `VRMLookAtController` integration (#165 / m10).
+///
+/// PR #168 (B1) parses `lookAt` from VRMA and exposes
+/// `AnimationClip.lookAtTargetSampler`. This file verifies that the data is
+/// actually consumed by the renderer's look-at pipeline when a player runs
+/// the clip — closing the end-to-end loop.
+final class VRMALookAtIntegrationTests: XCTestCase {
+
+    private func makeMinimalGLTF() -> GLTFDocument {
+        let json: [String: Any] = ["asset": ["version": "2.0", "generator": "Test"]]
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return try! JSONDecoder().decode(GLTFDocument.self, from: data)
+    }
+
+    private func makeFixtureModel() -> VRMModel {
+        let model = VRMModel(
+            specVersion: .v1_0,
+            meta: VRMMeta(licenseUrl: ""),
+            humanoid: nil,
+            gltf: makeMinimalGLTF()
+        )
+        return model
+    }
+
+    /// Player attached to a controller drives `target = .point(sampler(t))` when
+    /// the clip carries a `lookAtTargetSampler`.
+    func testPlayerDrivesLookAtControllerFromVRMASampler() {
+        let model = makeFixtureModel()
+        let controller = VRMLookAtController()
+
+        var clip = AnimationClip(duration: 1.0)
+        // Sampler maps t → (10t, 5t, 2t). At t=0.25 → (2.5, 1.25, 0.5).
+        clip.lookAtTargetSampler = { t in
+            SIMD3<Float>(10 * t, 5 * t, 2 * t)
+        }
+
+        let player = AnimationPlayer()
+        player.lookAtController = controller
+        player.load(clip)
+        player.play()
+
+        player.update(deltaTime: 0.25, model: model)
+
+        guard case .point(let pos) = controller.target else {
+            return XCTFail("Expected controller.target to be .point after VRMA-driven update; got \(controller.target)")
+        }
+        XCTAssertEqual(pos.x, 2.5, accuracy: 1e-5)
+        XCTAssertEqual(pos.y, 1.25, accuracy: 1e-5)
+        XCTAssertEqual(pos.z, 0.5, accuracy: 1e-5)
+    }
+
+    /// When `clip.lookAtTargetSampler` is nil, the player must not touch
+    /// `controller.target` — preserving any user-set target (camera/user/forward).
+    func testPlayerLeavesControllerTargetAloneWhenSamplerAbsent() {
+        let model = makeFixtureModel()
+        let controller = VRMLookAtController()
+        controller.target = .camera
+
+        let clip = AnimationClip(duration: 1.0) // no lookAtTargetSampler
+
+        let player = AnimationPlayer()
+        player.lookAtController = controller
+        player.load(clip)
+        player.play()
+
+        player.update(deltaTime: 0.1, model: model)
+
+        guard case .camera = controller.target else {
+            return XCTFail("Player must not overwrite controller.target when clip has no lookAt sampler; got \(controller.target)")
+        }
+    }
+
+    /// When `player.lookAtController` is nil, having a sampler on the clip is
+    /// inert — no crash, no observable effect on any controller.
+    func testNoControllerNoIntegration() {
+        let model = makeFixtureModel()
+
+        var clip = AnimationClip(duration: 1.0)
+        clip.lookAtTargetSampler = { _ in SIMD3<Float>(1, 2, 3) }
+
+        let player = AnimationPlayer()
+        player.load(clip)
+        player.play()
+
+        // Must not crash.
+        player.update(deltaTime: 0.5, model: model)
+    }
+
+    /// `AnimationPlayer.time` must expose the internal `currentTime` so consumers
+    /// who want to drive the controller manually (e.g. via a different sampler)
+    /// can read where playback currently sits.
+    func testPlayerExposesCurrentTime() {
+        let model = makeFixtureModel()
+        let clip = AnimationClip(duration: 10.0)
+
+        let player = AnimationPlayer()
+        player.load(clip)
+        player.play()
+
+        XCTAssertEqual(player.time, 0, accuracy: 1e-6, "newly-loaded player must report time = 0")
+
+        player.update(deltaTime: 0.42, model: model)
+        XCTAssertEqual(player.time, 0.42, accuracy: 1e-6, "player.time must reflect accumulated deltaTime")
+
+        player.seek(to: 3.0)
+        XCTAssertEqual(player.time, 3.0, accuracy: 1e-6, "player.time must reflect seek")
+    }
+}


### PR DESCRIPTION
## Summary

Closes #165 (m10 follow-up to PR #168 B1). PR #168 parsed \`VRMC_vrm_animation §lookAt\` into \`AnimationClip.lookAtTargetSampler\` but nothing consumed it — eyes did not follow VRMA-authored gaze data. This closes the loop.

## API

\`\`\`swift
extension AnimationPlayer {
    /// Optional controller driven by the loaded clip's lookAtTargetSampler.
    /// Held weakly to avoid retain cycles.
    public weak var lookAtController: VRMLookAtController?

    /// Current playback time in seconds.
    public var time: Float { get }
}
\`\`\`

## Behavior

When **both** are set:

- \`player.lookAtController\` (non-nil)
- \`clip.lookAtTargetSampler\` (non-nil)

each \`update(deltaTime:model:)\` writes \`controller.target = .point(sampler(localTime))\`. The clip's loop-respecting local time is used so VRMA gaze data loops cleanly with the rest of the animation.

When the sampler is nil, the player **leaves \`controller.target\` alone**. Any user-set target (\`.camera\` / \`.user\` / \`.forward\` / explicit \`.point\`) is preserved.

## Usage

\`\`\`swift
let model = try await VRMModel.load(...)
let renderer = VRMRenderer(...)
renderer.loadModel(model)

let clip = try VRMAnimationLoader.loadVRMA(...)
let player = AnimationPlayer()
player.lookAtController = renderer.lookAtController  // <-- new
player.load(clip)
player.play()

// Render loop:
player.update(deltaTime: dt, model: model)  // now drives lookAt automatically
renderer.draw(...)
\`\`\`

## Test plan

- [x] 4 new tests in \`VRMALookAtIntegrationTests\`:
  - \`testPlayerDrivesLookAtControllerFromVRMASampler\` — sampler output reaches \`controller.target\` exactly.
  - \`testPlayerLeavesControllerTargetAloneWhenSamplerAbsent\` — preserves user-set \`.camera\` target.
  - \`testNoControllerNoIntegration\` — no crash when controller is unset and sampler is set.
  - \`testPlayerExposesCurrentTime\` — \`player.time\` reflects update + seek.
- [x] Full suite: 1,366 tests + 4 new = 1,370, exit 0 (\`swift test --parallel --num-workers 14 -j 16 --disable-sandbox\`).

## Why \`weak\`

The renderer typically holds the controller; the same caller usually also holds the player. A strong reference would create a cycle if the player ever outlived the controller's owner. \`weak\` makes the integration safe by default.

## Related

- Closes #165
- Refs PR #168 (B1 / m10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)