### PR TITLE
feat(gltf): GLTFMorphBufferPool prune/clear + 16-bit primitive ID doc

### DIFF
--- a/Sources/GLTFMetalKit/Renderer/GLTFMorphBufferPool.swift
+++ b/Sources/GLTFMetalKit/Renderer/GLTFMorphBufferPool.swift
@@ -58,8 +58,11 @@ final class GLTFMorphBufferPool: @unchecked Sendable {
     /// weights, returns the cached buffer without re-blending.
     ///
     /// - Parameters:
-    ///   - primitiveID: Stable identifier for the primitive across calls
-    ///     (typically `meshIndex << 16 | primitiveIndex`).
+    ///   - primitiveID: Stable identifier for the primitive across calls.
+    ///     `GLTFAssetLoader` packs this as `(meshIndex << 16) | primitiveIndex`,
+    ///     which assumes both fit in 16 bits (65,535 meshes × 65,535 primitives
+    ///     per mesh). Realistic glTF assets stay well under that bound; if a
+    ///     future caller needs more, switch to `Hasher.combine(...)`.
     ///   - morph: The primitive's morph deltas + base attributes.
     ///   - weights: Per-target weights to blend. Shorter than `targetCount`
     ///     is zero-extended; longer is clipped.
@@ -131,6 +134,27 @@ final class GLTFMorphBufferPool: @unchecked Sendable {
         entry.lastWeights = weights
         entries[primitiveID] = entry
         return target
+    }
+
+    /// Drop ring storage for any primitive ID **not** in `activeIDs`.
+    /// Use this when an asset transitions between large sub-scenes — the
+    /// pool grows monotonically as new primitives are seen and never
+    /// reclaims storage on its own. For long-lived assets with stable
+    /// primitive sets this is a no-op; for assets that swap visible
+    /// primitive sets, call after the swap to release dead rings.
+    func prune(activeIDs: Set<Int>) {
+        lock.lock()
+        defer { lock.unlock() }
+        entries = entries.filter { activeIDs.contains($0.key) }
+    }
+
+    /// Drop ring storage for every tracked primitive. Equivalent to a
+    /// freshly-constructed pool; safe to call between unrelated asset loads
+    /// that share the same pool instance.
+    func clear() {
+        lock.lock()
+        defer { lock.unlock() }
+        entries.removeAll(keepingCapacity: false)
     }
 
     /// Number of primitives currently tracked. Test-only accessor.

--- a/Tests/GLTFMetalKitTests/GLTFMorphBufferPoolTests.swift
+++ b/Tests/GLTFMetalKitTests/GLTFMorphBufferPoolTests.swift
@@ -111,6 +111,48 @@ final class GLTFMorphBufferPoolTests: XCTestCase {
         XCTAssertEqual(pool.bufferCount(forPrimitiveID: 2), GLTFMorphBufferPool.framesInFlight)
     }
 
+    func testPruneDropsInactivePrimitives() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw XCTSkip("No Metal device available (CI without GPU)")
+        }
+
+        let pool = GLTFMorphBufferPool(device: device)
+        let morph = makeMorphData(vertexCount: 4, targetCount: 2)
+        for id in 1...4 {
+            _ = pool.buffer(primitiveID: id, morph: morph, weights: [1, 0], joints: nil, skinWeights: nil, skinned: false)
+        }
+        XCTAssertEqual(pool.trackedPrimitiveCount, 4)
+
+        // Keep only IDs 2 and 4; the other two should be dropped.
+        pool.prune(activeIDs: [2, 4])
+        XCTAssertEqual(pool.trackedPrimitiveCount, 2)
+        XCTAssertEqual(pool.bufferCount(forPrimitiveID: 1), 0)
+        XCTAssertEqual(pool.bufferCount(forPrimitiveID: 2), GLTFMorphBufferPool.framesInFlight)
+        XCTAssertEqual(pool.bufferCount(forPrimitiveID: 3), 0)
+        XCTAssertEqual(pool.bufferCount(forPrimitiveID: 4), GLTFMorphBufferPool.framesInFlight)
+    }
+
+    func testClearDropsAllPrimitives() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw XCTSkip("No Metal device available (CI without GPU)")
+        }
+
+        let pool = GLTFMorphBufferPool(device: device)
+        let morph = makeMorphData(vertexCount: 4, targetCount: 2)
+        _ = pool.buffer(primitiveID: 1, morph: morph, weights: [1, 0], joints: nil, skinWeights: nil, skinned: false)
+        _ = pool.buffer(primitiveID: 2, morph: morph, weights: [0, 1], joints: nil, skinWeights: nil, skinned: false)
+        XCTAssertEqual(pool.trackedPrimitiveCount, 2)
+
+        pool.clear()
+        XCTAssertEqual(pool.trackedPrimitiveCount, 0)
+        XCTAssertEqual(pool.bufferCount(forPrimitiveID: 1), 0)
+        XCTAssertEqual(pool.bufferCount(forPrimitiveID: 2), 0)
+
+        // Re-use after clear: pool still functional.
+        _ = pool.buffer(primitiveID: 1, morph: morph, weights: [0.5, 0.5], joints: nil, skinWeights: nil, skinned: false)
+        XCTAssertEqual(pool.trackedPrimitiveCount, 1)
+    }
+
     // MARK: - Helpers
 
     /// Build a minimal `GLTFPrimitiveMorphData` with `vertexCount` vertices


### PR DESCRIPTION
## Summary

Two minor PR #253 review follow-ups from @superninja-app. Both small, both genuinely useful:

### Closes
- **Minor #1**: \`GLTFMorphBufferPool\` unbounded growth across asset lifetime. Adds \`prune(activeIDs:)\` and \`clear()\` so callers managing large dynamic assets can release ring storage for primitives no longer in the visible scene.
- **Minor #7**: \`primitiveID = (meshIndex << 16) | primitiveIndex\` 16-bit assumption is now documented inline with the suggested escape (\`Hasher.combine(...)\`) for future callers.

## Why not just open issues

The reviewer marked these as non-blocking, but both fixes are < 30 lines combined and exactly the kind of thing that's easier to land now than to track:

- The lifetime API (\`prune\`/\`clear\`) is small surface, has obvious semantics, and unlocks a use case the original PR explicitly couldn't support (long-lived assets with dynamic primitive sets).
- The doc note costs nothing and prevents future mystery debugging when someone sees a \`primitiveID\` collision on an absurdly-large asset.

## Test plan
- [x] \`swift test --filter GLTFMorphBufferPoolTests --disable-sandbox\` — 6 pool tests pass (+2 new: \`testPruneDropsInactivePrimitives\`, \`testClearDropsAllPrimitives\`)
- [x] \`swift test --parallel --num-workers 14 -j 16 --disable-sandbox\` — 1,475 tests pass

## Deferred (separate issues if desired)

The remaining PR #253 minor concerns are micro-optimizations or API design questions, not worth additional churn right now:

- **Minor #2/#3**: \`Entry\` value-type rewrite cost / \`lastWeights ==\` hash optimization. Sub-microsecond per primitive per frame — won't move any benchmark needle.
- **Minor #5**: Expose \`kIrradianceSampleCount\` as a \`GLTFEnvironment.IrradianceQuality\` enum. Worth doing if anyone ever needs to tune; not yet.
- **Suggestion**: Open an issue for \"refresh \`GLTFAsset.lights\` from animated node transforms on \`drawCalls(animationIndex:time:)\`\". Real follow-up issue, but separate scope.

## Stacking

Branch is based on \`issue/247-gltf-followups\` (PR #253). Merge that first; this rebases cleanly onto \`main\` after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)