### PR TITLE
docs(perf): roadmap index for #200 (Romero-style perf review)

### DIFF
--- a/docs/PERF_ROADMAP.md
+++ b/docs/PERF_ROADMAP.md
@@ -1,0 +1,48 @@
+# Performance Roadmap
+
+Engineering tracking doc for the prioritized performance work captured in the
+**[Romero-style perf review epic — #200][epic]**. Each row links to a focused
+issue. This file is an index, not a spec — design and implementation detail
+live on each issue.
+
+[epic]: https://github.com/arkavo-org/VRMMetalKit/issues/200
+
+## Prerequisite
+
+| Issue | Title |
+|-------|-------|
+| [#156](https://github.com/arkavo-org/VRMMetalKit/issues/156) | Benchmark CI regression gate — **must land first** |
+
+Romero / Carmack rule: never optimise anything you haven't measured. Every
+optimisation below claims an impact; none of those claims are verifiable
+until #156 produces a baseline.
+
+## Optimisations (priority order)
+
+| # | Area | Issue | Notes |
+|---|------|-------|-------|
+| 1 | Baselines | [#156](https://github.com/arkavo-org/VRMMetalKit/issues/156) | prerequisite, already filed |
+| 2 | Outline pass merge (tile memory / instanced draws) | [#192](https://github.com/arkavo-org/VRMMetalKit/issues/192) | alternative to [#88](https://github.com/arkavo-org/VRMMetalKit/issues/88) (ICBs) — pick one |
+| 3 | SpringBone sleep gate | [#149](https://github.com/arkavo-org/VRMMetalKit/issues/149) | already filed |
+| 4 | MToon shader specialisation via `[[function_constant]]` | [#193](https://github.com/arkavo-org/VRMMetalKit/issues/193) | |
+| 5 | Mask-dispatch morph targets | [#194](https://github.com/arkavo-org/VRMMetalKit/issues/194) | orthogonal to [#150](https://github.com/arkavo-org/VRMMetalKit/issues/150) |
+| 6 | Vertex layout: position-only + attribute split | [#195](https://github.com/arkavo-org/VRMMetalKit/issues/195) | |
+| 7 | Half-precision MToon fragment math | [#196](https://github.com/arkavo-org/VRMMetalKit/issues/196) | |
+| 8 | Tile-memory pass merge | folded into [#192](https://github.com/arkavo-org/VRMMetalKit/issues/192) | |
+| 9 | MPS-backed Kalman face smoothing | [#198](https://github.com/arkavo-org/VRMMetalKit/issues/198) | |
+| 10 | Dual-quaternion joint palette | [#197](https://github.com/arkavo-org/VRMMetalKit/issues/197) | |
+| + | GPU occlusion queries for crowd avatars | [#199](https://github.com/arkavo-org/VRMMetalKit/issues/199) | extends [#91](https://github.com/arkavo-org/VRMMetalKit/issues/91) / [#154](https://github.com/arkavo-org/VRMMetalKit/issues/154) |
+
+## Why this lives in the repo as well as in issues
+
+GitHub issues are the source of truth; this file is a stable, code-adjacent
+index so contributors browsing `docs/` find the roadmap alongside
+[`PERFORMANCE_REPORT.md`](PERFORMANCE_REPORT.md) and
+[`PERFORMANCE_OPTIMIZATION_GUIDE.md`](PERFORMANCE_OPTIMIZATION_GUIDE.md).
+Update the table whenever issues close or new ones are filed.
+
+## Cultural commitments the source review called out
+
+- Every PR runs against a fixed reference scene (`AvatarSample_A_1.0.vrm.glb`).
+- No performance regression merges without explicit sign-off.
+- Publish a frame-time budget and defend it.


### PR DESCRIPTION
## Summary
Triage of the Romero-style performance review report into actionable GitHub issues, plus an in-repo index doc.

**No code changes.** Only `docs/PERF_ROADMAP.md` is added.

## What was filed
- **Epic** [#200](https://github.com/arkavo-org/VRMMetalKit/issues/200) — Romero-style performance roadmap (10 prioritized optimizations)
- **Sub-issues** (8 new):
  - [#192](https://github.com/arkavo-org/VRMMetalKit/issues/192) — Outline + silhouette + color into a single tile-memory render pass
  - [#193](https://github.com/arkavo-org/VRMMetalKit/issues/193) — MToon shader specialisation via `[[function_constant]]`
  - [#194](https://github.com/arkavo-org/VRMMetalKit/issues/194) — Mask-dispatch morph targets
  - [#195](https://github.com/arkavo-org/VRMMetalKit/issues/195) — Vertex layout split (position-only + attributes)
  - [#196](https://github.com/arkavo-org/VRMMetalKit/issues/196) — Half-precision MToon fragment math
  - [#197](https://github.com/arkavo-org/VRMMetalKit/issues/197) — Dual-quaternion joint palette
  - [#198](https://github.com/arkavo-org/VRMMetalKit/issues/198) — MPS-backed Kalman face smoothing
  - [#199](https://github.com/arkavo-org/VRMMetalKit/issues/199) — GPU occlusion queries for crowd avatars
- **Cross-referenced existing issues** that already cover Romero items: #156 (baselines, prerequisite), #149 (SpringBone sleep), #150 (morph skip — orthogonal to #194), #154 (frustum), #155 (MToon maintenance), #88 (outline via ICBs — alternative to #192), #91 (crowd scaling).

## Test plan
- [x] All 8 sub-issues link to the epic and to relevant existing issues.
- [x] Epic links to all sub-issues and prerequisite #156.
- [x] `docs/PERF_ROADMAP.md` table matches the epic body.
- [ ] Reviewer: confirm the issue triage is the right granularity and that no items should be bundled or split.

## Notes
The Romero report makes specific impact claims (30–40 % on single-avatar, ~2× on crowd). All of those are unverified until #156 (CI benchmark gate) lands and produces a baseline. The epic and the roadmap doc both call this out explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)