### PR TITLE
feat(animation): VRMExpressionController public getter API

### DIFF
--- a/Sources/VRMMetalKit/Animation/VRMMorphTargets.swift
+++ b/Sources/VRMMetalKit/Animation/VRMMorphTargets.swift
@@ -544,6 +544,19 @@ public class VRMExpressionController: @unchecked Sendable {
         updateMorphTargets()
     }
 
+    /// Current weight of a preset expression. Returns 0 when the preset
+    /// has not been set (matches the `init()` default).
+    public func weight(for preset: VRMExpressionPreset) -> Float {
+        currentWeights[preset] ?? 0
+    }
+
+    /// Current weight of a registered custom expression. Returns `nil`
+    /// when the name has not been registered via
+    /// `registerCustomExpression(_:name:)`.
+    public func weight(forCustom name: String) -> Float? {
+        customCurrentWeights[name]
+    }
+
     // MARK: - Preset Animations
 
     /// Plays a one-shot blink that rises to full weight over `duration` and decays back to `0` over the same `duration`.

--- a/Tests/VRMMetalKitTests/ExpressionTests.swift
+++ b/Tests/VRMMetalKitTests/ExpressionTests.swift
@@ -64,6 +64,27 @@ final class ExpressionTests: XCTestCase {
         XCTAssertNotNil(renderer.expressionController, "Expression controller should be initialized")
     }
 
+    func testExpressionControllerGetters() throws {
+        let c = VRMExpressionController()
+        c.setExpressionWeight(.aa, weight: 0.7)
+        XCTAssertEqual(c.weight(for: .aa), 0.7, accuracy: 1e-6)
+        c.setExpressionWeight(.aa, weight: 1.5)  // clamps to 1.0
+        XCTAssertEqual(c.weight(for: .aa), 1.0, accuracy: 1e-6)
+        XCTAssertEqual(c.weight(for: .ih), 0.0, "unset should return default 0.0")
+
+        // Unregistered custom expression should return nil
+        XCTAssertNil(c.weight(forCustom: "PerfectSyncEyeBlinkLeft"))
+
+        // Register and set custom expression
+        let customExpr = VRMExpression()
+        c.registerCustomExpression(customExpr, name: "PerfectSyncEyeBlinkLeft")
+        XCTAssertNil(c.weight(forCustom: "PerfectSyncEyeBlinkLeft"), "registered but unset custom expression should be nil")
+        
+        c.setCustomExpressionWeight("PerfectSyncEyeBlinkLeft", weight: 0.8)
+        let val = try XCTUnwrap(c.weight(forCustom: "PerfectSyncEyeBlinkLeft"))
+        XCTAssertEqual(val, 0.8, accuracy: 1e-6)
+    }
+
     func testSetMoodHappyAppliesWeight() {
         guard let controller = renderer.expressionController else {
             XCTFail("Expression controller not available")


### PR DESCRIPTION
### Description
This PR addresses **Issue #273** by implementing public getter methods on `VRMExpressionController` to read back the currently active (post-clamping / post-interpolation) expression weights. This completes the setter/getter symmetry and allows downstream conformance testing tools (like `vrm-conformance` dumps) to verify expression-driven mesh morphs end-to-end.

### Key Changes
- **Public Getters (`VRMMorphTargets.swift`)**: Exposes public `weight(for:)` for preset expressions (returns `Float`, default `0.0`) and `weight(forCustom:)` for registered custom expressions (returns optional `Float?`).
- **Unit Verification (`ExpressionTests.swift`)**: Adds strict-asserting `testExpressionControllerGetters()` validating all lookup, default, registration, and clamp-to-1.0 behaviors.

### Verification
* All **37 tests** in `ExpressionTests` pass flawlessly.