### PR TITLE
fix(loader,animation): GLTFParser BIN-chunk leak (#189) + VRMA lookAt head-local space (#190)

### DIFF
--- a/Sources/VRMMetalKit/Animation/AnimationPlayer.swift
+++ b/Sources/VRMMetalKit/Animation/AnimationPlayer.swift
@@ -48,12 +48,11 @@ import simd
 /// 3. Caches morph weights for the next ``applyMorphWeights(to:)`` call.
 /// 4. When ``lookAtController`` is attached and the clip carries a
 ///    `lookAtTargetSampler` (VRMC_vrm_animation §lookAt), look-at target
-///    tracks are applied by setting `controller.target = .point(sampler(time))`.
-///    The sampler value is forwarded verbatim; per the VRMC_vrm_animation-1.0
-///    spec, this value is in head-bone-local coordinates. (Note: there is a
-///    possible latent inconsistency with ``VRMLookAtController``'s
-///    interpretation of `.point` as world-space — tracked separately for
-///    code-level audit.)
+///    tracks are applied by setting
+///    `controller.target = .headLocalPoint(sampler(time))`. The sampler value
+///    is in head-bone-local coordinates per the VRMC_vrm_animation-1.0 spec;
+///    ``VRMLookAtController`` resolves the value through the head bone's
+///    world transform at update time.
 /// 5. Propagates world transforms, then runs the ``ConstraintSolver`` on any
 ///    `VRMNodeConstraint`s the model carries and propagates again so
 ///    descendants see constraint output.
@@ -103,8 +102,9 @@ public final class AnimationPlayer: @unchecked Sendable {
 
     /// Optional controller driven by the loaded clip's `lookAtTargetSampler`.
     /// When both are non-nil, each `update(deltaTime:model:)` call sets
-    /// `controller.target = .point(sampler(currentTime))` so VRMA-authored
-    /// look-at data drives the eyes end-to-end. Held weakly to avoid a
+    /// `controller.target = .headLocalPoint(sampler(currentTime))` so VRMA-authored
+    /// look-at data drives the eyes end-to-end (sampler values are in head-bone
+    /// local space per the VRMC_vrm_animation-1.0 spec). Held weakly to avoid a
     /// retain cycle if the controller's owner also holds the player.
     public weak var lookAtController: VRMLookAtController?
 
@@ -254,11 +254,13 @@ public final class AnimationPlayer: @unchecked Sendable {
 
             // 4. VRMA-driven lookAt: if a controller is attached and the clip
             //    has a lookAtTargetSampler (VRMC_vrm_animation §lookAt), set
-            //    the controller's target to the sampled world position.
+            //    the controller's target. The sampler value is head-bone-local
+            //    per the spec, so route through .headLocalPoint and let the
+            //    controller compose with the head world transform at apply time.
             //    Skipped when sampler is nil so user-set targets (.camera /
             //    .user / .forward) are preserved.
             if let controller = lookAtController, let sampler = clip.lookAtTargetSampler {
-                controller.target = .point(sampler(localTime))
+                controller.target = .headLocalPoint(sampler(localTime))
             }
 
             // 5. Propagate world transforms once so aim/rotation constraints see this

--- a/Sources/VRMMetalKit/Animation/VRMLookAtController.swift
+++ b/Sources/VRMMetalKit/Animation/VRMLookAtController.swift
@@ -361,7 +361,9 @@ public class VRMLookAtController {
                 let world = m * SIMD4<Float>(localPos, 1)
                 targetPos = SIMD3<Float>(world.x, world.y, world.z)
             } else {
-                // No head bone available — treat as model-space fallback.
+                // No head bone wired up — last-resort path: treat the payload
+                // as world-space so gaze still has a defined direction (though
+                // it will not track head motion).
                 targetPos = localPos
             }
         case .forward:

--- a/Sources/VRMMetalKit/Animation/VRMLookAtController.swift
+++ b/Sources/VRMMetalKit/Animation/VRMLookAtController.swift
@@ -28,6 +28,14 @@ public enum VRMLookAtTarget {
     case user
     /// Look at a specific world-space point.
     case point(SIMD3<Float>)
+    /// Look at a point expressed in the head bone's local space.
+    ///
+    /// This matches the coordinate space defined by the
+    /// [VRMC_vrm_animation-1.0 spec](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm_animation-1.0/README.md)
+    /// for `lookAt` tracks. The controller resolves it through the head bone's
+    /// world transform at each ``update(deltaTime:)`` call, so callers do not
+    /// need to recompose the value when the head moves.
+    case headLocalPoint(SIMD3<Float>)
     /// Look straight ahead along the rest pose forward direction (no gaze deviation).
     case forward
 }
@@ -318,26 +326,15 @@ public class VRMLookAtController {
     private func updateTargetAngles() {
         guard let model = model else { return }
 
-        // Get target position based on target type
-        let targetPos: SIMD3<Float>
-        switch target {
-        case .camera:
-            targetPos = cameraPosition
-        case .user:
-            targetPos = userPosition
-        case .point(let pos):
-            targetPos = pos
-        case .forward:
-            targetYaw = 0
-            targetPitch = 0
-            return
-        }
-
-        // Get eye position (approximate from head bone or model center)
+        // Resolve head-bone world transform once (used for both eye position and
+        // for head-local targets). Falls back to a default eye height when the
+        // model has no head bone wired up.
         var eyePosition = SIMD3<Float>(0, 1.5, 0) // Default eye height
+        var headWorldMatrix: simd_float4x4?
 
         if let headIndex = headBoneIndex, headIndex < model.nodes.count {
             let headNode = model.nodes[headIndex]
+            headWorldMatrix = headNode.worldMatrix
             eyePosition = SIMD3<Float>(
                 headNode.worldMatrix[3][0],
                 headNode.worldMatrix[3][1],
@@ -348,6 +345,29 @@ public class VRMLookAtController {
             if let lookAt = lookAtData {
                 eyePosition += lookAt.offsetFromHeadBone
             }
+        }
+
+        // Get target position based on target type
+        let targetPos: SIMD3<Float>
+        switch target {
+        case .camera:
+            targetPos = cameraPosition
+        case .user:
+            targetPos = userPosition
+        case .point(let pos):
+            targetPos = pos
+        case .headLocalPoint(let localPos):
+            if let m = headWorldMatrix {
+                let world = m * SIMD4<Float>(localPos, 1)
+                targetPos = SIMD3<Float>(world.x, world.y, world.z)
+            } else {
+                // No head bone available — treat as model-space fallback.
+                targetPos = localPos
+            }
+        case .forward:
+            targetYaw = 0
+            targetPitch = 0
+            return
         }
 
         // Calculate direction vector

--- a/Sources/VRMMetalKit/Loader/GLTFParser.swift
+++ b/Sources/VRMMetalKit/Loader/GLTFParser.swift
@@ -673,9 +673,9 @@ public class GLTFParser {
 
     /// Creates an empty parser.
     ///
-    /// Reuse with care: ``binaryChunk`` is not reset between calls, so always
-    /// use the binary data returned from the current call rather than reading
-    /// the property afterward.
+    /// Parser instances are safe to reuse across multiple ``parse(data:filePath:)``
+    /// invocations; ``binaryChunk`` is rewritten on every successful call (and is
+    /// `nil` when the input GLB has no BIN chunk).
     public init() {}
 
     /// Parses a GLB byte stream and returns the decoded document plus the optional binary chunk.
@@ -719,6 +719,7 @@ public class GLTFParser {
         // Parse chunks
         var offset = 12
         var jsonChunk: Data?
+        var parsedBinaryChunk: Data?
 
         while offset < data.count {
             // Ensure we have at least 8 bytes for chunk header
@@ -742,7 +743,7 @@ public class GLTFParser {
             if chunkType == 0x4E4F534A { // "JSON"
                 jsonChunk = chunkData
             } else if chunkType == 0x004E4942 { // "BIN\0"
-                binaryChunk = chunkData
+                parsedBinaryChunk = chunkData
             }
 
             offset += 8 + Int(chunkLength)
@@ -760,7 +761,8 @@ public class GLTFParser {
         let decoder = JSONDecoder()
         do {
             let document = try decoder.decode(GLTFDocument.self, from: jsonData)
-            return (document, self.binaryChunk)
+            self.binaryChunk = parsedBinaryChunk
+            return (document, parsedBinaryChunk)
         } catch {
             throw VRMError.invalidJSON(
                 context: "Failed to decode glTF JSON structure",

--- a/Sources/VRMMetalKit/Loader/GLTFParser.swift
+++ b/Sources/VRMMetalKit/Loader/GLTFParser.swift
@@ -675,7 +675,8 @@ public class GLTFParser {
     ///
     /// Parser instances are safe to reuse across multiple ``parse(data:filePath:)``
     /// invocations; ``binaryChunk`` is rewritten on every successful call (and is
-    /// `nil` when the input GLB has no BIN chunk).
+    /// `nil` when the input GLB has no BIN chunk). When a ``parse(data:filePath:)``
+    /// call throws, ``binaryChunk`` retains its previous value.
     public init() {}
 
     /// Parses a GLB byte stream and returns the decoded document plus the optional binary chunk.

--- a/Tests/VRMMetalKitTests/GLTFParserStateTests.swift
+++ b/Tests/VRMMetalKitTests/GLTFParserStateTests.swift
@@ -1,0 +1,86 @@
+//
+// Copyright 2026 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+@testable import VRMMetalKit
+
+/// Regression coverage for `GLTFParser` cross-call state. See issue #189: a parser
+/// instance reused for a second `parse(data:)` call must not surface the previous
+/// call's `BIN` chunk when the new input has none.
+final class GLTFParserStateTests: XCTestCase {
+
+    // Minimal glTF JSON that satisfies `GLTFDocument` decoding.
+    private static let minimalJSON: Data = {
+        let payload: [String: Any] = ["asset": ["version": "2.0", "generator": "test"]]
+        return try! JSONSerialization.data(withJSONObject: payload, options: [])
+    }()
+
+    /// Builds a GLB byte stream with a JSON chunk and (optionally) a BIN chunk.
+    /// Each chunk's payload is padded to a 4-byte multiple per the GLB spec.
+    private func makeGLB(binaryChunk: Data?) -> Data {
+        var bytes = Data()
+
+        // Header: magic "glTF", version 2, total length filled in later.
+        bytes.append(contentsOf: [0x67, 0x6C, 0x54, 0x46])           // "glTF"
+        withUnsafeBytes(of: UInt32(2).littleEndian) { bytes.append(contentsOf: $0) }
+        withUnsafeBytes(of: UInt32(0).littleEndian) { bytes.append(contentsOf: $0) } // placeholder
+
+        func appendChunk(_ payload: Data, type: [UInt8], pad: UInt8) {
+            var padded = payload
+            while padded.count % 4 != 0 { padded.append(pad) }
+            withUnsafeBytes(of: UInt32(padded.count).littleEndian) { bytes.append(contentsOf: $0) }
+            bytes.append(contentsOf: type)
+            bytes.append(padded)
+        }
+
+        appendChunk(Self.minimalJSON, type: [0x4A, 0x53, 0x4F, 0x4E], pad: 0x20) // "JSON", space pad
+        if let bin = binaryChunk {
+            appendChunk(bin, type: [0x42, 0x49, 0x4E, 0x00], pad: 0x00)         // "BIN\0", zero pad
+        }
+        return bytes
+    }
+
+    /// Parsing a GLB with a BIN chunk and then a GLB without one must surface
+    /// `nil` for the second call's binary data (and on `parser.binaryChunk`).
+    /// Pre-#189 this returned the first call's bytes.
+    func testParserResetsBinaryChunkBetweenCalls() throws {
+        let parser = GLTFParser()
+        let firstBinaryPayload = Data([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x10, 0x20])
+
+        let firstGLB = makeGLB(binaryChunk: firstBinaryPayload)
+        let (_, firstBinary) = try parser.parse(data: firstGLB)
+        XCTAssertEqual(firstBinary, firstBinaryPayload, "first parse should return the BIN chunk bytes")
+        XCTAssertEqual(parser.binaryChunk, firstBinaryPayload, "parser.binaryChunk should reflect the first parse")
+
+        let secondGLB = makeGLB(binaryChunk: nil)
+        let (_, secondBinary) = try parser.parse(data: secondGLB)
+        XCTAssertNil(secondBinary, "second parse without a BIN chunk must return nil binary data")
+        XCTAssertNil(parser.binaryChunk, "parser.binaryChunk must be cleared on the second parse")
+    }
+
+    /// Re-parsing with a *different* BIN chunk must overwrite, not append or
+    /// otherwise leak the first chunk into the second result.
+    func testParserOverwritesBinaryChunkOnSubsequentParse() throws {
+        let parser = GLTFParser()
+        let first = Data([0x01, 0x02, 0x03, 0x04])
+        let second = Data([0xDE, 0xAD, 0xBE, 0xEF])
+
+        _ = try parser.parse(data: makeGLB(binaryChunk: first))
+        let (_, secondBinary) = try parser.parse(data: makeGLB(binaryChunk: second))
+        XCTAssertEqual(secondBinary, second, "second parse must return the new BIN chunk, not the prior one")
+        XCTAssertEqual(parser.binaryChunk, second, "parser.binaryChunk must reflect the most recent parse")
+    }
+}

--- a/Tests/VRMMetalKitTests/VRMALookAtIntegrationTests.swift
+++ b/Tests/VRMMetalKitTests/VRMALookAtIntegrationTests.swift
@@ -101,6 +101,121 @@ final class VRMALookAtIntegrationTests: XCTestCase {
         player.update(deltaTime: 0.5, model: model)
     }
 
+    // MARK: - Head-local resolution (issue #190)
+
+    /// Builds a minimal `GLTFNode` via the JSON decoder so a `VRMNode` can be
+    /// constructed without a full glTF file. All transforms default to identity.
+    private func makeGLTFNode(name: String) throws -> GLTFNode {
+        let json: [String: Any] = ["name": name]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(GLTFNode.self, from: data)
+    }
+
+    /// Builds a tiny rig: head at the supplied world transform, with leftEye and
+    /// rightEye as parent-less siblings, all wired through `VRMHumanoid`. The
+    /// returned controller is set up with `smoothing = 0` and saccades disabled
+    /// so `update(deltaTime:)` is deterministic. The eye nodes are returned so
+    /// the caller can read `localRotation` after `update`.
+    private func makeRig(
+        headWorld: simd_float4x4
+    ) throws -> (model: VRMModel, controller: VRMLookAtController, leftEye: VRMNode, rightEye: VRMNode) {
+        let head = try VRMNode(index: 0, gltfNode: makeGLTFNode(name: "head"))
+        let leftEye = try VRMNode(index: 1, gltfNode: makeGLTFNode(name: "leftEye"))
+        let rightEye = try VRMNode(index: 2, gltfNode: makeGLTFNode(name: "rightEye"))
+        head.worldMatrix = headWorld
+        head.localMatrix = headWorld // parent-less, so updateWorldTransform() preserves the value
+
+        let humanoid = VRMHumanoid()
+        humanoid.humanBones[.head] = VRMHumanoid.VRMHumanBone(node: 0)
+        humanoid.humanBones[.leftEye] = VRMHumanoid.VRMHumanBone(node: 1)
+        humanoid.humanBones[.rightEye] = VRMHumanoid.VRMHumanBone(node: 2)
+
+        let model = VRMModel(
+            specVersion: .v1_0,
+            meta: VRMMeta(licenseUrl: ""),
+            humanoid: humanoid,
+            gltf: makeMinimalGLTF()
+        )
+        model.nodes = [head, leftEye, rightEye]
+        model.lookAt = VRMLookAt()
+        model.lookAt?.type = .bone
+
+        let controller = VRMLookAtController()
+        controller.smoothing = 0          // instant — no frame-rate-dependent lerp
+        controller.saccadeEnabled = false // remove jitter from the comparison
+        controller.setup(model: model)
+        controller.mode = .bone           // force bone path regardless of model detection
+
+        return (model, controller, leftEye, rightEye)
+    }
+
+    private func assertQuatEqual(
+        _ a: simd_quatf, _ b: simd_quatf,
+        accuracy tol: Float,
+        _ message: String,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        XCTAssertEqual(a.real,   b.real,   accuracy: tol, message, file: file, line: line)
+        XCTAssertEqual(a.imag.x, b.imag.x, accuracy: tol, message, file: file, line: line)
+        XCTAssertEqual(a.imag.y, b.imag.y, accuracy: tol, message, file: file, line: line)
+        XCTAssertEqual(a.imag.z, b.imag.z, accuracy: tol, message, file: file, line: line)
+    }
+
+    /// With the head at a known non-identity world transform, `.headLocalPoint(p)`
+    /// must produce the same eye rotations as `.point(head_world * p)`. This is
+    /// the core invariant from VRMC_vrm_animation-1.0 §lookAt; pre-#190 the
+    /// controller treated `.point` as world-space and silently dropped the head
+    /// transform, so VRMA-authored gaze pointed in the wrong direction whenever
+    /// the head was rotated or translated.
+    func testHeadLocalPointResolvesThroughHeadWorldMatrix() throws {
+        // Head translated up + rotated 90° around Y (head-local +Z → world +X).
+        let translation = float4x4(translation: SIMD3<Float>(0.3, 1.6, 0.0))
+        let rotation    = float4x4(simd_quatf(angle: .pi / 2, axis: SIMD3<Float>(0, 1, 0)))
+        let headWorld   = translation * rotation
+
+        let localPoint  = SIMD3<Float>(0, 0, 1)              // 1 m forward in head-local
+        let world4      = headWorld * SIMD4<Float>(localPoint, 1)
+        let worldPoint  = SIMD3<Float>(world4.x, world4.y, world4.z)
+
+        // Path A: world-space target.
+        let rigA = try makeRig(headWorld: headWorld)
+        rigA.controller.target = .point(worldPoint)
+        rigA.controller.update(deltaTime: 1.0 / 60.0)
+
+        // Path B: head-local target. Equivalent if (and only if) the controller
+        // resolves through the head's world matrix.
+        let rigB = try makeRig(headWorld: headWorld)
+        rigB.controller.target = .headLocalPoint(localPoint)
+        rigB.controller.update(deltaTime: 1.0 / 60.0)
+
+        let tol: Float = 1e-5
+        assertQuatEqual(rigA.leftEye.rotation,  rigB.leftEye.rotation,  accuracy: tol,
+                        "left eye rotation must match between .point(head_world*p) and .headLocalPoint(p)")
+        assertQuatEqual(rigA.rightEye.rotation, rigB.rightEye.rotation, accuracy: tol,
+                        "right eye rotation must match between .point(head_world*p) and .headLocalPoint(p)")
+    }
+
+    /// Sanity check the fixture itself: with an identity head transform,
+    /// `.point(p)` and `.headLocalPoint(p)` are degenerate and must agree.
+    /// Catches setup errors that would otherwise let the non-identity test
+    /// pass for the wrong reason.
+    func testHeadLocalPointMatchesPointWhenHeadIsIdentity() throws {
+        let p = SIMD3<Float>(0.5, 1.4, 1.0)
+
+        let rigA = try makeRig(headWorld: matrix_identity_float4x4)
+        rigA.controller.target = .point(p)
+        rigA.controller.update(deltaTime: 1.0 / 60.0)
+
+        let rigB = try makeRig(headWorld: matrix_identity_float4x4)
+        rigB.controller.target = .headLocalPoint(p)
+        rigB.controller.update(deltaTime: 1.0 / 60.0)
+
+        assertQuatEqual(rigA.leftEye.rotation,  rigB.leftEye.rotation,  accuracy: 1e-5,
+                        "identity-head fixture: left eye paths must agree")
+        assertQuatEqual(rigA.rightEye.rotation, rigB.rightEye.rotation, accuracy: 1e-5,
+                        "identity-head fixture: right eye paths must agree")
+    }
+
     /// `AnimationPlayer.time` must expose the internal `currentTime` so consumers
     /// who want to drive the controller manually (e.g. via a different sampler)
     /// can read where playback currently sits.

--- a/Tests/VRMMetalKitTests/VRMALookAtIntegrationTests.swift
+++ b/Tests/VRMMetalKitTests/VRMALookAtIntegrationTests.swift
@@ -36,8 +36,9 @@ final class VRMALookAtIntegrationTests: XCTestCase {
         return model
     }
 
-    /// Player attached to a controller drives `target = .point(sampler(t))` when
-    /// the clip carries a `lookAtTargetSampler`.
+    /// Player attached to a controller drives `target = .headLocalPoint(sampler(t))` when
+    /// the clip carries a `lookAtTargetSampler` (VRMC_vrm_animation-1.0 specifies the
+    /// sampled value is in head-bone-local space; see issue #190).
     func testPlayerDrivesLookAtControllerFromVRMASampler() {
         let model = makeFixtureModel()
         let controller = VRMLookAtController()
@@ -55,8 +56,8 @@ final class VRMALookAtIntegrationTests: XCTestCase {
 
         player.update(deltaTime: 0.25, model: model)
 
-        guard case .point(let pos) = controller.target else {
-            return XCTFail("Expected controller.target to be .point after VRMA-driven update; got \(controller.target)")
+        guard case .headLocalPoint(let pos) = controller.target else {
+            return XCTFail("Expected controller.target to be .headLocalPoint after VRMA-driven update; got \(controller.target)")
         }
         XCTAssertEqual(pos.x, 2.5, accuracy: 1e-5)
         XCTAssertEqual(pos.y, 1.25, accuracy: 1e-5)


### PR DESCRIPTION
## Summary
Two small, independent bug fixes surfaced by the PR #188 docs review. One commit per issue so each can be reverted in isolation.

### `fix(loader)` — Fixes #189
- `GLTFParser.binaryChunk` previously leaked between `parse(data:)` calls. A second parse against a GLB with no BIN chunk returned the *first* call's binary bytes via the result tuple.
- Use a local accumulator and only mutate the property on the success path, so `binaryChunk` is atomic per successful parse and `nil` after a parse whose input had no BIN chunk.
- Drops the "reuse with care" caveat from the `init()` doc comment.

### `fix(animation)` — Fixes #190
- `AnimationPlayer` was forwarding VRMA `lookAtTargetSampler` values verbatim as `controller.target = .point(p)`. Per VRMC_vrm_animation-1.0 the sample is **head-bone-local**, but `VRMLookAtController` interprets `.point` as **world-space** — every VRMA clip with a `lookAt` track gazed in the wrong direction.
- New `.headLocalPoint(SIMD3<Float>)` case on `VRMLookAtTarget`; resolved in `VRMLookAtController.updateTargetAngles` through `head.worldMatrix * SIMD4(p, 1)`.
- Player now routes the sampler through `.headLocalPoint`. World-space `.point` semantics unchanged for direct callers.

## Test plan
- [x] `swift build` clean
- [x] New `GLTFParserStateTests` (2 tests) covers reset-on-no-BIN-reparse and overwrite-on-different-BIN-reparse
- [x] `VRMALookAtIntegrationTests` updated to assert the player produces `.headLocalPoint(payload)` end-to-end
- [x] Ran combined `VRMLookAt|VRMALookAt|GLTFParser|Loader|VRMAExpression|VRMAPath|VRMASpec` suites — 95 tests, all green
- [ ] Reviewer: optionally spot-check a VRMA clip with a non-zero `lookAt` track to confirm gaze now tracks head orientation

🤖 Generated with [Claude Code](https://claude.com/claude-code)