### PR TITLE
fix(pipeline): include pixel format + sample count in cache key

### DIFF
--- a/Sources/VRMMetalKit/Renderer/VRMRenderer+Pipeline.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer+Pipeline.swift
@@ -21,6 +21,24 @@ import MetalKit
 import simd
 
 extension VRMRenderer {
+    /// Build a ``VRMPipelineCache`` key that captures every property of the
+    /// pipeline descriptor that affects compilation.
+    ///
+    /// The static `name` pins the shader-function pair, blend state,
+    /// alpha-to-coverage flag, and vertex layout (which are constant per
+    /// call site). `config.colorPixelFormat` and `config.sampleCount` vary
+    /// per renderer, so they must be part of the cache key — otherwise a
+    /// second renderer asking for the "same" pipeline at a different format
+    /// or sample count receives the first renderer's pipeline back and the
+    /// GPU silently writes the wrong attachment layout. That latent collision
+    /// is what surfaced as the framebuffer-format mismatch behind
+    /// vrm-conformance #213 (linear bytes where sRGB-encoded bytes were
+    /// expected, because the cache returned a `.bgra8Unorm` pipeline for a
+    /// `.rgba8Unorm_srgb` render target).
+    func pipelineKey(_ name: String) -> String {
+        return "\(name)|fmt=\(config.colorPixelFormat.rawValue)|samples=\(config.sampleCount)"
+    }
+
     func validateMaterialUniformAlignment() {
         // Calculate Swift struct size and stride
         let swiftSize = MemoryLayout<MToonMaterialUniforms>.size
@@ -209,7 +227,7 @@ extension VRMRenderer {
             let opaqueState = try VRMPipelineCache.shared.getPipelineState(
                 device: device,
                 descriptor: opaqueDescriptor,
-                key: "mtoon_opaque"
+                key: pipelineKey("mtoon_opaque")
             )
             try strictValidator?.validatePipelineState(opaqueState, name: "mtoon_opaque_pipeline")
             opaquePipelineState = opaqueState
@@ -234,7 +252,7 @@ extension VRMRenderer {
             let blendState = try VRMPipelineCache.shared.getPipelineState(
                 device: device,
                 descriptor: blendDescriptor,
-                key: "mtoon_blend"
+                key: pipelineKey("mtoon_blend")
             )
             try strictValidator?.validatePipelineState(blendState, name: "mtoon_blend_pipeline")
             blendPipelineState = blendState
@@ -250,7 +268,7 @@ extension VRMRenderer {
             let wireframeState = try VRMPipelineCache.shared.getPipelineState(
                 device: device,
                 descriptor: wireframeDescriptor,
-                key: "mtoon_wireframe"
+                key: pipelineKey("mtoon_wireframe")
             )
             try strictValidator?.validatePipelineState(wireframeState, name: "mtoon_wireframe_pipeline")
             wireframePipelineState = wireframeState
@@ -267,7 +285,7 @@ extension VRMRenderer {
             let maskA2CState = try VRMPipelineCache.shared.getPipelineState(
                 device: device,
                 descriptor: maskA2CDescriptor,
-                key: "mtoon_mask_a2c"
+                key: pipelineKey("mtoon_mask_a2c")
             )
             try strictValidator?.validatePipelineState(maskA2CState, name: "mtoon_mask_a2c_pipeline")
             maskAlphaToCoveragePipelineState = maskA2CState
@@ -293,7 +311,7 @@ extension VRMRenderer {
                 let outlineState = try VRMPipelineCache.shared.getPipelineState(
                     device: device,
                     descriptor: outlineDescriptor,
-                    key: "mtoon_outline"
+                    key: pipelineKey("mtoon_outline")
                 )
                 mtoonOutlinePipelineState = outlineState
                 vrmLog("[VRMRenderer] Created MToon outline pipeline successfully")
@@ -426,7 +444,7 @@ extension VRMRenderer {
             let skinnedOpaqueState = try VRMPipelineCache.shared.getPipelineState(
                 device: device,
                 descriptor: skinnedOpaqueDescriptor,
-                key: "mtoon_skinned_opaque"
+                key: pipelineKey("mtoon_skinned_opaque")
             )
             try strictValidator?.validatePipelineState(skinnedOpaqueState, name: "skinned_opaque_pipeline")
             skinnedOpaquePipelineState = skinnedOpaqueState
@@ -449,7 +467,7 @@ extension VRMRenderer {
             let skinnedBlendState = try VRMPipelineCache.shared.getPipelineState(
                 device: device,
                 descriptor: skinnedBlendDescriptor,
-                key: "mtoon_skinned_blend"
+                key: pipelineKey("mtoon_skinned_blend")
             )
             try strictValidator?.validatePipelineState(skinnedBlendState, name: "skinned_blend_pipeline")
             skinnedBlendPipelineState = skinnedBlendState
@@ -466,7 +484,7 @@ extension VRMRenderer {
             let skinnedMaskA2CState = try VRMPipelineCache.shared.getPipelineState(
                 device: device,
                 descriptor: skinnedMaskA2CDescriptor,
-                key: "mtoon_skinned_mask_a2c"
+                key: pipelineKey("mtoon_skinned_mask_a2c")
             )
             try strictValidator?.validatePipelineState(skinnedMaskA2CState, name: "skinned_mask_a2c_pipeline")
             skinnedMaskAlphaToCoveragePipelineState = skinnedMaskA2CState
@@ -492,7 +510,7 @@ extension VRMRenderer {
                 let skinnedOutlineState = try VRMPipelineCache.shared.getPipelineState(
                     device: device,
                     descriptor: skinnedOutlineDescriptor,
-                    key: "mtoon_skinned_outline"
+                    key: pipelineKey("mtoon_skinned_outline")
                 )
                 mtoonSkinnedOutlinePipelineState = skinnedOutlineState
                 vrmLog("[SKINNED PSO] Created skinned MToon outline pipeline successfully")
@@ -571,7 +589,7 @@ extension VRMRenderer {
             spritePipelineState = try VRMPipelineCache.shared.getPipelineState(
                 device: device,
                 descriptor: pipelineDescriptor,
-                key: "sprite"
+                key: pipelineKey("sprite")
             )
             vrmLog("[VRMRenderer] Created sprite pipeline successfully")
 

--- a/Tests/VRMMetalKitTests/VRMPipelineCacheKeyTests.swift
+++ b/Tests/VRMMetalKitTests/VRMPipelineCacheKeyTests.swift
@@ -1,0 +1,261 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+
+import XCTest
+import Metal
+import simd
+@testable import VRMMetalKit
+
+/// Regression test for the latent ``VRMPipelineCache`` key bug surfaced while
+/// diagnosing vrm-conformance #213. Cache keys were static strings
+/// (`"mtoon_opaque"`, `"mtoon_blend"`, ...) that didn't include the descriptor
+/// state actually used to compile the pipeline (`colorAttachments[0].pixelFormat`
+/// and `rasterSampleCount`). Two renderers asking for the same logical pipeline
+/// at different formats received the **first** renderer's pipeline back —
+/// silently routing draws to a pipeline with the wrong attachment layout.
+///
+/// In single-renderer use this never bit (one config, one cache entry). It
+/// surfaced once the vrm-conformance corpus tried to switch the framebuffer
+/// pixel format between renders — see #213's full diagnosis.
+@MainActor
+final class VRMPipelineCacheKeyTests: XCTestCase {
+
+    private var device: MTLDevice!
+
+    override func setUp() async throws {
+        guard let dev = MTLCreateSystemDefaultDevice() else {
+            throw XCTSkip("Metal not available")
+        }
+        device = dev
+        // Reset cache so the test owns its own occupancy counts. The cache
+        // is process-wide, so prior tests would otherwise pollute the stats.
+        VRMPipelineCache.shared.clearCache()
+    }
+
+    /// Build three renderers that differ only in pipeline-affecting config
+    /// fields and assert each produced a *distinct* cache entry per logical
+    /// pipeline name. Pre-fix, the second and third renderers would reuse the
+    /// first's pipeline state (wrong format / wrong sample count) and the
+    /// cache occupancy after the third renderer would equal the count after
+    /// the first.
+    func testDifferentPixelFormatsProduceDistinctCacheEntries() throws {
+        // Renderer A: linear bgra8Unorm, single-sample (the package default).
+        var configA = RendererConfig()
+        configA.colorPixelFormat = .bgra8Unorm
+        configA.sampleCount = 1
+        _ = VRMRenderer(device: device, config: configA)
+        let countA = VRMPipelineCache.shared.getStatistics().pipelineStateCount
+        XCTAssertGreaterThan(countA, 0, "First renderer must populate at least one cache entry.")
+
+        // Renderer B: same sample count, sRGB-encoded format. Must NOT reuse
+        // A's cached pipelines — they were compiled against bgra8Unorm.
+        var configB = RendererConfig()
+        configB.colorPixelFormat = .rgba8Unorm_srgb
+        configB.sampleCount = 1
+        _ = VRMRenderer(device: device, config: configB)
+        let countB = VRMPipelineCache.shared.getStatistics().pipelineStateCount
+        XCTAssertGreaterThan(
+            countB, countA,
+            "Pipelines for a second pixel format must be new cache entries. " +
+            "Got countA=\(countA), countB=\(countB) — same count means the cache " +
+            "returned A's pipelines for B's format request (vrm-conformance #213 root cause)."
+        )
+
+        // Renderer C: same format as A, different sample count. Must also be
+        // a distinct cache slice — `rasterSampleCount` affects pipeline
+        // compilation (MSAA shader variants) the same way pixel format does.
+        var configC = RendererConfig()
+        configC.colorPixelFormat = .bgra8Unorm
+        configC.sampleCount = 4
+        _ = VRMRenderer(device: device, config: configC)
+        let countC = VRMPipelineCache.shared.getStatistics().pipelineStateCount
+        XCTAssertGreaterThan(
+            countC, countB,
+            "Pipelines for a different sample count must be new cache entries. " +
+            "Got countB=\(countB), countC=\(countC) — same count means the cache " +
+            "ignores sampleCount, which causes the same wrong-pipeline-returned " +
+            "class of bug as the pixel-format omission did."
+        )
+    }
+
+    /// End-to-end correctness witness. Build two renderers — `.rgba8Unorm`
+    /// (linear) and `.rgba8Unorm_srgb` — and render the exact same scene.
+    /// With the cache-key fix in place, the sRGB renderer's center pixel
+    /// must be visibly brighter than the linear renderer's (sRGB encoding
+    /// pushes mid-range linear values up by ~50%). Pre-fix, both renderers
+    /// got the same cached pipeline and produced identical bytes.
+    func testCachedPipelineRespectsConfiguredPixelFormat() throws {
+        let linearByte = try renderCenterRedByte(format: .rgba8Unorm)
+        let srgbByte   = try renderCenterRedByte(format: .rgba8Unorm_srgb)
+
+        print("[#213 cache-key] linear=\(linearByte), srgb=\(srgbByte)")
+
+        // Shader output for this scene is ~0.46 linear. Encoding gap:
+        //   .rgba8Unorm:      byte ≈ 0.46 * 255 ≈ 117
+        //   .rgba8Unorm_srgb: byte ≈ sRGB_encode(0.46) * 255 ≈ 180
+        XCTAssertGreaterThan(
+            srgbByte - linearByte, 40,
+            "sRGB-encoded center pixel must be at least 40 bytes brighter than " +
+            "the linear-encoded center pixel (got srgb=\(srgbByte), linear=\(linearByte), " +
+            "delta=\(srgbByte - linearByte)). A small delta means the cache returned the " +
+            "wrong-format pipeline and the GPU never applied sRGB encoding."
+        )
+    }
+
+    /// Build a renderer with the supplied pixel format, render a single MToon
+    /// triangle lit from above into a 32×32 framebuffer of that format, and
+    /// return the R-channel byte at the center pixel.
+    ///
+    /// **Important:** does *not* clear the pipeline cache. The two calls in
+    /// `testCachedPipelineRespectsConfiguredPixelFormat` share a cache, so the
+    /// pre-fix collision (second renderer reuses first's wrong-format pipeline)
+    /// is what the test relies on to fail.
+    private func renderCenterRedByte(format: MTLPixelFormat) throws -> Int {
+        var config = RendererConfig()
+        config.colorPixelFormat = format
+        config.sampleCount = 1
+        config.strict = .off
+        let renderer = VRMRenderer(device: device, config: config)
+        renderer.performanceTracker = PerformanceTracker()
+
+        // Single triangle filling NDC, normal pointing toward camera. Lit
+        // straight on so NdotL=1 and the MToon shader exercises its
+        // brightest direct-lighting path — that's where the format-encode
+        // delta is largest.
+        let model = try makeSingleTriangleModel()
+        renderer.loadModel(model)
+        renderer.viewMatrix = matrix_identity_float4x4
+        renderer.projectionMatrix = matrix_identity_float4x4
+        renderer.setLight(0, direction: SIMD3<Float>(0, 0, 1), color: SIMD3<Float>(1, 1, 1), intensity: 1.0)
+        renderer.disableLight(1)
+        renderer.disableLight(2)
+        renderer.setAmbientColor(SIMD3<Float>(0, 0, 0))
+
+        let size = 32
+        let colorDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: format, width: size, height: size, mipmapped: false)
+        colorDesc.usage = [.renderTarget, .shaderRead]
+        colorDesc.storageMode = .shared
+        let depthDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .depth32Float, width: size, height: size, mipmapped: false)
+        depthDesc.usage = .renderTarget
+        depthDesc.storageMode = .private
+
+        guard let colorTex = device.makeTexture(descriptor: colorDesc),
+              let depthTex = device.makeTexture(descriptor: depthDesc),
+              let queue = device.makeCommandQueue(),
+              let cb = queue.makeCommandBuffer() else {
+            throw XCTSkip("Could not allocate Metal render targets")
+        }
+
+        let rpd = MTLRenderPassDescriptor()
+        rpd.colorAttachments[0].texture = colorTex
+        rpd.colorAttachments[0].loadAction = .clear
+        rpd.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 1)
+        rpd.colorAttachments[0].storeAction = .store
+        rpd.depthAttachment.texture = depthTex
+        rpd.depthAttachment.loadAction = .clear
+        rpd.depthAttachment.clearDepth = 1.0
+        rpd.depthAttachment.storeAction = .dontCare
+
+        renderer.drawOffscreenHeadless(to: colorTex, depth: depthTex, commandBuffer: cb, renderPassDescriptor: rpd)
+        cb.commit()
+        cb.waitUntilCompleted()
+
+        var bytes = [UInt8](repeating: 0, count: size * size * 4)
+        bytes.withUnsafeMutableBytes { buf in
+            colorTex.getBytes(buf.baseAddress!, bytesPerRow: size * 4, from: MTLRegionMake2D(0, 0, size, size), mipmapLevel: 0)
+        }
+        // R-channel byte at center pixel; rgba8Unorm stores RGBA in memory order.
+        let i = ((size / 2) * size + size / 2) * 4
+        return Int(bytes[i])
+    }
+
+    /// One MToon triangle filling NDC with a +Z normal (lit pole when the
+    /// light comes from the camera). baseColor white, shadeColor mid-gray —
+    /// matches the conformance corpus's MToon defaults so the brightness
+    /// arithmetic is identical to what surfaced #213.
+    private func makeSingleTriangleModel() throws -> VRMModel {
+        let gltfJSON = """
+        {"asset":{"version":"2.0"},"scene":0,"scenes":[{"nodes":[0]}],
+         "nodes":[{"name":"root","mesh":0}]}
+        """
+        let gltf = try JSONDecoder().decode(GLTFDocument.self, from: gltfJSON.data(using: .utf8)!)
+        let model = VRMModel(
+            specVersion: .v1_0,
+            meta: VRMMeta(licenseUrl: "https://vrm.dev/licenses/1.0/"),
+            humanoid: nil,
+            gltf: gltf
+        )
+        for (i, gltfNode) in (gltf.nodes ?? []).enumerated() {
+            model.nodes.append(VRMNode(index: i, gltfNode: gltfNode))
+        }
+        for n in model.nodes { n.updateWorldTransform() }
+
+        let mesh = VRMMesh(name: "tri")
+        let primitive = VRMPrimitive()
+        var verts = [VRMVertex(), VRMVertex(), VRMVertex()]
+        verts[0].position = SIMD3<Float>(-0.9, -0.9, 0)
+        verts[1].position = SIMD3<Float>( 0.9, -0.9, 0)
+        verts[2].position = SIMD3<Float>( 0.0,  0.9, 0)
+        for i in 0..<3 {
+            verts[i].normal = SIMD3<Float>(0, 0, 1)
+            verts[i].texCoord = SIMD2<Float>(0, 0)
+            verts[i].color = SIMD4<Float>(1, 1, 1, 1)
+        }
+        primitive.vertexCount = 3
+        primitive.vertexBuffer = device.makeBuffer(
+            bytes: verts,
+            length: 3 * MemoryLayout<VRMVertex>.stride,
+            options: .storageModeShared
+        )
+        primitive.localMin = SIMD3<Float>(-0.9, -0.9, 0)
+        primitive.localMax = SIMD3<Float>( 0.9,  0.9, 0)
+        let indices: [UInt16] = [0, 1, 2]
+        primitive.indexBuffer = device.makeBuffer(
+            bytes: indices,
+            length: 3 * MemoryLayout<UInt16>.stride,
+            options: .storageModeShared
+        )
+        primitive.indexCount = 3
+        primitive.indexType = .uint16
+        primitive.indexBufferOffset = 0
+        primitive.primitiveType = .triangle
+        primitive.hasNormals = true
+        primitive.hasTexCoords = false
+        primitive.hasColors = false
+        primitive.hasJoints = false
+        primitive.hasWeights = false
+        primitive.requiredPaletteSize = 0
+        primitive.materialIndex = 0
+        mesh.primitives = [primitive]
+        model.meshes = [mesh]
+
+        let materialJSON = """
+        {
+          "name":"mtoon_test",
+          "pbrMetallicRoughness":{"baseColorFactor":[1.0,1.0,1.0,1.0]},
+          "extensions":{
+            "VRMC_materials_mtoon":{
+              "specVersion":"1.0",
+              "shadeColorFactor":[0.5,0.5,0.5],
+              "shadingToonyFactor":0.9,
+              "shadingShiftFactor":0.0,
+              "giEqualizationFactor":0.9
+            }
+          }
+        }
+        """
+        let gltfMat = try JSONDecoder().decode(GLTFMaterial.self, from: materialJSON.data(using: .utf8)!)
+        let material = VRMMaterial(from: gltfMat, textures: [], vrm0MaterialProperty: nil, vrmVersion: .v1_0)
+        model.materials = [material]
+        return model
+    }
+}


### PR DESCRIPTION
## Summary

`VRMPipelineCache` keyed compiled pipelines by static name strings (`\"mtoon_opaque\"`, `\"mtoon_blend\"`, ...) that didn't reflect the descriptor properties actually used to compile them. `colorAttachments[0].pixelFormat` (driven by `config.colorPixelFormat`) and `rasterSampleCount` (driven by `config.sampleCount`) vary per renderer; a second renderer asking for the \"same\" pipeline at a different format or sample count received the first renderer's pipeline back, and the GPU silently wrote draws against the wrong attachment layout.

Latent in single-renderer use (one config → one cache entry per name), it surfaced while diagnosing vrm-conformance #213: the conformance runner builds a renderer with the default `.bgra8Unorm` config and then renders to `.rgba8Unorm_srgb` textures. The cache returned the `.bgra8Unorm` pipeline; the GPU wrote raw linear bytes into the sRGB-typed texture (no sRGB encoding applied), and the PNG read back ~118 byte where the UniVRM / three-vrm reference cluster reads ~181 byte.

This PR fixes the latent VMK side. The adapter-side bugs (`colorSpace == \"Srgb\"` case mismatch + missing `config.colorPixelFormat` pass-through) live in vrm-conformance and are QA's to land.

## What changed

- New `pipelineKey(_ name:)` helper on the `VRMRenderer` pipeline extension that suffixes the static name with `fmt=\\(colorPixelFormat.rawValue)` and `samples=\\(sampleCount)`. Other compilation-affecting descriptor properties (vertex layout, blend state, alpha-to-coverage, function names) are constant per call site and already encoded in the name prefix.
- All ten `VRMPipelineCache.shared.getPipelineState(...)` call sites routed through the helper — five MToon unskinned (opaque / blend / wireframe / mask-A2C / outline), four MToon skinned (same set sans wireframe), one sprite.
- New `Tests/VRMMetalKitTests/VRMPipelineCacheKeyTests.swift` with two assertions:
    * `testDifferentPixelFormatsProduceDistinctCacheEntries` — three renderers across two formats and two sample counts produce a strictly increasing `pipelineStateCount`. Pre-fix all three share the same 10 cache entries.
    * `testCachedPipelineRespectsConfiguredPixelFormat` — render the same MToon scene through `.rgba8Unorm` and `.rgba8Unorm_srgb`, assert the sRGB framebuffer's center pixel is >40 bytes brighter than the linear one. Pre-fix both renderers used the first's cached pipeline and produced identical bytes.

## Test plan

- [x] `swift test --filter VRMPipelineCacheKeyTests --disable-sandbox` — both new tests fail on `main` (`countA=10, countB=10, countC=10`; `linear=41, srgb=41, delta=0`), pass post-fix (`countA=10, countB=20, countC=30`; `linear=41, srgb=111, delta=70`).
- [x] `swift test --parallel --num-workers 14 -j 16 --disable-sandbox` — 1424/1424 pass.
- [ ] Cross-check via vrm-conformance after the adapter-side case + config-pass-through fix lands (QA-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)