### PR TITLE
fix(parser): apply Int-vs-Double fix to residual VRMExtensionParser sites

### DIFF
--- a/Sources/VRMMetalKit/Loader/VRMExtensionParser.swift
+++ b/Sources/VRMMetalKit/Loader/VRMExtensionParser.swift
@@ -386,11 +386,13 @@ public class VRMExtensionParser {
             vrmLog("[VRMExtensionParser] Found firstPersonBone: \(firstPersonBone)")
         }
 
-        // Handle VRM 0.0 firstPersonBoneOffset
+        // Handle VRM 0.0 firstPersonBoneOffset. Use `parseFloatValue` so
+        // whole-number components (e.g. `"x": 0`) decoded as `Int` by
+        // AnyCodable don't silently fall through.
         if let offsetDict = dict["firstPersonBoneOffset"] as? [String: Any],
-           let x = offsetDict["x"] as? Double,
-           let y = offsetDict["y"] as? Double,
-           let z = offsetDict["z"] as? Double {
+           let x = parseFloatValue(offsetDict["x"]),
+           let y = parseFloatValue(offsetDict["y"]),
+           let z = parseFloatValue(offsetDict["z"]) {
             vrmLog("[VRMExtensionParser] Found firstPersonBoneOffset: (\(x), \(y), \(z))")
         }
 
@@ -446,16 +448,11 @@ public class VRMExtensionParser {
     private func parseVRM0LookAtCurve(_ dict: [String: Any]) -> VRMLookAtRangeMap {
         var rangeMap = VRMLookAtRangeMap()
 
-        // VRM 0.0 uses xRange for input and yRange for output
-        if let xRange = dict["xRange"] as? Double {
-            rangeMap.inputMaxValue = Float(xRange)
-        } else if let xRange = dict["xRange"] as? Float {
+        // VRM 0.0 uses xRange for input and yRange for output.
+        if let xRange = parseFloatValue(dict["xRange"]) {
             rangeMap.inputMaxValue = xRange
         }
-
-        if let yRange = dict["yRange"] as? Double {
-            rangeMap.outputScale = Float(yRange)
-        } else if let yRange = dict["yRange"] as? Float {
+        if let yRange = parseFloatValue(dict["yRange"]) {
             rangeMap.outputScale = yRange
         }
 
@@ -499,16 +496,10 @@ public class VRMExtensionParser {
     private func parseRangeMap(_ dict: [String: Any]) -> VRMLookAtRangeMap {
         var rangeMap = VRMLookAtRangeMap()
 
-        // JSON numbers are Double by default, try Double first then Float
-        if let inputMaxValue = dict["inputMaxValue"] as? Double {
-            rangeMap.inputMaxValue = Float(inputMaxValue)
-        } else if let inputMaxValue = dict["inputMaxValue"] as? Float {
+        if let inputMaxValue = parseFloatValue(dict["inputMaxValue"]) {
             rangeMap.inputMaxValue = inputMaxValue
         }
-
-        if let outputScale = dict["outputScale"] as? Double {
-            rangeMap.outputScale = Float(outputScale)
-        } else if let outputScale = dict["outputScale"] as? Float {
+        if let outputScale = parseFloatValue(dict["outputScale"]) {
             rangeMap.outputScale = outputScale
         }
 
@@ -785,11 +776,27 @@ public class VRMExtensionParser {
         return nil
     }
 
-    private func parseFloatValue(_ value: Any?) -> Float? {
+    /// Coerce a JSON scalar to `Float`, accepting whichever numeric type the
+    /// decoder produced. Critical: ``AnyCodable`` (used by `GLTFParser` for
+    /// extension dictionaries) tries `Int` *before* `Double`, so JSON
+    /// whole-number literals like `1.0`, `-1`, `0` arrive as raw `Int` —
+    /// without the explicit `Int` branch, every `as? Double` cast on a
+    /// whole-number factor silently returns `nil` and the field falls back
+    /// to its default. This is the root cause class of VMK#238 / VMK#239 in
+    /// MToon parsing; the explicit `Int` branch here keeps the bug from
+    /// re-appearing in VRM 0.x lookAt range maps, firstPersonBoneOffset,
+    /// and similar extension scalars.
+    ///
+    /// Internal rather than private so the regression test for this exact
+    /// numeric-coercion contract can pin down all four branches without
+    /// going through end-to-end VRM loading.
+    func parseFloatValue(_ value: Any?) -> Float? {
         if let floatVal = value as? Float {
             return floatVal
         } else if let doubleVal = value as? Double {
             return Float(doubleVal)
+        } else if let intVal = value as? Int {
+            return Float(intVal)
         } else if let numVal = value as? NSNumber {
             return numVal.floatValue
         }

--- a/Sources/VRMMetalKit/Renderer/VRMGeometry.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMGeometry.swift
@@ -1604,12 +1604,7 @@ public class VRMMaterial {
     /// silently failing for spec-conformant integer-valued vectors.
     private func floatArray(from value: Any?, count: Int) -> [Float]? {
         guard let array = value as? [Any], array.count >= count else { return nil }
-        let parsed: [Float] = array.compactMap {
-            if let intVal = $0 as? Int { return Float(intVal) }
-            if let doubleVal = $0 as? Double { return Float(doubleVal) }
-            if let floatVal = $0 as? Float { return floatVal }
-            return nil
-        }
+        let parsed: [Float] = array.compactMap { floatScalar(from: $0) }
         return parsed.count >= count ? parsed : nil
     }
 

--- a/Tests/VRMMetalKitTests/Conformance/JSONScalarCoercionTests.swift
+++ b/Tests/VRMMetalKitTests/Conformance/JSONScalarCoercionTests.swift
@@ -1,0 +1,58 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+
+import XCTest
+@testable import VRMMetalKit
+
+/// PR #254 review follow-up: lock in that VRMExtensionParser's
+/// `parseFloatValue(_:)` handles every numeric type the JSON pipeline can
+/// produce — `Int`, `Double`, `Float`, and `NSNumber`. The original
+/// VMK#238/#239 root cause was that an `as? Double` cast silently failed
+/// when AnyCodable stored a JSON whole-number literal as `Int`. The same
+/// pattern existed at several other sites (`xRange`, `yRange`,
+/// `inputMaxValue`, `outputScale`, `firstPersonBoneOffset.{x,y,z}`); this
+/// test pins down the canonical reader so the bug class can't return.
+final class JSONScalarCoercionTests: XCTestCase {
+
+    func testParseFloatValueAcceptsIntFromAnyCodable() {
+        let parser = VRMExtensionParser()
+        // AnyCodable decodes JSON `1` and JSON `1.0` both as raw Swift Int.
+        // Without the explicit Int branch the cast silently failed.
+        XCTAssertEqual(parser.parseFloatValue(Int(1)), 1.0)
+        XCTAssertEqual(parser.parseFloatValue(Int(0)), 0.0)
+        XCTAssertEqual(parser.parseFloatValue(Int(-1)), -1.0)
+    }
+
+    func testParseFloatValueAcceptsDouble() {
+        let parser = VRMExtensionParser()
+        XCTAssertEqual(parser.parseFloatValue(Double(0.5)), 0.5)
+        XCTAssertEqual(parser.parseFloatValue(Double(-2.25)), -2.25)
+    }
+
+    func testParseFloatValueAcceptsFloat() {
+        let parser = VRMExtensionParser()
+        XCTAssertEqual(parser.parseFloatValue(Float(3.14)), 3.14)
+    }
+
+    func testParseFloatValueAcceptsNSNumber() {
+        let parser = VRMExtensionParser()
+        // JSONSerialization (used for VRM 0.0 `floatProperties` etc.) emits
+        // NSNumber, not Int/Double directly. Catch this path too.
+        let n: NSNumber = 42
+        XCTAssertEqual(parser.parseFloatValue(n), 42.0)
+    }
+
+    func testParseFloatValueReturnsNilForNonNumeric() {
+        let parser = VRMExtensionParser()
+        XCTAssertNil(parser.parseFloatValue(nil))
+        XCTAssertNil(parser.parseFloatValue("0.5"))
+        XCTAssertNil(parser.parseFloatValue([1.0, 2.0]))
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #254 review (@superninja-app's strongest non-blocking ask): the same \`as? Double\`-without-\`as? Int\` pattern that broke MToon parsing in VMK#238/#239 still existed at ~10 other sites in \`VRMExtensionParser\`. Those would silently default-out on whole-number JSON literals — same bug class, just waiting for the right conformance fixture to trigger.

> The only material gap is that **the same \`as? Double\`-without-\`as? Int\` pattern exists elsewhere in the codebase** and could silently strike again on a different VRM extension. … Strongly recommend opening a follow-up issue for the residual \`as? Double\` sites before they generate the next conformance regression.
> — @superninja-app, PR #254 review

This PR is that follow-up (skipping the issue step and just fixing).

## Changes

- **\`parseFloatValue(_:)\` gains an explicit \`Int\` branch** (Float → Double → Int → NSNumber). Promoted from \`private\` to \`internal\` so the numeric-coercion contract can be regression-tested directly.
- **Three hand-rolled \`as? Double\` fall-through chains** now route through \`parseFloatValue\`:
  - \`firstPersonBoneOffset.{x, y, z}\`
  - \`parseVRM0LookAtCurve\` (xRange / yRange)
  - \`parseRangeMap\` (inputMaxValue / outputScale on lookAt range maps)
- **\`floatArray(from:count:)\` in \`VRMMaterial\` now reuses \`floatScalar(from:)\`** — collapses the duplicated branch tree the reviewer noted as cosmetic.
- **New \`JSONScalarCoercionTests\`** pins down all four numeric branches of \`parseFloatValue\` (Int, Double, Float, NSNumber) plus the nil-on-non-numeric contract.

## Deferred from this PR

- **\`shadingShiftTexture.scale\` test**: needs a fixture variant the upstream \`vrm-asset-generator\` doesn't emit yet. Worth a vrm-conformance issue.
- **Lifting \`floatScalar\` to a shared GLTFCore utility**: the duplication is across two distinct concerns (MToon JSON in \`VRMGeometry\`, VRM extensions in \`VRMExtensionParser\`); they're both ~6 lines and the lift would cross module boundaries. Not worth the indirection right now.
- **PR #253's minor follow-ups** (pool prune(), IrradianceQuality enum, primitive ID 16-bit doc): tracked separately — those are perf/robustness refinements on a different branch.

## Test plan
- [x] \`swift test --filter JSONScalarCoercionTests --disable-sandbox\` — 5 new tests pass
- [x] \`swift test --parallel --num-workers 14 -j 16 --disable-sandbox\` — 1,475 tests pass
- [x] \`AvatarSample_A.png\` regenerated — bit-identical to PR #254 baseline (none of the fixed paths affect the bundled avatar)

## Stacking

Branch is based on \`issue/236-vmk-conformance\` (PR #254). Merge PR #254 first, then this rebases cleanly onto \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)