### PR TITLE
feat(testing): mutation testing on DepthBiasCalculator + retargeting samplers (#282)

### DIFF
--- a/.muter/depth-bias.json
+++ b/.muter/depth-bias.json
@@ -1,0 +1,12 @@
+{
+  "executable": "/usr/bin/swift",
+  "arguments": [
+    "test",
+    "--filter",
+    "DepthBiasCalculatorTests",
+    "--disable-sandbox"
+  ],
+  "exclude": [],
+  "excludeCalls": [],
+  "coverageThreshold": 0
+}

--- a/.muter/depth-bias.yml
+++ b/.muter/depth-bias.yml
@@ -1,0 +1,11 @@
+executable: /usr/bin/swift
+arguments:
+  - test
+  - --filter
+  - DepthBiasCalculatorTests
+  - --disable-sandbox
+  - --build-path
+  - /tmp/vrm-muter-build
+exclude: []
+excludeCalls: []
+coverageThreshold: 0

--- a/.muter/patches/v16-schemata-content-fallback.patch
+++ b/.muter/patches/v16-schemata-content-fallback.patch
@@ -1,0 +1,120 @@
+diff --git a/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift b/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
+index f0a9756..4c9f3fe 100644
+--- a/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
++++ b/Sources/muterCore/MutationSchemata/SchemataMutationMapping.swift
+@@ -6,6 +6,10 @@ typealias MutationSchemata = [MutationSchema]
+ final class SchemataMutationMapping {
+     let filePath: String
+     fileprivate var mappings: [CodeBlockItemListSyntax: MutationSchemata]
++    // Content-keyed index built at insertion time (while the syntax arena is alive).
++    // Used as a fallback in schemata(for:) when re-parsed nodes have different
++    // tree-position identity than the original discovery-time nodes.
++    fileprivate var mappingsByDescription: [String: MutationSchemata]
+ 
+     var count: Int {
+         mappings.count
+@@ -20,7 +24,7 @@ final class SchemataMutationMapping {
+     }
+ 
+     var codeBlocks: [String] {
+-        mappings.keys.map(\.description).sorted()
++        Array(mappingsByDescription.keys).sorted()
+     }
+ 
+     var fileName: String {
+@@ -32,16 +36,19 @@ final class SchemataMutationMapping {
+     ) {
+         self.init(
+             filePath: filePath,
+-            mappings: [:]
++            mappings: [:],
++            mappingsByDescription: [:]
+         )
+     }
+ 
+     fileprivate init(
+         filePath: String = "",
+-        mappings: [CodeBlockItemListSyntax: MutationSchemata]
++        mappings: [CodeBlockItemListSyntax: MutationSchemata],
++        mappingsByDescription: [String: MutationSchemata] = [:]
+     ) {
+         self.filePath = filePath
+         self.mappings = mappings
++        self.mappingsByDescription = mappingsByDescription
+     }
+ 
+     func add(
+@@ -49,6 +56,7 @@ final class SchemataMutationMapping {
+         _ schemata: MutationSchema
+     ) {
+         mappings[codeBlockSyntax, default: []].append(schemata)
++        mappingsByDescription[codeBlockSyntax.description, default: []].append(schemata)
+     }
+ 
+     func add(
+@@ -56,12 +64,27 @@ final class SchemataMutationMapping {
+         _ schemata: MutationSchemata
+     ) {
+         mappings[codeBlockSyntax, default: []].append(contentsOf: schemata)
++        mappingsByDescription[codeBlockSyntax.description, default: []].append(contentsOf: schemata)
+     }
+ 
+     func schemata(
+         _ codeBlockSyntax: CodeBlockItemListSyntax
+     ) -> MutationSchemata? {
+-        mappings[codeBlockSyntax]
++        // Fast path: identity-based lookup (works for original discovery-time nodes).
++        if let direct = mappings[codeBlockSyntax] {
++            return direct
++        }
++        // Fallback: content-based lookup for re-parsed nodes whose tree-position
++        // identity differs from the original discovery-time nodes. The description
++        // index is built at insertion time so no arena access is needed here.
++        // Remove the entry after matching to prevent re-injection into the `else`
++        // branch of the injected schemata switch, which contains the original code.
++        let key = codeBlockSyntax.description
++        if let result = mappingsByDescription[key] {
++            mappingsByDescription.removeValue(forKey: key)
++            return result
++        }
++        return nil
+     }
+ }
+ 
+@@ -80,7 +103,8 @@ extension SchemataMutationMapping: Codable {
+ 
+         self.init(
+             filePath: filePath,
+-            mappings: mappings
++            mappings: mappings,
++            mappingsByDescription: [:]
+         )
+     }
+ 
+@@ -110,9 +134,9 @@ func + (
+         filePath: lhs.filePath
+     )
+ 
+-    let mergedMappgins = lhs.mappings.merging(rhs.mappings) { $0 + $1 }
++    let mergedMappings = lhs.mappings.merging(rhs.mappings) { $0 + $1 }
+ 
+-    for (codeBlock, schemata) in mergedMappgins {
++    for (codeBlock, schemata) in mergedMappings {
+         result.add(codeBlock, schemata)
+     }
+ 
+@@ -140,11 +164,11 @@ extension SchemataMutationMapping: CustomStringConvertible, CustomDebugStringCon
+     var debugDescription: String { description }
+ 
+     var description: String {
+-        let description = mappings.keys.sorted().reduce(into: "") { accum, key in
++        let description = mappingsByDescription.keys.sorted().reduce(into: "") { accum, key in
+             accum +=
+                 """
+-                source: "\(key.escapedDescription)",
+-                schemata: \(mappings[key]!)
++                source: "\(key)",
++                schemata: \(mappingsByDescription[key]!)
+                 """
+         }
+         return """

--- a/.muter/retargeting-samplers.yml
+++ b/.muter/retargeting-samplers.yml
@@ -1,0 +1,11 @@
+executable: /usr/bin/swift
+arguments:
+  - test
+  - --filter
+  - RetargetingSamplersTests
+  - --disable-sandbox
+  - --build-path
+  - /tmp/vrm-muter-build
+exclude: []
+excludeCalls: []
+coverageThreshold: 0

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for VRMMetalKit shader compilation
 # Copyright 2025 Arkavo
 
-.PHONY: help shaders shaders-macos shaders-ios shaders-iossim gltf-shaders clean test docs docs-static muter-bootstrap mutation-test
+.PHONY: help shaders shaders-macos shaders-ios shaders-iossim gltf-shaders clean test docs docs-static muter-bootstrap mutation-test mutation-test-depth-bias mutation-test-retargeting
 
 help:
 	@echo "VRMMetalKit Build Targets:"
@@ -15,7 +15,9 @@ help:
 	@echo "  make docs          - Preview documentation locally"
 	@echo "  make docs-static   - Generate a static documentation site under .build/docs"
 	@echo "  make muter-bootstrap - Build muter from a pinned SHA into .build/tools/"
-	@echo "  make mutation-test - Run mutation testing against DepthBiasCalculator"
+	@echo "  make mutation-test - Run all mutation-test targets"
+	@echo "  make mutation-test-depth-bias - Mutation-test DepthBiasCalculator"
+	@echo "  make mutation-test-retargeting - Mutation-test RetargetingSamplers"
 
 # Compile all VRM Metal shaders into three SDK-specific metallibs:
 #   - macosx          (FP32, baseline; preserves PR #279's safe-default)
@@ -107,14 +109,26 @@ $(MUTER_BIN):
 muter-bootstrap: $(MUTER_BIN)
 	@$(MUTER_BIN) --version
 
-mutation-test: $(MUTER_BIN)
+mutation-test: mutation-test-depth-bias mutation-test-retargeting
+	@echo "✅ All mutation-test targets complete"
+
+mutation-test-depth-bias: $(MUTER_BIN)
 	@mkdir -p .build/mutation-testing
 	@$(MUTER_BIN) run \
 		--configuration .muter/depth-bias.yml \
 		--files-to-mutate Sources/GLTFCore/Utilities/DepthBiasCalculator.swift \
 		--skip-coverage \
 		--format json \
-		--output .build/mutation-testing/last-run.json
+		--output .build/mutation-testing/depth-bias.json
+
+mutation-test-retargeting: $(MUTER_BIN)
+	@mkdir -p .build/mutation-testing
+	@$(MUTER_BIN) run \
+		--configuration .muter/retargeting-samplers.yml \
+		--files-to-mutate Sources/VRMMetalKit/Animation/RetargetingSamplers.swift \
+		--skip-coverage \
+		--format json \
+		--output .build/mutation-testing/retargeting-samplers.json
 
 # List functions in the compiled metallib
 list-functions:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for VRMMetalKit shader compilation
 # Copyright 2025 Arkavo
 
-.PHONY: help shaders shaders-macos shaders-ios shaders-iossim gltf-shaders clean test docs docs-static
+.PHONY: help shaders shaders-macos shaders-ios shaders-iossim gltf-shaders clean test docs docs-static muter-bootstrap mutation-test
 
 help:
 	@echo "VRMMetalKit Build Targets:"
@@ -14,6 +14,8 @@ help:
 	@echo "  make test          - Run Swift tests"
 	@echo "  make docs          - Preview documentation locally"
 	@echo "  make docs-static   - Generate a static documentation site under .build/docs"
+	@echo "  make muter-bootstrap - Build muter from a pinned SHA into .build/tools/"
+	@echo "  make mutation-test - Run mutation testing against DepthBiasCalculator"
 
 # Compile all VRM Metal shaders into three SDK-specific metallibs:
 #   - macosx          (FP32, baseline; preserves PR #279's safe-default)
@@ -82,6 +84,31 @@ gltf-shaders:
 	@echo "✅ GLTFMetalKit shaders compiled"
 	@echo "📦 Output: Sources/GLTFMetalKit/Resources/GLTFMetalKitShaders.metallib"
 	@ls -lh Sources/GLTFMetalKit/Resources/GLTFMetalKitShaders.metallib
+
+# Mutation testing (issue #282) — first target: DepthBiasCalculator
+# muter is built from a pinned master SHA into .build/tools/ because the
+# last tagged release (16, 2023) predates Swift 6.2 toolchain changes.
+MUTER_SHA := 99624ecfde93dac3cc1f7a66ac6f7df05611091d
+MUTER_BIN := .build/tools/bin/muter
+
+$(MUTER_BIN):
+	@echo "🔧 Building muter @ $(MUTER_SHA)..."
+	@mkdir -p .build/tools
+	@if [ ! -d .build/tools/muter-src ]; then \
+		git clone https://github.com/muter-mutation-testing/muter.git .build/tools/muter-src; \
+	fi
+	@cd .build/tools/muter-src && git fetch && git checkout $(MUTER_SHA)
+	@cd .build/tools/muter-src && swift build -c release --product muter
+	@mkdir -p .build/tools/bin
+	@ln -sf ../muter-src/.build/release/muter $(MUTER_BIN)
+	@echo "✅ muter built: $$(./$(MUTER_BIN) --version 2>/dev/null || echo unknown)"
+
+muter-bootstrap: $(MUTER_BIN)
+	@$(MUTER_BIN) --version
+
+mutation-test: $(MUTER_BIN)
+	@mkdir -p .build/mutation-testing
+	@$(MUTER_BIN) run --configuration .muter/depth-bias.json
 
 # List functions in the compiled metallib
 list-functions:

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ muter-bootstrap: $(MUTER_BIN)
 mutation-test: $(MUTER_BIN)
 	@mkdir -p .build/mutation-testing
 	@$(MUTER_BIN) run \
-		--configuration .muter/depth-bias.json \
+		--configuration .muter/depth-bias.yml \
 		--files-to-mutate Sources/GLTFCore/Utilities/DepthBiasCalculator.swift \
 		--skip-coverage \
 		--format json \

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,12 @@ muter-bootstrap: $(MUTER_BIN)
 
 mutation-test: $(MUTER_BIN)
 	@mkdir -p .build/mutation-testing
-	@$(MUTER_BIN) run --configuration .muter/depth-bias.json
+	@$(MUTER_BIN) run \
+		--configuration .muter/depth-bias.json \
+		--files-to-mutate Sources/GLTFCore/Utilities/DepthBiasCalculator.swift \
+		--skip-coverage \
+		--format json \
+		--output .build/mutation-testing/last-run.json
 
 # List functions in the compiled metallib
 list-functions:

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ $(MUTER_BIN):
 		git clone https://github.com/muter-mutation-testing/muter.git .build/tools/muter-src; \
 	fi
 	@cd .build/tools/muter-src && git fetch && git checkout $(MUTER_SHA)
+	@cd .build/tools/muter-src && git checkout -- . && git apply ../../../.muter/patches/v16-schemata-content-fallback.patch
 	@cd .build/tools/muter-src && swift build -c release --product muter
 	@mkdir -p .build/tools/bin
 	@ln -sf ../muter-src/.build/release/muter $(MUTER_BIN)

--- a/Sources/VRMMetalKit/Animation/RetargetingSamplers.swift
+++ b/Sources/VRMMetalKit/Animation/RetargetingSamplers.swift
@@ -1,0 +1,133 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import simd
+
+// VRMA rest-pose retargeting samplers.
+//
+// Extracted from VRMAnimationLoader.swift so the retargeting math is an
+// isolated, directly-testable unit (issue #282). VRMAnimationLoader builds
+// `KeyTrack`s from parsed GLB data and calls these to produce per-frame
+// closures.
+//
+// Rest-pose retargeting (VRM 1.0 `how_to_transform_human_pose.md`):
+//   delta  = inverse(animationRestRotation) * animationRotation
+//   result = modelRestRotation * delta
+// with the W-term change-of-basis applied for rigs whose world-rest
+// orientations differ. See makeRotationSampler for the full derivation.
+
+func makeRotationSampler(track: KeyTrack,
+                         animationRestRotation: simd_quatf,
+                         animationRestWorldRotation: simd_quatf,
+                         modelRestRotation: simd_quatf?,
+                         modelRestWorldRotation: simd_quatf?) -> ((Float) -> simd_quatf)? {
+    let L_A = simd_normalize(animationRestRotation)
+    let W_A = simd_normalize(animationRestWorldRotation)
+
+    // Non-humanoid tracks pass nil for model rest — there's no model-
+    // side bone to normalise against, so the animation rotation flows
+    // through unchanged.
+    guard let modelRest = modelRestRotation,
+          let modelWorld = modelRestWorldRotation else {
+        return { t in sampleQuaternion(track, at: t) }
+    }
+    let L_B = simd_normalize(modelRest)
+    let W_B = simd_normalize(modelWorld)
+
+    // VRM 1.0 pose-normalisation (`how_to_transform_human_pose.md`):
+    //
+    //   Normalized       = W_A · L_A⁻¹ · A.LocalRotation · W_A⁻¹
+    //   B.LocalRotation  = L_B · W_B⁻¹ · Normalized · W_B
+    //
+    // Combined: B = L_B · W_B⁻¹ · W_A · L_A⁻¹ · A · W_A⁻¹ · W_B
+    //
+    // For two rigs that share the same world-rest orientation
+    // (`W_A == W_B`), the W terms cancel and the formula collapses to
+    // `B = L_B · L_A⁻¹ · A` — the previous "delta retargeting" formula.
+    // For VRMAs authored on a different rest pose (e.g. arms-forward
+    // when the model is T-pose) the W terms perform the change-of-
+    // basis that aligns the animation's world frame with the model's.
+    // VMK#269 was the regression where the W terms were missing.
+    let invL_A = simd_inverse(L_A)
+    let invW_A = simd_inverse(W_A)
+    let invW_B = simd_inverse(W_B)
+    return { t in
+        let A = sampleQuaternion(track, at: t)
+        let normalized = simd_normalize(W_A * invL_A * A * invW_A)
+        let result = simd_normalize(L_B * invW_B * normalized * W_B)
+        return result
+    }
+}
+
+// Translation Retargeting with Delta-Based Alignment
+//
+// ROOT MOTION POLICY:
+// -------------------
+// Translation deltas (including hips XYZ) are applied in LOCAL humanoid space.
+// This means hips translation from the animation moves the character relative to
+// its own coordinate frame, not the scene/world.
+//
+// Current Behavior:
+//   • Hips XZ translation = character-relative horizontal movement (walk cycles, shifts)
+//   • Hips Y translation = vertical movement (crouch, jump, body bounce)
+//   • All deltas preserve animation intent while adapting to different skeleton proportions
+//
+// For Scene Locomotion (Future):
+//   If you need the character to move through the world based on animation:
+//   1. Extract hips XZ deltas separately (before applying to bone)
+//   2. Accumulate as "root motion" vector
+//   3. Apply to character's scene transform (not skeleton)
+//   4. Optionally zero out the hips XZ in the skeleton to prevent "double movement"
+//
+// See also: AnimationPlayer.update() for frame-by-frame sampling
+//
+func makeTranslationSampler(track: KeyTrack,
+                            animationRestTranslation: SIMD3<Float>,
+                            modelRestTranslation: SIMD3<Float>?) -> ((Float) -> SIMD3<Float>)? {
+    guard let modelRest = modelRestTranslation else {
+        return { t in sampleVector3(track, at: t) }
+    }
+
+    return { t in
+        let animTranslation = sampleVector3(track, at: t)
+        let delta = animTranslation - animationRestTranslation
+        return modelRest + delta
+    }
+}
+
+func makeScaleSampler(track: KeyTrack,
+                      animationRestScale: SIMD3<Float>,
+                      modelRestScale: SIMD3<Float>?) -> ((Float) -> SIMD3<Float>)? {
+    guard let modelRest = modelRestScale else {
+        return { t in sampleVector3(track, at: t) }
+    }
+
+    return { t in
+        let animScale = sampleVector3(track, at: t)
+        let ratio = safeDivide(animScale, by: animationRestScale)
+        return modelRest * ratio
+    }
+}
+
+func safeDivide(_ numerator: SIMD3<Float>, by denominator: SIMD3<Float>) -> SIMD3<Float> {
+    let epsilon: Float = 1e-6
+    return SIMD3<Float>(
+        numerator.x / (abs(denominator.x) > epsilon ? denominator.x : 1),
+        numerator.y / (abs(denominator.y) > epsilon ? denominator.y : 1),
+        numerator.z / (abs(denominator.z) > epsilon ? denominator.z : 1)
+    )
+}

--- a/Sources/VRMMetalKit/Animation/VRMAnimationLoader.swift
+++ b/Sources/VRMMetalKit/Animation/VRMAnimationLoader.swift
@@ -18,7 +18,7 @@
 import Foundation
 import simd
 
-private enum Interpolation: String {
+enum Interpolation: String {
     case linear = "LINEAR"
     case step = "STEP"
     case cubicSpline = "CUBICSPLINE"
@@ -34,7 +34,7 @@ private enum Interpolation: String {
     var description: String { rawValue }
 }
 
-private struct KeyTrack {
+struct KeyTrack {
     let times: [Float]
     let values: [Float]
     let path: String
@@ -602,116 +602,6 @@ private func componentCount(for path: String) -> Int? {
     }
 }
 
-// Rotation Retargeting (Delta-Based)
-//
-// VRM ANIMATION SPEC:
-// ------------------
-// VRMA animations target humanoid bones identified by extension data.
-// Retargeting transforms animation from animation's rest space to model's rest space.
-//
-// Spec: https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm_animation-1.0/
-//
-// Formula (per VRMC_node_constraint-1.0):
-//   delta = inverse(animationRestRotation) * animationRotation
-//   result = modelRestRotation * delta
-//
-// This works for all cases:
-// - Identical rest poses: delta = animRotation, result = modelRest * animRotation
-// - Different rest poses: delta transforms animation to model's coordinate frame
-//
-private func makeRotationSampler(track: KeyTrack,
-                                 animationRestRotation: simd_quatf,
-                                 animationRestWorldRotation: simd_quatf,
-                                 modelRestRotation: simd_quatf?,
-                                 modelRestWorldRotation: simd_quatf?) -> ((Float) -> simd_quatf)? {
-    let L_A = simd_normalize(animationRestRotation)
-    let W_A = simd_normalize(animationRestWorldRotation)
-
-    // Non-humanoid tracks pass nil for model rest — there's no model-
-    // side bone to normalise against, so the animation rotation flows
-    // through unchanged.
-    guard let modelRest = modelRestRotation,
-          let modelWorld = modelRestWorldRotation else {
-        return { t in sampleQuaternion(track, at: t) }
-    }
-    let L_B = simd_normalize(modelRest)
-    let W_B = simd_normalize(modelWorld)
-
-    // VRM 1.0 pose-normalisation (`how_to_transform_human_pose.md`):
-    //
-    //   Normalized       = W_A · L_A⁻¹ · A.LocalRotation · W_A⁻¹
-    //   B.LocalRotation  = L_B · W_B⁻¹ · Normalized · W_B
-    //
-    // Combined: B = L_B · W_B⁻¹ · W_A · L_A⁻¹ · A · W_A⁻¹ · W_B
-    //
-    // For two rigs that share the same world-rest orientation
-    // (`W_A == W_B`), the W terms cancel and the formula collapses to
-    // `B = L_B · L_A⁻¹ · A` — the previous "delta retargeting" formula.
-    // For VRMAs authored on a different rest pose (e.g. arms-forward
-    // when the model is T-pose) the W terms perform the change-of-
-    // basis that aligns the animation's world frame with the model's.
-    // VMK#269 was the regression where the W terms were missing.
-    let invL_A = simd_inverse(L_A)
-    let invW_A = simd_inverse(W_A)
-    let invW_B = simd_inverse(W_B)
-    return { t in
-        let A = sampleQuaternion(track, at: t)
-        let normalized = simd_normalize(W_A * invL_A * A * invW_A)
-        let result = simd_normalize(L_B * invW_B * normalized * W_B)
-        return result
-    }
-}
-
-// Translation Retargeting with Delta-Based Alignment
-//
-// ROOT MOTION POLICY:
-// -------------------
-// Translation deltas (including hips XYZ) are applied in LOCAL humanoid space.
-// This means hips translation from the animation moves the character relative to
-// its own coordinate frame, not the scene/world.
-//
-// Current Behavior:
-//   • Hips XZ translation = character-relative horizontal movement (walk cycles, shifts)
-//   • Hips Y translation = vertical movement (crouch, jump, body bounce)
-//   • All deltas preserve animation intent while adapting to different skeleton proportions
-//
-// For Scene Locomotion (Future):
-//   If you need the character to move through the world based on animation:
-//   1. Extract hips XZ deltas separately (before applying to bone)
-//   2. Accumulate as "root motion" vector
-//   3. Apply to character's scene transform (not skeleton)
-//   4. Optionally zero out the hips XZ in the skeleton to prevent "double movement"
-//
-// See also: AnimationPlayer.update() for frame-by-frame sampling
-//
-private func makeTranslationSampler(track: KeyTrack,
-                                    animationRestTranslation: SIMD3<Float>,
-                                    modelRestTranslation: SIMD3<Float>?) -> ((Float) -> SIMD3<Float>)? {
-    guard let modelRest = modelRestTranslation else {
-        return { t in sampleVector3(track, at: t) }
-    }
-
-    return { t in
-        let animTranslation = sampleVector3(track, at: t)
-        let delta = animTranslation - animationRestTranslation
-        return modelRest + delta
-    }
-}
-
-private func makeScaleSampler(track: KeyTrack,
-                              animationRestScale: SIMD3<Float>,
-                              modelRestScale: SIMD3<Float>?) -> ((Float) -> SIMD3<Float>)? {
-    guard let modelRest = modelRestScale else {
-        return { t in sampleVector3(track, at: t) }
-    }
-
-    return { t in
-        let animScale = sampleVector3(track, at: t)
-        let ratio = safeDivide(animScale, by: animationRestScale)
-        return modelRest * ratio
-    }
-}
-
 // Expression Weight Sampler
 // Extracts the X component of a translation track as the expression weight.
 // VRMA expression tracks encode weight as translation.x (0.0 to 1.0).
@@ -729,7 +619,7 @@ private func makeExpressionWeightSampler(track: KeyTrack) -> (Float) -> Float {
 // spec-correct math — including `simd_slerp` for LINEAR rotations and
 // shortest-arc fixup on CUBICSPLINE rotation tangents.
 
-private func sampleQuaternion(_ track: KeyTrack, at time: Float) -> simd_quatf {
+func sampleQuaternion(_ track: KeyTrack, at time: Float) -> simd_quatf {
     guard track.componentCount == 4, !track.times.isEmpty else {
         return simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
     }
@@ -741,7 +631,7 @@ private func sampleQuaternion(_ track: KeyTrack, at time: Float) -> simd_quatf {
     )
 }
 
-private func sampleVector3(_ track: KeyTrack, at time: Float) -> SIMD3<Float> {
+func sampleVector3(_ track: KeyTrack, at time: Float) -> SIMD3<Float> {
     guard track.componentCount == 3, !track.times.isEmpty else {
         return SIMD3<Float>(repeating: 0)
     }
@@ -926,15 +816,6 @@ private struct RestTransform {
                   translation: node.translation,
                   scale: node.scale)
     }
-}
-
-private func safeDivide(_ numerator: SIMD3<Float>, by denominator: SIMD3<Float>) -> SIMD3<Float> {
-    let epsilon: Float = 1e-6
-    return SIMD3<Float>(
-        numerator.x / (abs(denominator.x) > epsilon ? denominator.x : 1),
-        numerator.y / (abs(denominator.y) > epsilon ? denominator.y : 1),
-        numerator.z / (abs(denominator.z) > epsilon ? denominator.z : 1)
-    )
 }
 
 // MARK: - VRM 0.0 Coordinate Conversion

--- a/Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift
+++ b/Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift
@@ -184,4 +184,76 @@ final class DepthBiasCalculatorTests: XCTestCase {
         XCTAssertNotEqual(body, cloth,
                           "Distinct material names must produce distinct biases")
     }
+
+    // MARK: - Survivor-driven additions
+
+    // Pins each individual keyword in the clothing || chain so that a
+    // logical-connector mutant (|| → &&) on any one of them is caught.
+
+    func testClothKeywordAloneMatchesClothing() {
+        // "cloth" alone (no "clothing") must still hit the clothing branch (0.015).
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "cloth_mesh", isOverlay: false), 0.015, accuracy: 1e-6)
+    }
+
+    func testClothingKeywordAloneMatchesClothing() {
+        // "clothing" alone (no "skirt") must still hit the clothing branch (0.015).
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "clothing_mesh", isOverlay: false), 0.015, accuracy: 1e-6)
+    }
+
+    func testSkirtKeywordAloneMatchesClothing() {
+        // "skirt" alone (no "bottoms") must still hit the clothing branch (0.015).
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "skirt_back", isOverlay: false), 0.015, accuracy: 1e-6)
+    }
+
+    func testBottomsKeywordAloneMatchesClothing() {
+        // "bottoms" alone (no "pants") must still hit the clothing branch (0.015).
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "bottoms_mesh", isOverlay: false), 0.015, accuracy: 1e-6)
+    }
+
+    func testPantsKeywordAloneMatchesClothing() {
+        // "pants" alone must still hit the clothing branch (0.015).
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "pants_mesh", isOverlay: false), 0.015, accuracy: 1e-6)
+    }
+
+    func testMouthKeywordAloneMatchesMouth() {
+        // "mouth" alone (no "lip") must hit the mouth branch (0.02).
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "mouth_inner", isOverlay: false), 0.02, accuracy: 1e-6)
+    }
+
+    func testLipKeywordAloneMatchesMouth() {
+        // "lip" alone (no "mouth") must hit the mouth branch (0.02).
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "lip_mesh", isOverlay: false), 0.02, accuracy: 1e-6)
+    }
+
+    func testBrowKeywordAloneMatchesEyebrow() {
+        // "brow" alone (no "eyebrow") must hit the eyebrow branch (0.025).
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "brow_left", isOverlay: false), 0.025, accuracy: 1e-6)
+    }
+
+    func testOverlayOffsetIsPositiveNotZero() {
+        // Pins the SwapTernary mutant: isOverlay:true must ADD overlayBiasOffset,
+        // not substitute 0.0. Verifies the absolute value, not just the delta.
+        let calc = DepthBiasCalculator()
+        let base = calc.depthBias(for: "unknown_xyz", isOverlay: false)
+        let overlay = calc.depthBias(for: "unknown_xyz", isOverlay: true)
+        XCTAssertGreaterThan(overlay, base,
+            "overlay bias must be strictly greater than base bias for the same material")
+        XCTAssertEqual(overlay, 0.02, accuracy: 1e-6,
+            "default(0.01) + overlayOffset(0.01) must equal 0.02")
+    }
+
+    func testNonOverlayDoesNotApplyOffset() {
+        // Complementary pin: isOverlay:false must NOT add the overlay offset.
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "unknown_xyz", isOverlay: false), 0.01, accuracy: 1e-6,
+            "Non-overlay unknown material must return exactly the default bias (0.01), not 0.01 + overlayOffset")
+    }
 }

--- a/Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift
+++ b/Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift
@@ -186,56 +186,58 @@ final class DepthBiasCalculatorTests: XCTestCase {
     }
 
     // MARK: - Survivor-driven additions
+    //
+    // Each test below uses a multi-keyword input that exposes the priority chain.
+    // Single-keyword inputs are caught by the safety-net partial-match scan in
+    // computeBias() and cannot kill the explicit if-chain's logical-connector
+    // mutants.
 
-    // Pins each individual keyword in the clothing || chain so that a
-    // logical-connector mutant (|| → &&) on any one of them is caught.
-
-    func testClothKeywordAloneMatchesClothing() {
-        // "cloth" alone (no "clothing") must still hit the clothing branch (0.015).
+    func testClothBodyReturnsClothing() {
+        // Kills ChangeLogicalConnector at line 165 col 41 (cloth || clothing → &&).
+        // Original: clothing chain catches "cloth" → 0.015.
+        // Mutated: "cloth_body".contains("cloth")=true && contains("clothing")=false
+        //   → false → falls through to body check → 0.005.
         let calc = DepthBiasCalculator()
-        XCTAssertEqual(calc.depthBias(for: "cloth_mesh", isOverlay: false), 0.015, accuracy: 1e-6)
+        XCTAssertEqual(calc.depthBias(for: "cloth_body", isOverlay: false), 0.015, accuracy: 1e-6,
+                       "Multi-keyword 'cloth_body' must hit clothing branch (Priority 1) before body (Priority 2)")
     }
 
-    func testClothingKeywordAloneMatchesClothing() {
-        // "clothing" alone (no "skirt") must still hit the clothing branch (0.015).
+    func testSkirtBodyReturnsClothing() {
+        // Kills ChangeLogicalConnector at line 165 col 76 (clothing || skirt → &&)
+        // AND line 166 col 41 (skirt || bottoms → &&).
+        // Original: "skirt_body" → 0.015 (clothing chain catches "skirt").
+        // Mutated: chain fails → falls through → body → 0.005.
         let calc = DepthBiasCalculator()
-        XCTAssertEqual(calc.depthBias(for: "clothing_mesh", isOverlay: false), 0.015, accuracy: 1e-6)
+        XCTAssertEqual(calc.depthBias(for: "skirt_body", isOverlay: false), 0.015, accuracy: 1e-6,
+                       "Multi-keyword 'skirt_body' must hit clothing branch")
     }
 
-    func testSkirtKeywordAloneMatchesClothing() {
-        // "skirt" alone (no "bottoms") must still hit the clothing branch (0.015).
+    func testBottomsBodyReturnsClothing() {
+        // Kills ChangeLogicalConnector at line 166 col 75 (bottoms || pants → &&).
+        // Original: "bottoms_body" → 0.015.
+        // Mutated: chain fails → body → 0.005.
         let calc = DepthBiasCalculator()
-        XCTAssertEqual(calc.depthBias(for: "skirt_back", isOverlay: false), 0.015, accuracy: 1e-6)
+        XCTAssertEqual(calc.depthBias(for: "bottoms_body", isOverlay: false), 0.015, accuracy: 1e-6,
+                       "Multi-keyword 'bottoms_body' must hit clothing branch")
     }
 
-    func testBottomsKeywordAloneMatchesClothing() {
-        // "bottoms" alone (no "pants") must still hit the clothing branch (0.015).
+    func testMouthEyeReturnsMouth() {
+        // Kills ChangeLogicalConnector at line 178 col 41 (mouth || lip → &&).
+        // Original: "mouth_eye" → 0.02 (mouth branch catches before eye).
+        // Mutated: mouth check fails → eyebrow no → eye yes → 0.03.
         let calc = DepthBiasCalculator()
-        XCTAssertEqual(calc.depthBias(for: "bottoms_mesh", isOverlay: false), 0.015, accuracy: 1e-6)
+        XCTAssertEqual(calc.depthBias(for: "mouth_eye", isOverlay: false), 0.02, accuracy: 1e-6,
+                       "Multi-keyword 'mouth_eye' must hit mouth branch before eye")
     }
 
-    func testPantsKeywordAloneMatchesClothing() {
-        // "pants" alone must still hit the clothing branch (0.015).
+    func testBrowEyeReturnsEyebrow() {
+        // Kills ChangeLogicalConnector at line 181 col 43 (eyebrow || brow → &&).
+        // Original: "brow_eye" → 0.025 (eyebrow check catches via "brow").
+        // Mutated: needs both "eyebrow" AND "brow" → "brow_eye" lacks "eyebrow"
+        //   → falls through → eye → 0.03.
         let calc = DepthBiasCalculator()
-        XCTAssertEqual(calc.depthBias(for: "pants_mesh", isOverlay: false), 0.015, accuracy: 1e-6)
-    }
-
-    func testMouthKeywordAloneMatchesMouth() {
-        // "mouth" alone (no "lip") must hit the mouth branch (0.02).
-        let calc = DepthBiasCalculator()
-        XCTAssertEqual(calc.depthBias(for: "mouth_inner", isOverlay: false), 0.02, accuracy: 1e-6)
-    }
-
-    func testLipKeywordAloneMatchesMouth() {
-        // "lip" alone (no "mouth") must hit the mouth branch (0.02).
-        let calc = DepthBiasCalculator()
-        XCTAssertEqual(calc.depthBias(for: "lip_mesh", isOverlay: false), 0.02, accuracy: 1e-6)
-    }
-
-    func testBrowKeywordAloneMatchesEyebrow() {
-        // "brow" alone (no "eyebrow") must hit the eyebrow branch (0.025).
-        let calc = DepthBiasCalculator()
-        XCTAssertEqual(calc.depthBias(for: "brow_left", isOverlay: false), 0.025, accuracy: 1e-6)
+        XCTAssertEqual(calc.depthBias(for: "brow_eye", isOverlay: false), 0.025, accuracy: 1e-6,
+                       "Multi-keyword 'brow_eye' must hit eyebrow branch before eye")
     }
 
     func testOverlayOffsetIsPositiveNotZero() {

--- a/Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift
+++ b/Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift
@@ -1,0 +1,187 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+@testable import VRMMetalKit
+
+/// Direct unit tests for `DepthBiasCalculator` — the mutation-testing oracle suite.
+///
+/// These tests assert known input/output pairs on the calculator's public
+/// surface so that mutation testing (issue #282) has a meaningful target.
+/// `HipSkirtTests` exercises the calculator only incidentally via the
+/// hip-skirt scenario; muter must not be pointed at it.
+final class DepthBiasCalculatorTests: XCTestCase {
+
+    // MARK: - Construction & constants
+
+    func testDefaultScaleIsOne() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.scale, 1.0)
+    }
+
+    func testExplicitScaleIsRetained() {
+        let calc = DepthBiasCalculator(scale: 2.5)
+        XCTAssertEqual(calc.scale, 2.5)
+    }
+
+    func testSlopeScaleConstant() {
+        XCTAssertEqual(DepthBiasCalculator().slopeScale, 2.0)
+    }
+
+    func testClampConstant() {
+        XCTAssertEqual(DepthBiasCalculator().clamp, 0.1)
+    }
+
+    // MARK: - Exact-match lookups (from baseBiasValues table)
+
+    func testBodySkinExactMatch() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "Body_SKIN", isOverlay: false), 0.005, accuracy: 1e-6)
+    }
+
+    func testFaceExactMatch() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "Face", isOverlay: false), 0.01, accuracy: 1e-6)
+    }
+
+    func testEyeExactMatch() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "Eye", isOverlay: false), 0.03, accuracy: 1e-6)
+    }
+
+    func testHighlightExactMatch() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "Highlight", isOverlay: false), 0.04, accuracy: 1e-6)
+    }
+
+    // MARK: - Priority ordering in computeBias
+
+    func testClothingPriorityBeatsBody() {
+        // "Body_Clothing" — clothing check (Priority 1) must fire before body check (Priority 2).
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "Body_Clothing", isOverlay: false), 0.015, accuracy: 1e-6,
+                       "Material containing both 'body' and 'clothing' must hit the clothing branch first")
+    }
+
+    func testBodyPriorityBeatsFaceAndSkin() {
+        // "Body_Face_Skin" — body (Priority 2) must fire before face (Priority 3) and skin (Priority 4).
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "Body_Face_Skin", isOverlay: false), 0.005, accuracy: 1e-6)
+    }
+
+    func testEyebrowPriorityBeatsEye() {
+        // "Eyebrow" contains "eye", but the eyebrow check fires first.
+        let calc = DepthBiasCalculator()
+        let bias = calc.depthBias(for: "left_eyebrow_inner", isOverlay: false)
+        XCTAssertEqual(bias, 0.025, accuracy: 1e-6,
+                       "Eyebrow-containing names must hit eyebrow (0.025), not eye (0.03)")
+    }
+
+    func testMouthPriorityFires() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "mouth_inner", isOverlay: false), 0.02, accuracy: 1e-6)
+    }
+
+    // MARK: - Case-insensitive substring match
+
+    func testLowercaseInputMatchesBody() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "body_mesh", isOverlay: false), 0.005, accuracy: 1e-6)
+    }
+
+    func testUppercaseInputMatchesBody() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "BODY_MESH", isOverlay: false), 0.005, accuracy: 1e-6)
+    }
+
+    func testMixedCaseInputMatchesClothing() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "MyCloThInG_Material", isOverlay: false), 0.015, accuracy: 1e-6)
+    }
+
+    // MARK: - Default fallback
+
+    func testUnknownMaterialReturnsDefault() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "totally_unknown_material_xyz", isOverlay: false), 0.01, accuracy: 1e-6)
+    }
+
+    func testEmptyStringReturnsDefault() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "", isOverlay: false), 0.01, accuracy: 1e-6)
+    }
+
+    // MARK: - Overlay offset
+
+    func testOverlayAddsOffsetToBody() {
+        let calc = DepthBiasCalculator()
+        let base = calc.depthBias(for: "Body_SKIN", isOverlay: false)
+        let overlay = calc.depthBias(for: "Body_SKIN", isOverlay: true)
+        XCTAssertEqual(overlay - base, 0.01, accuracy: 1e-6,
+                       "isOverlay:true must add exactly 0.01 to the base bias")
+    }
+
+    func testOverlayAddsOffsetToDefault() {
+        let calc = DepthBiasCalculator()
+        let base = calc.depthBias(for: "unknown_xyz", isOverlay: false)
+        let overlay = calc.depthBias(for: "unknown_xyz", isOverlay: true)
+        XCTAssertEqual(overlay - base, 0.01, accuracy: 1e-6)
+    }
+
+    // MARK: - Scale multiplication
+
+    func testScaleMultipliesBase() {
+        let calc = DepthBiasCalculator(scale: 3.0)
+        let bias = calc.depthBias(for: "Body_SKIN", isOverlay: false)
+        XCTAssertEqual(bias, 0.015, accuracy: 1e-6, "0.005 * 3.0 = 0.015")
+    }
+
+    func testScaleMultipliesOverlay() {
+        let calc = DepthBiasCalculator(scale: 2.0)
+        let bias = calc.depthBias(for: "Body_SKIN", isOverlay: true)
+        XCTAssertEqual(bias, 0.03, accuracy: 1e-6, "(0.005 + 0.01) * 2.0 = 0.03")
+    }
+
+    func testScaleZeroProducesZero() {
+        let calc = DepthBiasCalculator(scale: 0.0)
+        XCTAssertEqual(calc.depthBias(for: "Highlight", isOverlay: true), 0.0, accuracy: 1e-6)
+    }
+
+    func testNegativeScaleNegates() {
+        let calc = DepthBiasCalculator(scale: -1.0)
+        XCTAssertEqual(calc.depthBias(for: "Body_SKIN", isOverlay: false), -0.005, accuracy: 1e-6)
+    }
+
+    // MARK: - Cache behavior (observable via repeated calls)
+
+    func testRepeatCallsReturnSameValue() {
+        let calc = DepthBiasCalculator()
+        let first = calc.depthBias(for: "Skirt_v2", isOverlay: true)
+        let second = calc.depthBias(for: "Skirt_v2", isOverlay: true)
+        let third = calc.depthBias(for: "Skirt_v2", isOverlay: true)
+        XCTAssertEqual(first, second, accuracy: 0.0,
+                       "Cache hit must return bit-identical value")
+        XCTAssertEqual(second, third, accuracy: 0.0)
+    }
+
+    func testCacheDoesNotConflateDistinctMaterials() {
+        let calc = DepthBiasCalculator()
+        let body = calc.depthBias(for: "Body_SKIN", isOverlay: false)
+        let cloth = calc.depthBias(for: "Skirt", isOverlay: false)
+        XCTAssertNotEqual(body, cloth,
+                          "Distinct material names must produce distinct biases")
+    }
+}

--- a/Tests/VRMMetalKitTests/RetargetingSamplersTests.swift
+++ b/Tests/VRMMetalKitTests/RetargetingSamplersTests.swift
@@ -1,0 +1,245 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+import simd
+@testable import VRMMetalKit
+
+/// Direct unit tests for the VRMA retargeting samplers — the mutation-testing
+/// oracle suite for issue #282.
+///
+/// The samplers return closures; each test builds a single-keyframe STEP
+/// `KeyTrack`, obtains the closure, invokes it, and asserts the output.
+final class RetargetingSamplersTests: XCTestCase {
+
+    // MARK: - Track builders
+
+    /// Single-keyframe STEP quaternion track holding `q`.
+    private func quatTrack(_ q: simd_quatf) -> KeyTrack {
+        KeyTrack(times: [0],
+                 values: [q.imag.x, q.imag.y, q.imag.z, q.real],
+                 path: "rotation",
+                 interpolation: .step,
+                 componentCount: 4)
+    }
+
+    /// Single-keyframe STEP vec3 track holding `v`.
+    private func vec3Track(_ v: SIMD3<Float>) -> KeyTrack {
+        KeyTrack(times: [0],
+                 values: [v.x, v.y, v.z],
+                 path: "translation",
+                 interpolation: .step,
+                 componentCount: 3)
+    }
+
+    /// Asserts two quaternions are equal component-wise (no ± double-cover
+    /// tolerance — the retargeting formula is sign-deterministic for these
+    /// inputs, and allowing ± would let a sign-flip mutant survive).
+    private func assertQuat(_ a: simd_quatf, _ b: simd_quatf,
+                            accuracy: Float = 1e-5,
+                            _ message: String = "",
+                            file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(a.imag.x, b.imag.x, accuracy: accuracy, message, file: file, line: line)
+        XCTAssertEqual(a.imag.y, b.imag.y, accuracy: accuracy, message, file: file, line: line)
+        XCTAssertEqual(a.imag.z, b.imag.z, accuracy: accuracy, message, file: file, line: line)
+        XCTAssertEqual(a.real,   b.real,   accuracy: accuracy, message, file: file, line: line)
+    }
+
+    private func assertVec3(_ a: SIMD3<Float>, _ b: SIMD3<Float>,
+                            accuracy: Float = 1e-5,
+                            _ message: String = "",
+                            file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(a.x, b.x, accuracy: accuracy, message, file: file, line: line)
+        XCTAssertEqual(a.y, b.y, accuracy: accuracy, message, file: file, line: line)
+        XCTAssertEqual(a.z, b.z, accuracy: accuracy, message, file: file, line: line)
+    }
+
+    private let identity = simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
+
+    // MARK: - Rotation sampler: nil model rest (passthrough)
+
+    func testRotationNilModelRestPassesAnimationThrough() {
+        let q = simd_normalize(simd_quatf(angle: .pi / 3, axis: [0, 1, 0]))
+        let sampler = makeRotationSampler(track: quatTrack(q),
+                                          animationRestRotation: identity,
+                                          animationRestWorldRotation: identity,
+                                          modelRestRotation: nil,
+                                          modelRestWorldRotation: nil)
+        XCTAssertNotNil(sampler)
+        assertQuat(sampler!(0), q, "nil model rest must pass the animation rotation through")
+    }
+
+    // MARK: - Rotation sampler: identity rest poses
+
+    func testRotationIdentityRestPosesReturnNormalizedAnimation() {
+        let q = simd_normalize(simd_quatf(angle: .pi / 2, axis: [1, 0, 0]))
+        let sampler = makeRotationSampler(track: quatTrack(q),
+                                          animationRestRotation: identity,
+                                          animationRestWorldRotation: identity,
+                                          modelRestRotation: identity,
+                                          modelRestWorldRotation: identity)
+        XCTAssertNotNil(sampler)
+        assertQuat(sampler!(0), q, "identity rests must reduce to result = animation rotation")
+    }
+
+    // MARK: - Rotation sampler: W_A == W_B collapse
+
+    func testRotationWorldRestsEqualCollapseToDeltaFormula() {
+        let L_A = simd_normalize(simd_quatf(angle: .pi / 6, axis: [0, 1, 0]))
+        let L_B = simd_normalize(simd_quatf(angle: .pi / 2, axis: [0, 1, 0]))
+        let W   = simd_normalize(simd_quatf(angle: .pi / 4, axis: [1, 0, 0]))
+        let A   = simd_normalize(simd_quatf(angle: .pi / 3, axis: [0, 0, 1]))
+
+        let sampler = makeRotationSampler(track: quatTrack(A),
+                                          animationRestRotation: L_A,
+                                          animationRestWorldRotation: W,
+                                          modelRestRotation: L_B,
+                                          modelRestWorldRotation: W)
+        XCTAssertNotNil(sampler)
+        let expected = simd_normalize(L_B * simd_inverse(L_A) * A)
+        assertQuat(sampler!(0), expected,
+                   "W_A == W_B must collapse to result = L_B · L_A⁻¹ · A")
+    }
+
+    // MARK: - Rotation sampler: full W-term change-of-basis
+
+    func testRotationDifferingWorldRestsApplyChangeOfBasis() {
+        let L_A = simd_normalize(simd_quatf(angle: .pi / 6, axis: [0, 1, 0]))
+        let L_B = simd_normalize(simd_quatf(angle: .pi / 2, axis: [0, 1, 0]))
+        let W_A = simd_normalize(simd_quatf(angle: .pi / 4, axis: [1, 0, 0]))
+        let W_B = simd_normalize(simd_quatf(angle: .pi / 3, axis: [0, 0, 1]))
+        let A   = simd_normalize(simd_quatf(angle: .pi / 3, axis: [0, 0, 1]))
+
+        let withChangeOfBasis = makeRotationSampler(track: quatTrack(A),
+                                                    animationRestRotation: L_A,
+                                                    animationRestWorldRotation: W_A,
+                                                    modelRestRotation: L_B,
+                                                    modelRestWorldRotation: W_B)
+        let collapsed = simd_normalize(L_B * simd_inverse(L_A) * A)
+        XCTAssertNotNil(withChangeOfBasis)
+
+        let result = withChangeOfBasis!(0)
+        let delta = abs(result.imag.x - collapsed.imag.x)
+                  + abs(result.imag.y - collapsed.imag.y)
+                  + abs(result.imag.z - collapsed.imag.z)
+                  + abs(result.real   - collapsed.real)
+        XCTAssertGreaterThan(delta, 1e-3,
+            "Differing world rests must apply a change of basis (W terms not dead code)")
+    }
+
+    func testRotationFullWTermFormulaMatchesReference() {
+        let L_A = simd_normalize(simd_quatf(angle: .pi / 6, axis: [0, 1, 0]))
+        let L_B = simd_normalize(simd_quatf(angle: .pi / 2, axis: [0, 1, 0]))
+        let W_A = simd_normalize(simd_quatf(angle: .pi / 4, axis: [1, 0, 0]))
+        let W_B = simd_normalize(simd_quatf(angle: .pi / 3, axis: [0, 0, 1]))
+        let A   = simd_normalize(simd_quatf(angle: .pi / 5, axis: [0, 1, 0]))
+
+        let sampler = makeRotationSampler(track: quatTrack(A),
+                                          animationRestRotation: L_A,
+                                          animationRestWorldRotation: W_A,
+                                          modelRestRotation: L_B,
+                                          modelRestWorldRotation: W_B)
+        XCTAssertNotNil(sampler)
+
+        let normalized = simd_normalize(W_A * simd_inverse(L_A) * A * simd_inverse(W_A))
+        let expected = simd_normalize(L_B * simd_inverse(W_B) * normalized * W_B)
+        assertQuat(sampler!(0), expected,
+                   "full W-term formula must match the documented two-step reference")
+    }
+
+    // MARK: - Translation sampler
+
+    func testTranslationNilModelRestPassesThrough() {
+        let v = SIMD3<Float>(3, -2, 7)
+        let sampler = makeTranslationSampler(track: vec3Track(v),
+                                             animationRestTranslation: SIMD3<Float>(1, 1, 1),
+                                             modelRestTranslation: nil)
+        XCTAssertNotNil(sampler)
+        assertVec3(sampler!(0), v, "nil model rest must pass translation through")
+    }
+
+    func testTranslationAppliesAdditiveDelta() {
+        let sampler = makeTranslationSampler(track: vec3Track(SIMD3<Float>(3, 0, 0)),
+                                             animationRestTranslation: SIMD3<Float>(1, 0, 0),
+                                             modelRestTranslation: SIMD3<Float>(0, 5, 0))
+        XCTAssertNotNil(sampler)
+        assertVec3(sampler!(0), SIMD3<Float>(2, 5, 0),
+                   "translation must apply modelRest + (anim - animRest)")
+    }
+
+    func testTranslationZeroDeltaWhenAnimEqualsRest() {
+        let sampler = makeTranslationSampler(track: vec3Track(SIMD3<Float>(4, 4, 4)),
+                                             animationRestTranslation: SIMD3<Float>(4, 4, 4),
+                                             modelRestTranslation: SIMD3<Float>(9, 8, 7))
+        XCTAssertNotNil(sampler)
+        assertVec3(sampler!(0), SIMD3<Float>(9, 8, 7),
+                   "anim == animRest must yield exactly modelRest")
+    }
+
+    // MARK: - Scale sampler
+
+    func testScaleNilModelRestPassesThrough() {
+        let v = SIMD3<Float>(2, 3, 4)
+        let sampler = makeScaleSampler(track: vec3Track(v),
+                                       animationRestScale: SIMD3<Float>(1, 1, 1),
+                                       modelRestScale: nil)
+        XCTAssertNotNil(sampler)
+        assertVec3(sampler!(0), v, "nil model rest must pass scale through")
+    }
+
+    func testScaleAppliesRatio() {
+        let sampler = makeScaleSampler(track: vec3Track(SIMD3<Float>(4, 4, 4)),
+                                       animationRestScale: SIMD3<Float>(2, 2, 2),
+                                       modelRestScale: SIMD3<Float>(3, 3, 3))
+        XCTAssertNotNil(sampler)
+        assertVec3(sampler!(0), SIMD3<Float>(6, 6, 6),
+                   "scale must apply modelRest * (animScale / animRest)")
+    }
+
+    func testScaleUnitRatioWhenAnimEqualsRest() {
+        let sampler = makeScaleSampler(track: vec3Track(SIMD3<Float>(5, 5, 5)),
+                                       animationRestScale: SIMD3<Float>(5, 5, 5),
+                                       modelRestScale: SIMD3<Float>(2, 3, 4))
+        XCTAssertNotNil(sampler)
+        assertVec3(sampler!(0), SIMD3<Float>(2, 3, 4),
+                   "animScale == animRest must yield exactly modelRest")
+    }
+
+    // MARK: - safeDivide
+
+    func testSafeDivideNormal() {
+        assertVec3(safeDivide(SIMD3<Float>(4, 9, 6), by: SIMD3<Float>(2, 3, 2)),
+                   SIMD3<Float>(2, 3, 3))
+    }
+
+    func testSafeDivideByZeroFallsBackToOne() {
+        assertVec3(safeDivide(SIMD3<Float>(4, 4, 4), by: SIMD3<Float>(0, 0, 0)),
+                   SIMD3<Float>(4, 4, 4),
+                   "zero denominator must fall back to dividing by 1")
+    }
+
+    func testSafeDivideBelowEpsilonFallsBackToOne() {
+        assertVec3(safeDivide(SIMD3<Float>(4, 4, 4), by: SIMD3<Float>(1e-7, 1e-7, 1e-7)),
+                   SIMD3<Float>(4, 4, 4),
+                   "sub-epsilon denominator must fall back to dividing by 1")
+    }
+
+    func testSafeDivideNegativeDenominatorDivides() {
+        assertVec3(safeDivide(SIMD3<Float>(4, 4, 4), by: SIMD3<Float>(-2, -2, -2)),
+                   SIMD3<Float>(-2, -2, -2),
+                   "negative denominator above epsilon must divide normally")
+    }
+}

--- a/docs/mutation-testing/depthbiascalculator-baseline.md
+++ b/docs/mutation-testing/depthbiascalculator-baseline.md
@@ -1,0 +1,96 @@
+# Mutation Testing Baseline — `DepthBiasCalculator`
+
+**Issue:** [#282](https://github.com/arkavo-org/VRMMetalKit/issues/282)
+**Last run:** 2026-05-21
+**Target:** `Sources/GLTFCore/Utilities/DepthBiasCalculator.swift`
+**Oracle suite:** `Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift` (32 tests)
+
+## Tooling
+
+`muter` built from `master` at SHA `99624ecfde93dac3cc1f7a66ac6f7df05611091d` with one local patch
+(see `.muter/patches/v16-schemata-content-fallback.patch`). The patch fixes a v16 bug where
+`SchemataMutationMapping` keyed mutant branches by SwiftSyntax tree-position identity, but
+`ApplySchemata` re-parsed source files, so identity-based lookups always missed and the schemata
+embedding produced no-op binaries (0% killed on any suite).
+
+- Bootstrap: `make muter-bootstrap`
+- Run: `make mutation-test`
+- Report: `.build/mutation-testing/last-run.json` (gitignored)
+
+### Bumping the muter SHA
+
+1. Edit `MUTER_SHA` in `Makefile`.
+2. Delete `.build/tools/muter-src` to force a fresh clone:
+   `rm -rf .build/tools/muter-src`
+3. Run `make muter-bootstrap`. The bootstrap target re-clones, checks out the new SHA, applies the
+   patch (`git apply ../../../.muter/patches/v16-schemata-content-fallback.patch`), and builds.
+4. If the patch fails to apply against the new SHA (`git apply` errors), refresh the patch:
+   - Manually re-apply the content-based fallback in `SchemataMutationMapping.swift`
+   - `cd .build/tools/muter-src && git diff > /tmp/muter-fix.patch`
+   - `cp /tmp/muter-fix.patch .muter/patches/v16-schemata-content-fallback.patch`
+   - Re-run `make muter-bootstrap` to confirm.
+5. If the new SHA itself fails to build under Swift 6.2, fall back to the most recent ancestor
+   that does (`cd .build/tools/muter-src && git log --oneline | head -20`).
+
+## Performance
+
+| Measurement | Time |
+|---|---|
+| Test suite cold run (`swift package clean && swift test --filter DepthBiasCalculatorTests --disable-sandbox`) | 16.6 s |
+| Test suite warm run | 0.58 s |
+| Total mutation-test wall time (8 mutants × baseline + 8 mutant runs) | ~7 s |
+
+The warm-run cost is dominated by SwiftPM resolution overhead; the actual test execution is
+sub-millisecond. Per-mutant wall time is well under the 15-second acceptance gate from the spec.
+
+## Mutation score
+
+| | Count |
+|---|---|
+| Total mutants generated | 8 |
+| Killed | 7 |
+| Survived (kill-pending) | 0 |
+| Survived (equivalent) | 0 |
+| Survived (accepted-gap) | 1 |
+| Timed out (counted as killed) | 0 |
+
+**Score: 7 / (8 − 0) = 87 %** — above the spec's 80 % acceptance bar.
+
+## Survivors
+
+Every surviving mutant in the final run is listed below. No unclassified survivors.
+
+| # | File:line | Operator | Before → After | Classification | Rationale |
+|---|---|---|---|---|---|
+| 1 | `DepthBiasCalculator.swift:141` | `RemoveSideEffects` | `encoder.setDepthBias(bias, slopeScale: slopeScale, clamp: clamp)` → removed | `accepted-gap` | The mutant deletes the call to `MTLRenderCommandEncoder.setDepthBias`. No pure-Swift unit test can observe the absence of that side-effect without a real Metal device and an encoder fixture. Closing this gap requires either (a) wrapping the encoder behind a mockable protocol that a unit test can verify call counts on, or (b) a GPU integration test. Both are out of scope for this PR — file a follow-up if the gap proves to matter. |
+
+## Survivors that were killed in triage
+
+Five new multi-keyword tests were added to the oracle suite after the first muter run revealed
+that single-keyword "alone" tests were caught by the partial-match scan in `computeBias()`. The
+multi-keyword approach exploits the priority chain — the original code returns one value via the
+explicit if-chain (the higher-priority branch), but a mutated code path falls through to a lower-
+priority branch with a different value, which the test catches.
+
+| # | Mutant file:line:col | Mutation | Killing test | Killing input |
+|---|---|---|---|---|
+| 1 | `:165:41` | `cloth \|\| clothing` → `&&` | `testClothBodyReturnsClothing` | `"cloth_body"` |
+| 2 | `:165:76` | `clothing \|\| skirt` → `&&` | `testSkirtBodyReturnsClothing` | `"skirt_body"` |
+| 3 | `:166:41` | `skirt \|\| bottoms` → `&&` | `testSkirtBodyReturnsClothing` | `"skirt_body"` |
+| 4 | `:166:75` | `bottoms \|\| pants` → `&&` | `testBottomsBodyReturnsClothing` | `"bottoms_body"` |
+| 5 | `:178:41` | `mouth \|\| lip` → `&&` | `testMouthEyeReturnsMouth` | `"mouth_eye"` |
+| 6 | `:181:43` | `eyebrow \|\| brow` → `&&` | `testBrowEyeReturnsEyebrow` | `"brow_eye"` |
+| 7 | `:112` | `isOverlay ? overlayBiasOffset : 0.0` → swapped | `testOverlayAddsOffsetToBody` and several others | (various) |
+
+## Follow-ups proposed
+
+- **Encoder side-effect coverage (#TBD):** the surviving `RemoveSideEffects` mutant on
+  `encoder.setDepthBias` could be killed by wrapping the encoder behind a mockable protocol that
+  records `setDepthBias` calls. Worth weighing the design cost against the value — the call is
+  a one-liner that's hard to break silently.
+- **Upstream the muter v16 patch:** the schemata identity-vs-content bug affects every muter user
+  on Swift 6.2; consider sending the fix in `.muter/patches/v16-schemata-content-fallback.patch`
+  upstream to [muter-mutation-testing/muter](https://github.com/muter-mutation-testing/muter).
+- **Expand mutation testing to other GLTFCore files** (per issue #282 scoping): the next
+  candidates by leverage are `Animation/KeyframeSampling.swift`, `Animation/SceneGraph.swift`,
+  then `Builder/GLTFDocumentBuilder.swift`. Each gets its own focused PR.

--- a/docs/mutation-testing/depthbiascalculator-baseline.md
+++ b/docs/mutation-testing/depthbiascalculator-baseline.md
@@ -14,8 +14,8 @@
 embedding produced no-op binaries (0% killed on any suite).
 
 - Bootstrap: `make muter-bootstrap`
-- Run: `make mutation-test`
-- Report: `.build/mutation-testing/last-run.json` (gitignored)
+- Run: `make mutation-test-depth-bias`
+- Report: `.build/mutation-testing/depth-bias.json` (gitignored)
 
 ### Bumping the muter SHA
 

--- a/docs/mutation-testing/retargeting-samplers-baseline.md
+++ b/docs/mutation-testing/retargeting-samplers-baseline.md
@@ -1,0 +1,106 @@
+# Mutation Testing Baseline — VRMA Retargeting Samplers
+
+**Issue:** [#282](https://github.com/arkavo-org/VRMMetalKit/issues/282)
+**Last run:** 2026-05-21
+**Target:** `Sources/VRMMetalKit/Animation/RetargetingSamplers.swift`
+**Oracle suite:** `Tests/VRMMetalKitTests/RetargetingSamplersTests.swift` (15 tests)
+
+## Tooling
+
+`muter` built from `master` at the SHA pinned in `Makefile`, with the local
+`.muter/patches/v16-schemata-content-fallback.patch` applied at bootstrap.
+
+- Bootstrap: `make muter-bootstrap`
+- Run: `make mutation-test-retargeting`
+- Report: `.build/mutation-testing/retargeting-samplers.json` (gitignored)
+
+## Mutation score
+
+| | Count |
+|---|---|
+| Total mutants generated | 6 |
+| Killed | 6 |
+| Survived (equivalent) | 0 |
+| Survived (accepted-gap) | 0 |
+
+**Score (killed / (total − equivalent)): 100 %**
+
+Total wall time: ~15 s. The first run scored 100 % — no triage cycle, no
+survivor-driven tests added.
+
+## Survivors
+
+None.
+
+## Mutant distribution — the result that matters
+
+All 6 mutants muter generated landed inside `safeDivide` (lines 129–131):
+
+| Line | Operator | Before → After |
+|---|---|---|
+| 129 | `RelationalOperatorReplacement` | `abs(denominator.x) > epsilon` → `< epsilon` |
+| 130 | `RelationalOperatorReplacement` | `abs(denominator.y) > epsilon` → `< epsilon` |
+| 131 | `RelationalOperatorReplacement` | `abs(denominator.z) > epsilon` → `< epsilon` |
+| 129 | `SwapTernary` | `… ? denominator.x : 1` → `… ? 1 : denominator.x` |
+| 130 | `SwapTernary` | `… ? denominator.y : 1` → `… ? 1 : denominator.y` |
+| 131 | `SwapTernary` | `… ? denominator.z : 1` → `… ? 1 : denominator.z` |
+
+The three retargeting samplers themselves — `makeRotationSampler` (the W-term
+pose-normalization), `makeTranslationSampler` (additive delta),
+`makeScaleSampler` (ratio) — generated **zero mutants**.
+
+The reason is structural. muter v16 ships exactly four operators:
+`RelationalOperatorReplacement`, `RemoveSideEffects`, `ChangeLogicalConnector`,
+`SwapTernary`. The retargeting math is composed entirely of `simd` quaternion
+and vector operations — `simd_normalize`, `simd_inverse`, quaternion `*`,
+`SIMD3 + / - / *` — with no relational comparisons, no logical connectors, no
+ternaries, and no discardable side-effecting statements. There is nothing in
+that code for muter's operator set to mutate. `safeDivide` is the one part of
+the file with scalar comparisons and ternaries, so it absorbed all 6 mutants.
+
+## Verdict
+
+**Validated, not adopted — lean stop. Do not stand mutation testing up as a
+routine.**
+
+Run #2 was the agreed go/no-go. It did not surface a test-effectiveness blind
+spot the way the `DepthBiasCalculator` POC did — but it surfaced something more
+decision-relevant: a **tooling blind spot**. muter v16's four scalar-oriented
+operators are nearly inert against `simd`-based math. A 100 % score here means
+"every mutant muter could generate was killed," and muter could only generate
+mutants in a 3-line guard helper. The retargeting formulas — the actual reason
+this file was chosen, the math where VMK#269 regressed — received no mutation
+coverage at all.
+
+This recontextualizes the POC. `DepthBiasCalculator` scored well *and* produced
+a meaningful finding because it is scalar control-flow code — string
+`contains`, `||` chains, dictionary fallbacks, `?` defaults — exactly what
+muter's operators target. That made it an unrepresentative first pick.
+VRMMetalKit's core — rendering, animation, physics — is overwhelmingly `simd`
+vector and quaternion math. Expanding mutation testing to further Animation /
+Renderer / physics modules would mostly reproduce this run's near-empty result.
+
+**Recommendation:**
+- Do **not** adopt mutation testing as a routine or CI gate.
+- Keep it as an occasional, opt-in spot-check for **scalar-logic-heavy files**
+  specifically — config/parameter resolvers, validation, state machines,
+  enum-dispatch tables — where muter's operator set has real purchase and the
+  POC demonstrated genuine value.
+- The infrastructure stays in place (`make mutation-test-*`, the patched muter
+  bootstrap, two baseline docs) so a future spot-check is one command away.
+
+### Considered and rejected: extending muter
+
+muter is open-source; one could add an arithmetic-operator-replacement operator
+and a `simd`-aware variant so the retargeting math becomes mutable. That is a
+real project — authoring and maintaining custom muter operators on top of the
+already-carried v16 schemata patch — and the maintenance cost is not justified
+at this project's scale. Recorded here so the option is not silently lost.
+
+## Follow-ups
+
+- Issue #282 can be closed after this run: the technique is validated, the
+  scope question is answered (stop at two targets), and the reasoning is
+  captured in this doc + `depthbiascalculator-baseline.md`.
+- If the muter v16 schemata patch is ever worth upstreaming, that remains a
+  standalone contribution independent of whether VRMMetalKit adopts the tool.

--- a/docs/superpowers/plans/2026-05-21-mutation-testing-gltfcore.md
+++ b/docs/superpowers/plans/2026-05-21-mutation-testing-gltfcore.md
@@ -1,0 +1,697 @@
+# Mutation Testing on `DepthBiasCalculator` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the end-to-end mutation-testing loop on one pure-math GLTFCore utility (`DepthBiasCalculator`), backed by a direct unit suite, with a ≥80% mutation score and every surviving mutant classified in a committed baseline document.
+
+**Architecture:** Install `muter` from a pinned `master` SHA into `.build/tools/`, scaffold a direct unit test suite (`DepthBiasCalculatorTests.swift`) before any mutation run, point muter at only that suite via `.muter/depth-bias.json`, triage survivors, then publish a Markdown baseline.
+
+**Tech Stack:** Swift 6.2, XCTest, [muter](https://github.com/muter-mutation-testing/muter) (built from source at pinned SHA `99624ec`), Make.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-mutation-testing-gltfcore-design.md`
+**Issue:** [#282](https://github.com/arkavo-org/VRMMetalKit/issues/282)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `Makefile` | Modify | Add `MUTER_SHA` var, `$(MUTER_BIN)` rule, `muter-bootstrap`, `mutation-test` targets |
+| `.muter/depth-bias.json` | Create | muter config: target one file, run one test filter |
+| `Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift` | Create | Direct unit oracle suite — written before any muter run |
+| `docs/mutation-testing/depthbiascalculator-baseline.md` | Create | Mutation score, every-survivor classification, measured per-test time, pinned SHA |
+| `.build/tools/muter-src/` | Create (gitignored) | muter source clone, gitignored under existing `.build/` rule |
+| `.build/tools/bin/muter` | Create (gitignored) | symlink to built binary |
+| `.build/mutation-testing/last-run.json` | Create (gitignored) | Deterministic JSON output path for future CI |
+
+No other files modified.
+
+---
+
+## Task 1: Bootstrap `muter` from pinned SHA
+
+**Files:**
+- Modify: `Makefile`
+
+The candidate pinned SHA is `99624ecfde93dac3cc1f7a66ac6f7df05611091d` (muter master @ 2026-04-27, the "fix: Prevent memory exhaustion on large codebases" commit). If this SHA fails to build under Swift 6.2 locally, the implementer chooses the most recent ancestor that does (see Step 4 below).
+
+- [ ] **Step 1: Add Makefile targets.**
+
+Append to `Makefile` (after the existing `gltf-shaders` block, before `clean`):
+
+```makefile
+# Mutation testing (issue #282) — first target: DepthBiasCalculator
+# muter is built from a pinned master SHA into .build/tools/ because the
+# last tagged release (16, 2023) predates Swift 6.2 toolchain changes.
+MUTER_SHA := 99624ecfde93dac3cc1f7a66ac6f7df05611091d
+MUTER_BIN := .build/tools/bin/muter
+
+$(MUTER_BIN):
+	@echo "🔧 Building muter @ $(MUTER_SHA)..."
+	@mkdir -p .build/tools
+	@if [ ! -d .build/tools/muter-src ]; then \
+		git clone https://github.com/muter-mutation-testing/muter.git .build/tools/muter-src; \
+	fi
+	@cd .build/tools/muter-src && git fetch && git checkout $(MUTER_SHA)
+	@cd .build/tools/muter-src && swift build -c release
+	@mkdir -p .build/tools/bin
+	@ln -sf ../muter-src/.build/release/muter $(MUTER_BIN)
+	@echo "✅ muter built: $$(./$(MUTER_BIN) --version 2>/dev/null || echo unknown)"
+
+muter-bootstrap: $(MUTER_BIN)
+	@$(MUTER_BIN) --version
+
+mutation-test: $(MUTER_BIN)
+	@mkdir -p .build/mutation-testing
+	@$(MUTER_BIN) run --configuration .muter/depth-bias.json
+```
+
+Also update `.PHONY` near the top of the file. Find the existing line (it currently includes `shaders shaders-macos shaders-ios shaders-iossim gltf-shaders clean test docs docs-static`) and add `muter-bootstrap mutation-test` at the end:
+
+```makefile
+.PHONY: help shaders shaders-macos shaders-ios shaders-iossim gltf-shaders clean test docs docs-static muter-bootstrap mutation-test
+```
+
+Update the `help:` block to mention the new targets. Find the existing shaders-related help lines and add immediately after:
+
+```makefile
+	@echo "  make muter-bootstrap - Build muter from a pinned SHA into .build/tools/"
+	@echo "  make mutation-test - Run mutation testing against DepthBiasCalculator"
+```
+
+- [ ] **Step 2: Run `make muter-bootstrap` to clone and build muter at the pinned SHA.**
+
+Run:
+
+```bash
+make muter-bootstrap 2>&1 | tail -20
+```
+
+Expected: build completes, `muter --version` prints a version string (likely `0.x.0` or similar; the exact number depends on the SHA's build metadata).
+
+- [ ] **Step 3: If the build fails, fall back to the most recent ancestor that builds.**
+
+If `swift build -c release` inside `.build/tools/muter-src` errors out (e.g., Swift 6.2 macro expansion issues, missing API, dependency conflicts):
+
+1. From inside `.build/tools/muter-src`, run `git log --oneline $(MUTER_SHA) -20` to list the 20 commits preceding the pinned SHA.
+2. Try each prior commit (oldest-first within that window): `git checkout <sha> && swift build -c release`.
+3. On the first commit that builds cleanly, copy its SHA back into `Makefile`'s `MUTER_SHA :=` line.
+4. Re-run `make muter-bootstrap` to confirm the bumped SHA builds via the Makefile path.
+
+If no commit in the 20-commit window builds, STOP and escalate — this is a tooling problem the plan didn't anticipate.
+
+- [ ] **Step 4: Verify the binary works on a no-op invocation.**
+
+Run:
+
+```bash
+.build/tools/bin/muter help 2>&1 | head -20
+```
+
+Expected: muter prints its CLI help banner. If it prints nothing or crashes, the build artifact is bad — STOP and investigate.
+
+- [ ] **Step 5: Commit the Makefile changes.**
+
+```bash
+git add Makefile
+git commit -m "build(mutation-testing): bootstrap muter from pinned SHA (#282)
+
+Adds make muter-bootstrap to build muter from a pinned master SHA into
+.build/tools/, and make mutation-test as the run target. The 2023 tagged
+release (16) predates Swift 6.2 toolchain changes; building from source
+is the only reliable path until muter cuts a new release.
+
+Issue #282
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"
+```
+
+(If the implementer bumped `MUTER_SHA` to an ancestor in Step 3, the commit message body should note the substitution and why.)
+
+---
+
+## Task 2: Write the direct unit test suite
+
+**Files:**
+- Create: `Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift`
+
+The suite is written **before** any mutation run. Tests target the public surface of `DepthBiasCalculator` with oracle pairs (known input → known output). They are not yet survivor-driven; the survivor-driven additions land in Task 5.
+
+- [ ] **Step 1: Create the test file.**
+
+Create `Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift` with:
+
+```swift
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+@testable import GLTFCore
+
+/// Direct unit tests for `DepthBiasCalculator` — the mutation-testing oracle suite.
+///
+/// These tests assert known input/output pairs on the calculator's public
+/// surface so that mutation testing (issue #282) has a meaningful target.
+/// `HipSkirtTests` exercises the calculator only incidentally via the
+/// hip-skirt scenario; muter must not be pointed at it.
+final class DepthBiasCalculatorTests: XCTestCase {
+
+    // MARK: - Construction & constants
+
+    func testDefaultScaleIsOne() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.scale, 1.0)
+    }
+
+    func testExplicitScaleIsRetained() {
+        let calc = DepthBiasCalculator(scale: 2.5)
+        XCTAssertEqual(calc.scale, 2.5)
+    }
+
+    func testSlopeScaleConstant() {
+        XCTAssertEqual(DepthBiasCalculator().slopeScale, 2.0)
+    }
+
+    func testClampConstant() {
+        XCTAssertEqual(DepthBiasCalculator().clamp, 0.1)
+    }
+
+    // MARK: - Exact-match lookups (from baseBiasValues table)
+
+    func testBodySkinExactMatch() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "Body_SKIN", isOverlay: false), 0.005, accuracy: 1e-6)
+    }
+
+    func testFaceExactMatch() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "Face", isOverlay: false), 0.01, accuracy: 1e-6)
+    }
+
+    func testEyeExactMatch() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "Eye", isOverlay: false), 0.03, accuracy: 1e-6)
+    }
+
+    func testHighlightExactMatch() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "Highlight", isOverlay: false), 0.04, accuracy: 1e-6)
+    }
+
+    // MARK: - Priority ordering in computeBias
+
+    func testClothingPriorityBeatsBody() {
+        // "Body_Clothing" — clothing check (Priority 1) must fire before body check (Priority 2).
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "Body_Clothing", isOverlay: false), 0.015, accuracy: 1e-6,
+                       "Material containing both 'body' and 'clothing' must hit the clothing branch first")
+    }
+
+    func testBodyPriorityBeatsFaceAndSkin() {
+        // "Body_Face_Skin" — body (Priority 2) must fire before face (Priority 3) and skin (Priority 4).
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "Body_Face_Skin", isOverlay: false), 0.005, accuracy: 1e-6)
+    }
+
+    func testEyebrowPriorityBeatsEye() {
+        // "Eyebrow" contains "eye", but the eyebrow check fires first.
+        let calc = DepthBiasCalculator()
+        let bias = calc.depthBias(for: "left_eyebrow_inner", isOverlay: false)
+        XCTAssertEqual(bias, 0.025, accuracy: 1e-6,
+                       "Eyebrow-containing names must hit eyebrow (0.025), not eye (0.03)")
+    }
+
+    func testMouthPriorityFires() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "mouth_inner", isOverlay: false), 0.02, accuracy: 1e-6)
+    }
+
+    // MARK: - Case-insensitive substring match
+
+    func testLowercaseInputMatchesBody() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "body_mesh", isOverlay: false), 0.005, accuracy: 1e-6)
+    }
+
+    func testUppercaseInputMatchesBody() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "BODY_MESH", isOverlay: false), 0.005, accuracy: 1e-6)
+    }
+
+    func testMixedCaseInputMatchesClothing() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "MyCloThInG_Material", isOverlay: false), 0.015, accuracy: 1e-6)
+    }
+
+    // MARK: - Default fallback
+
+    func testUnknownMaterialReturnsDefault() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "totally_unknown_material_xyz", isOverlay: false), 0.01, accuracy: 1e-6)
+    }
+
+    func testEmptyStringReturnsDefault() {
+        let calc = DepthBiasCalculator()
+        XCTAssertEqual(calc.depthBias(for: "", isOverlay: false), 0.01, accuracy: 1e-6)
+    }
+
+    // MARK: - Overlay offset
+
+    func testOverlayAddsOffsetToBody() {
+        let calc = DepthBiasCalculator()
+        let base = calc.depthBias(for: "Body_SKIN", isOverlay: false)
+        let overlay = calc.depthBias(for: "Body_SKIN", isOverlay: true)
+        XCTAssertEqual(overlay - base, 0.01, accuracy: 1e-6,
+                       "isOverlay:true must add exactly 0.01 to the base bias")
+    }
+
+    func testOverlayAddsOffsetToDefault() {
+        let calc = DepthBiasCalculator()
+        let base = calc.depthBias(for: "unknown_xyz", isOverlay: false)
+        let overlay = calc.depthBias(for: "unknown_xyz", isOverlay: true)
+        XCTAssertEqual(overlay - base, 0.01, accuracy: 1e-6)
+    }
+
+    // MARK: - Scale multiplication
+
+    func testScaleMultipliesBase() {
+        let calc = DepthBiasCalculator(scale: 3.0)
+        let bias = calc.depthBias(for: "Body_SKIN", isOverlay: false)
+        XCTAssertEqual(bias, 0.015, accuracy: 1e-6, "0.005 * 3.0 = 0.015")
+    }
+
+    func testScaleMultipliesOverlay() {
+        let calc = DepthBiasCalculator(scale: 2.0)
+        let bias = calc.depthBias(for: "Body_SKIN", isOverlay: true)
+        XCTAssertEqual(bias, 0.03, accuracy: 1e-6, "(0.005 + 0.01) * 2.0 = 0.03")
+    }
+
+    func testScaleZeroProducesZero() {
+        let calc = DepthBiasCalculator(scale: 0.0)
+        XCTAssertEqual(calc.depthBias(for: "Highlight", isOverlay: true), 0.0, accuracy: 1e-6)
+    }
+
+    func testNegativeScaleNegates() {
+        let calc = DepthBiasCalculator(scale: -1.0)
+        XCTAssertEqual(calc.depthBias(for: "Body_SKIN", isOverlay: false), -0.005, accuracy: 1e-6)
+    }
+
+    // MARK: - Cache behavior (observable via repeated calls)
+
+    func testRepeatCallsReturnSameValue() {
+        let calc = DepthBiasCalculator()
+        let first = calc.depthBias(for: "Skirt_v2", isOverlay: true)
+        let second = calc.depthBias(for: "Skirt_v2", isOverlay: true)
+        let third = calc.depthBias(for: "Skirt_v2", isOverlay: true)
+        XCTAssertEqual(first, second, accuracy: 0.0,
+                       "Cache hit must return bit-identical value")
+        XCTAssertEqual(second, third, accuracy: 0.0)
+    }
+
+    func testCacheDoesNotConflateDistinctMaterials() {
+        let calc = DepthBiasCalculator()
+        let body = calc.depthBias(for: "Body_SKIN", isOverlay: false)
+        let cloth = calc.depthBias(for: "Skirt", isOverlay: false)
+        XCTAssertNotEqual(body, cloth,
+                          "Distinct material names must produce distinct biases")
+    }
+}
+```
+
+- [ ] **Step 2: Build the test target.**
+
+Run:
+
+```bash
+swift build --target VRMMetalKitTests 2>&1 | tail -10
+```
+
+Expected: build succeeds. The `@testable import GLTFCore` needs the `GLTFCore` module to be visible — it should be, since `VRMMetalKitTests` already imports `GLTFCore`-using helpers via `VRMMetalKit`. If the import fails, add `@testable import VRMMetalKit` as a second line (since `VRMMetalKit` re-exports `GLTFCore` types) — but try `GLTFCore` first.
+
+- [ ] **Step 3: Run the suite and verify all tests pass.**
+
+```bash
+swift test --filter DepthBiasCalculatorTests --disable-sandbox 2>&1 | tail -30
+```
+
+Expected: all ~22 tests pass. If any fail, the test or the calculator has a real bug — STOP and investigate before adding more code.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift
+git commit -m "test(gltfcore): direct unit oracle suite for DepthBiasCalculator (#282)
+
+Adds 22 direct unit tests covering construction, exact-match lookups,
+priority ordering, case-insensitive matching, default fallback, overlay
+offset, scale multiplication, and cache observability. This suite is
+the muter target for issue #282; HipSkirtTests stays as the integration
+suite and is not part of the mutation oracle.
+
+Issue #282
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"
+```
+
+---
+
+## Task 3: Measure per-test-run time before committing to the loop
+
+**Files:** (none modified yet — this is a measurement step that informs Task 4)
+
+- [ ] **Step 1: Cold run.**
+
+```bash
+swift package clean
+time swift test --filter DepthBiasCalculatorTests --disable-sandbox 2>&1 | tail -5
+```
+
+Record the `real` time. Cold time includes full SwiftPM resolution.
+
+- [ ] **Step 2: Warm run.**
+
+Immediately re-run (no `swift package clean` this time):
+
+```bash
+time swift test --filter DepthBiasCalculatorTests --disable-sandbox 2>&1 | tail -5
+```
+
+Record the `real` time. This is the per-mutant cost muter will pay.
+
+- [ ] **Step 3: Acceptance gate.**
+
+- **Warm time ≤ 15 seconds:** proceed to Task 4.
+- **Warm time > 15 seconds:** STOP. Report the timing and pause for direction — the spec defines this as a checkpoint, not a stop-and-give-up. Possible mitigations include reducing operator set, using a smaller filter, or accepting longer runtimes.
+
+Record both times (cold and warm) — they go into the baseline doc in Task 6.
+
+(No commit here; nothing changed.)
+
+---
+
+## Task 4: Write muter configuration
+
+**Files:**
+- Create: `.muter/depth-bias.json`
+
+- [ ] **Step 1: Generate a template via muter init.**
+
+Run:
+
+```bash
+.build/tools/bin/muter init 2>&1 | head -10
+```
+
+This writes a `muter.conf.yml` (or `.muter.conf.yml`) at the repo root. Read that file to learn the exact key names and structure for the muter version you built. Then craft the JSON variant below.
+
+- [ ] **Step 2: Create the JSON config.**
+
+Create `.muter/depth-bias.json` with:
+
+```json
+{
+  "executable": "/usr/bin/env",
+  "arguments": [
+    "swift",
+    "test",
+    "--filter",
+    "DepthBiasCalculatorTests",
+    "--disable-sandbox"
+  ],
+  "mutate": {
+    "filesToMutate": [
+      "Sources/GLTFCore/Utilities/DepthBiasCalculator.swift"
+    ],
+    "operators": ["all"]
+  },
+  "exclude_files": [],
+  "outputPath": ".build/mutation-testing/last-run.json"
+}
+```
+
+**Note on key names:** muter's schema has shifted over time. Adapt the key names to match the `muter init` template you generated in Step 1 — if the schema uses `mutate_files` instead of `mutate.filesToMutate`, or `report` instead of `outputPath`, follow the template. The semantic contents (target file, test command, output path) are what matters.
+
+**Note on `--disable-sandbox`:** this flag is required because the project's tests need filesystem access for fixtures (per `CLAUDE.md` convention); muter additionally needs FS write access to perform source rewrites.
+
+- [ ] **Step 3: Delete the auto-generated template.**
+
+```bash
+rm -f muter.conf.yml .muter.conf.yml
+```
+
+We don't ship the template; the curated `.muter/depth-bias.json` is the single source of truth.
+
+- [ ] **Step 4: Dry-run-validate the config.**
+
+```bash
+.build/tools/bin/muter run --configuration .muter/depth-bias.json --steps 2>&1 | tail -20
+```
+
+If muter has a `--steps`, `--dry-run`, or schema-validation flag (varies by version), use it to confirm the config parses. If no such flag exists in the pinned SHA, skip this step.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add .muter/depth-bias.json
+git commit -m "build(mutation-testing): muter config targeting DepthBiasCalculator (#282)
+
+Mutates Sources/GLTFCore/Utilities/DepthBiasCalculator.swift using
+muter's default operator set. Tests run via swift test --filter
+DepthBiasCalculatorTests --disable-sandbox (sandbox-disabled because
+project tests need FS access for fixtures, and muter needs FS write
+access for source rewrites). JSON output path is deterministic for
+future CI artifact consumption.
+
+Issue #282
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"
+```
+
+---
+
+## Task 5: First muter run + survivor triage
+
+**Files:**
+- Modify: `Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift` (add tests to kill kill-pending survivors)
+
+- [ ] **Step 1: Run muter.**
+
+```bash
+make mutation-test 2>&1 | tee /tmp/muter-first-run.log
+```
+
+Expected: muter parses `DepthBiasCalculator.swift`, generates mutants, runs the unit suite against each, and reports results to stdout + `.build/mutation-testing/last-run.json`. Total wall time should be (warm-test-time × mutant-count); for a 253-LOC file with default operators, expect roughly 30–60 mutants.
+
+Capture and save:
+- Total mutants generated.
+- Killed / survived / equivalent / timeout counts.
+- Overall score `killed / (total - equivalent)`.
+- Wall time.
+
+- [ ] **Step 2: Triage every survivor.**
+
+Open `.build/mutation-testing/last-run.json`. For each surviving mutant, classify it into one of three buckets:
+
+1. **`kill-pending`** — the test suite has a real gap. Write an assertion that distinguishes the mutant. Add it to `DepthBiasCalculatorTests.swift` under a new `// MARK: - Survivor-driven additions` section.
+2. **`equivalent`** — the mutation produces semantically identical behavior under all reachable inputs. Examples: a constant `* 1.0` cast, mutating an unreachable `else` branch, or a default-fallback that's already been hit. Record one-line rationale.
+3. **`accepted-gap`** — a real gap that is deliberately not being closed in this PR (e.g., requires fixture data we don't have, would exercise a code path scheduled for removal). Record rationale and propose a follow-up if appropriate.
+
+- [ ] **Step 3: Re-run muter with the new tests.**
+
+```bash
+make mutation-test 2>&1 | tail -30
+```
+
+Repeat Step 2 if the score is still under 80% and unclassified survivors remain — but only until the score either reaches 80% or every remaining survivor is classified as `equivalent` or `accepted-gap` (i.e., legitimately unclosable in this PR).
+
+If the score plateaus below 80% and the spec's escape hatch applies (inherent equivalent-mutant surface), document why in the baseline doc and stop — do not gold-plate tests to hit a number.
+
+- [ ] **Step 4: Commit the new tests once the score stabilizes.**
+
+```bash
+git add Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift
+git commit -m "test(gltfcore): kill survivors from first DepthBiasCalculator mutation run (#282)
+
+Survivor-driven additions to the oracle suite. <one-line summary of what
+kinds of assertions were added — e.g., 'explicit constant-value checks
+for each priority branch, off-by-one boundary tests on the partial-match
+loop'.>
+
+Issue #282
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"
+```
+
+(Customize the body to reflect the actual additions. Avoid copying the bullet list verbatim.)
+
+---
+
+## Task 6: Write the baseline document
+
+**Files:**
+- Create: `docs/mutation-testing/depthbiascalculator-baseline.md`
+
+- [ ] **Step 1: Create the directory.**
+
+```bash
+mkdir -p docs/mutation-testing
+```
+
+- [ ] **Step 2: Write the baseline doc.**
+
+Create `docs/mutation-testing/depthbiascalculator-baseline.md` with this exact structure (fill in measurements from the actual run):
+
+```markdown
+# Mutation Testing Baseline — `DepthBiasCalculator`
+
+**Issue:** [#282](https://github.com/arkavo-org/VRMMetalKit/issues/282)
+**Last run:** YYYY-MM-DD
+**Target:** `Sources/GLTFCore/Utilities/DepthBiasCalculator.swift`
+**Oracle suite:** `Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift`
+
+## Tooling
+
+- `muter` built from `master` at SHA `<pinned-sha>`.
+- Bootstrap: `make muter-bootstrap`.
+- Run: `make mutation-test`.
+
+### Bumping the muter SHA
+
+1. Edit `MUTER_SHA` in the project `Makefile`.
+2. Delete `.build/tools/muter-src` to force a fresh clone.
+3. Run `make muter-bootstrap`. If the new SHA fails to build, try the most recent ancestor that does (`cd .build/tools/muter-src && git log --oneline`).
+
+## Performance
+
+| Measurement | Time |
+|---|---|
+| Test suite warm run (`swift test --filter DepthBiasCalculatorTests --disable-sandbox`) | _Xs_ |
+| Test suite cold run | _Xs_ |
+| Total mutation-test wall time | _Xm Ys_ |
+
+## Mutation score
+
+| | Count |
+|---|---|
+| Total mutants generated | _N_ |
+| Killed | _N_ |
+| Survived (kill-pending) | _N_ |
+| Survived (equivalent) | _N_ |
+| Survived (accepted-gap) | _N_ |
+| Timed out (counted as killed) | _N_ |
+
+**Score (killed / (total - equivalent)):** _NN%_
+
+## Survivors
+
+Every surviving mutant in the final run is listed here. No unclassified survivors.
+
+| # | File:line | Operator | Before → After | Classification | Rationale |
+|---|---|---|---|---|---|
+| 1 | DepthBiasCalculator.swift:115 | RelationalOperatorReplacement | `+ overlayOffset` → `- overlayOffset` | kill-pending | Closed by testOverlayAddsOffsetToBody |
+| 2 | DepthBiasCalculator.swift:90 | ChangeNumber | `0.01` → `1.0` | equivalent | Unreachable fallback when baseBiasValues lookup succeeds for all tested inputs |
+| ... | ... | ... | ... | ... | ... |
+
+## Follow-ups proposed
+
+(Empty if none. Otherwise: one bullet per follow-up issue with a one-line motivation.)
+```
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add docs/mutation-testing/depthbiascalculator-baseline.md
+git commit -m "docs(mutation-testing): DepthBiasCalculator mutation baseline (#282)
+
+First-target proof-of-concept baseline: score, every-survivor classification,
+performance measurements, and SHA-bump instructions.
+
+Issue #282
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"
+```
+
+---
+
+## Task 7: Push and open PR
+
+**Files:** (none)
+
+- [ ] **Step 1: Confirm with the user before pushing.**
+
+The project convention (see `CLAUDE.md` memory) is to not push without explicit consent. Ask the user; if approved, proceed.
+
+- [ ] **Step 2: Push the branch.**
+
+```bash
+git push -u origin issue/282-mutation-testing
+```
+
+- [ ] **Step 3: Open the PR.**
+
+```bash
+gh pr create --title "feat(testing): mutation testing on DepthBiasCalculator (#282)" --body "$(cat <<'EOF'
+Closes #282
+
+## Summary
+- Bootstraps `muter` from a pinned `master` SHA into `.build/tools/` (the 2023 tagged release predates Swift 6.2).
+- Adds a direct unit oracle suite (`DepthBiasCalculatorTests.swift`) — written before any mutation run so the muter target isn't an integration suite.
+- Ships `.muter/depth-bias.json` configured to mutate only `DepthBiasCalculator.swift`, run only the new unit suite, write JSON to a deterministic path.
+- Produces a baseline document with mutation score, per-survivor classification (kill-pending / equivalent / accepted-gap), and performance measurements.
+- `make muter-bootstrap` and `make mutation-test` reproduce the run locally.
+
+## Out of scope
+- Other GLTFCore files (own follow-ups).
+- CI integration (deferred until cost is understood).
+- Custom operator sets.
+
+## Test plan
+- [x] `make muter-bootstrap` builds muter from the pinned SHA
+- [x] `make mutation-test` produces a non-zero mutation score
+- [x] `swift test --filter DepthBiasCalculatorTests --disable-sandbox` passes
+- [x] Baseline doc classifies every surviving mutant
+- [x] Mutation score ≥80% (or documented escape hatch applies)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Hand the PR URL back to the user.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 (Toolchain, Approach B, bootstrap layout) → Task 1.
+- §2 (Direct unit suite first) → Task 2.
+- §3 (Measure before trust, 15s gate) → Task 3.
+- §4 (muter config, deterministic output path, --disable-sandbox justification) → Task 4.
+- §5 (Baseline doc structure) → Task 6.
+- §6 (Survivor triage workflow) → Task 5.
+- All 5 acceptance criteria mapped: bootstrap+run (Tasks 1, 4) → AC 1; unit suite (Task 2) → AC 2; ≥80% score (Task 5) → AC 3; every-survivor classification (Tasks 5, 6) → AC 4; warm time recorded (Tasks 3, 6) → AC 5.
+- All three risks have mitigation steps: pinned SHA failure (Task 1 Step 3), 80% unreachable (Task 5 Step 3), per-test-run time blow-up (Task 3 Step 3).
+
+**Placeholder scan:** No TBDs. The one templated section is the baseline doc's measurement values (intentional — the implementer fills them in from the actual run, not from a guess). Task 5 Step 4's commit message body has a `<one-line summary>` placeholder, which is also intentional — the implementer summarizes the actual additions.
+
+**Type consistency:** `DepthBiasCalculator`, `DepthBiasCalculatorTests`, `MUTER_SHA`, `MUTER_BIN`, `.muter/depth-bias.json`, `.build/mutation-testing/last-run.json` — names consistent across all tasks.

--- a/docs/superpowers/plans/2026-05-21-mutation-testing-retargeting.md
+++ b/docs/superpowers/plans/2026-05-21-mutation-testing-retargeting.md
@@ -1,0 +1,878 @@
+# Mutation Testing on VRMA Retargeting Samplers — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the three VRMA retargeting samplers into a testable unit, then mutation-test that unit to a ≥80% score — the agreed go/no-go run on whether mutation testing should become a routine.
+
+**Architecture:** Phase 1 is a behavior-preserving refactor — move `makeRotationSampler` / `makeTranslationSampler` / `makeScaleSampler` / `safeDivide` out of the 977-line `VRMAnimationLoader.swift` into a focused `RetargetingSamplers.swift`, promoting shared symbols to `internal`. Phase 2 reuses the DepthBiasCalculator POC's mutation methodology (already-bootstrapped patched muter) on the new file.
+
+**Tech Stack:** Swift 6.2, XCTest, `simd`, muter (already bootstrapped at `.build/tools/bin/muter`), Make.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-mutation-testing-retargeting-design.md`
+**Issue:** [#282](https://github.com/arkavo-org/VRMMetalKit/issues/282)
+**Branch:** `issue/282-mutation-testing` (continues PR #284 — Option C, expanded scope)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `Sources/VRMMetalKit/Animation/RetargetingSamplers.swift` | Create | The three retargeting samplers + `safeDivide`, `internal` |
+| `Sources/VRMMetalKit/Animation/VRMAnimationLoader.swift` | Modify | Delete the moved functions; promote `KeyTrack`/`Interpolation`/`sampleQuaternion`/`sampleVector3` to `internal` |
+| `Tests/VRMMetalKitTests/RetargetingSamplersTests.swift` | Create | Direct oracle suite for the samplers |
+| `.muter/retargeting-samplers.yml` | Create | muter config for the new target |
+| `Makefile` | Modify | Split `mutation-test` into per-target + aggregate |
+| `docs/mutation-testing/depthbiascalculator-baseline.md` | Modify | Update run-command + report-path references after the rename |
+| `docs/mutation-testing/retargeting-samplers-baseline.md` | Create | Score, survivor classification, Verdict |
+
+---
+
+## Task 1: Phase 1 — Extract `RetargetingSamplers.swift`
+
+Behavior-preserving refactor. No logic changes; only moves and visibility promotions.
+
+**Files:**
+- Create: `Sources/VRMMetalKit/Animation/RetargetingSamplers.swift`
+- Modify: `Sources/VRMMetalKit/Animation/VRMAnimationLoader.swift`
+
+- [ ] **Step 1: Create `RetargetingSamplers.swift` with the moved functions.**
+
+Create `Sources/VRMMetalKit/Animation/RetargetingSamplers.swift` with exactly this content. The three sampler functions and `safeDivide` are copied verbatim from `VRMAnimationLoader.swift` with `private func` changed to `func` (module-`internal` by default):
+
+```swift
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import simd
+
+// VRMA rest-pose retargeting samplers.
+//
+// Extracted from VRMAnimationLoader.swift so the retargeting math is an
+// isolated, directly-testable unit (issue #282). VRMAnimationLoader builds
+// `KeyTrack`s from parsed GLB data and calls these to produce per-frame
+// closures.
+//
+// Rest-pose retargeting (VRM 1.0 `how_to_transform_human_pose.md`):
+//   delta  = inverse(animationRestRotation) * animationRotation
+//   result = modelRestRotation * delta
+// with the W-term change-of-basis applied for rigs whose world-rest
+// orientations differ. See makeRotationSampler for the full derivation.
+
+func makeRotationSampler(track: KeyTrack,
+                         animationRestRotation: simd_quatf,
+                         animationRestWorldRotation: simd_quatf,
+                         modelRestRotation: simd_quatf?,
+                         modelRestWorldRotation: simd_quatf?) -> ((Float) -> simd_quatf)? {
+    let L_A = simd_normalize(animationRestRotation)
+    let W_A = simd_normalize(animationRestWorldRotation)
+
+    // Non-humanoid tracks pass nil for model rest — there's no model-
+    // side bone to normalise against, so the animation rotation flows
+    // through unchanged.
+    guard let modelRest = modelRestRotation,
+          let modelWorld = modelRestWorldRotation else {
+        return { t in sampleQuaternion(track, at: t) }
+    }
+    let L_B = simd_normalize(modelRest)
+    let W_B = simd_normalize(modelWorld)
+
+    // VRM 1.0 pose-normalisation (`how_to_transform_human_pose.md`):
+    //
+    //   Normalized       = W_A · L_A⁻¹ · A.LocalRotation · W_A⁻¹
+    //   B.LocalRotation  = L_B · W_B⁻¹ · Normalized · W_B
+    //
+    // Combined: B = L_B · W_B⁻¹ · W_A · L_A⁻¹ · A · W_A⁻¹ · W_B
+    //
+    // For two rigs that share the same world-rest orientation
+    // (`W_A == W_B`), the W terms cancel and the formula collapses to
+    // `B = L_B · L_A⁻¹ · A` — the previous "delta retargeting" formula.
+    // For VRMAs authored on a different rest pose (e.g. arms-forward
+    // when the model is T-pose) the W terms perform the change-of-
+    // basis that aligns the animation's world frame with the model's.
+    // VMK#269 was the regression where the W terms were missing.
+    let invL_A = simd_inverse(L_A)
+    let invW_A = simd_inverse(W_A)
+    let invW_B = simd_inverse(W_B)
+    return { t in
+        let A = sampleQuaternion(track, at: t)
+        let normalized = simd_normalize(W_A * invL_A * A * invW_A)
+        let result = simd_normalize(L_B * invW_B * normalized * W_B)
+        return result
+    }
+}
+
+// Translation Retargeting with Delta-Based Alignment
+//
+// ROOT MOTION POLICY:
+// -------------------
+// Translation deltas (including hips XYZ) are applied in LOCAL humanoid space.
+// This means hips translation from the animation moves the character relative to
+// its own coordinate frame, not the scene/world.
+//
+// Current Behavior:
+//   • Hips XZ translation = character-relative horizontal movement (walk cycles, shifts)
+//   • Hips Y translation = vertical movement (crouch, jump, body bounce)
+//   • All deltas preserve animation intent while adapting to different skeleton proportions
+//
+// For Scene Locomotion (Future):
+//   If you need the character to move through the world based on animation:
+//   1. Extract hips XZ deltas separately (before applying to bone)
+//   2. Accumulate as "root motion" vector
+//   3. Apply to character's scene transform (not skeleton)
+//   4. Optionally zero out the hips XZ in the skeleton to prevent "double movement"
+//
+// See also: AnimationPlayer.update() for frame-by-frame sampling
+//
+func makeTranslationSampler(track: KeyTrack,
+                            animationRestTranslation: SIMD3<Float>,
+                            modelRestTranslation: SIMD3<Float>?) -> ((Float) -> SIMD3<Float>)? {
+    guard let modelRest = modelRestTranslation else {
+        return { t in sampleVector3(track, at: t) }
+    }
+
+    return { t in
+        let animTranslation = sampleVector3(track, at: t)
+        let delta = animTranslation - animationRestTranslation
+        return modelRest + delta
+    }
+}
+
+func makeScaleSampler(track: KeyTrack,
+                      animationRestScale: SIMD3<Float>,
+                      modelRestScale: SIMD3<Float>?) -> ((Float) -> SIMD3<Float>)? {
+    guard let modelRest = modelRestScale else {
+        return { t in sampleVector3(track, at: t) }
+    }
+
+    return { t in
+        let animScale = sampleVector3(track, at: t)
+        let ratio = safeDivide(animScale, by: animationRestScale)
+        return modelRest * ratio
+    }
+}
+
+func safeDivide(_ numerator: SIMD3<Float>, by denominator: SIMD3<Float>) -> SIMD3<Float> {
+    let epsilon: Float = 1e-6
+    return SIMD3<Float>(
+        numerator.x / (abs(denominator.x) > epsilon ? denominator.x : 1),
+        numerator.y / (abs(denominator.y) > epsilon ? denominator.y : 1),
+        numerator.z / (abs(denominator.z) > epsilon ? denominator.z : 1)
+    )
+}
+```
+
+- [ ] **Step 2: Delete the moved functions from `VRMAnimationLoader.swift`.**
+
+In `Sources/VRMMetalKit/Animation/VRMAnimationLoader.swift`, delete these four declarations entirely (they now live in `RetargetingSamplers.swift`):
+
+1. `private func makeRotationSampler(track: KeyTrack, ...)` — the whole function.
+2. The `// Translation Retargeting with Delta-Based Alignment` … `// See also: AnimationPlayer.update()` comment block **and** the `private func makeTranslationSampler(...)` it documents — delete the comment block too, it moved with the function.
+3. `private func makeScaleSampler(track: KeyTrack, ...)` — the whole function.
+4. `private func safeDivide(_ numerator: SIMD3<Float>, by denominator: SIMD3<Float>) -> SIMD3<Float>` — the whole function.
+
+Do NOT delete `makeExpressionWeightSampler` — it stays.
+
+- [ ] **Step 3: Promote shared symbols to `internal` in `VRMAnimationLoader.swift`.**
+
+The moved functions and the upcoming test reference four symbols that are currently `private`. Change each (the symbols stay in `VRMAnimationLoader.swift`):
+
+- `private struct KeyTrack {` → `struct KeyTrack {`
+- `private enum Interpolation: String {` → `enum Interpolation: String {` (required: `KeyTrack.interpolation` is of this type, so an `internal` `KeyTrack` cannot expose a `private` `Interpolation`)
+- `private func sampleQuaternion(_ track: KeyTrack, at time: Float) -> simd_quatf {` → `func sampleQuaternion(_ track: KeyTrack, at time: Float) -> simd_quatf {`
+- `private func sampleVector3(_ track: KeyTrack, at time: Float) -> SIMD3<Float> {` → `func sampleVector3(_ track: KeyTrack, at time: Float) -> SIMD3<Float> {`
+
+Leave `private extension Interpolation { ... asGLTFCore ... }` and `makeExpressionWeightSampler` as `private` — neither crosses the file boundary.
+
+- [ ] **Step 4: Build.**
+
+Run:
+```bash
+swift build 2>&1 | tail -10
+```
+Expected: `Build complete!`. If you get "X is inaccessible due to 'private' protection level", a symbol in Step 3 was missed — promote it. If you get "invalid redeclaration", a function in Step 2 wasn't fully deleted.
+
+- [ ] **Step 5: Run the full test suite to confirm zero behavior change.**
+
+Run:
+```bash
+swift test --parallel --num-workers 14 -j 16 --disable-sandbox 2>&1 | tail -25
+```
+Expected: the same pass/fail set as before this task — in particular every animation/VRMA retargeting test still passes. The known-pre-existing SpringBone failures (4, unrelated to this work) may appear; anything *newly* failing means the extraction changed behavior — STOP and diagnose.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add Sources/VRMMetalKit/Animation/RetargetingSamplers.swift Sources/VRMMetalKit/Animation/VRMAnimationLoader.swift
+git commit -m "refactor(animation): extract RetargetingSamplers from VRMAnimationLoader (#282)
+
+Move makeRotationSampler / makeTranslationSampler / makeScaleSampler and
+their safeDivide helper into a focused RetargetingSamplers.swift so the
+VRMA retargeting math is an isolated, directly-testable unit. KeyTrack,
+Interpolation, sampleQuaternion and sampleVector3 are promoted private to
+internal so the new file (and tests) can reach them. No behavior change.
+
+Issue #282
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"
+```
+
+---
+
+## Task 2: Phase 2 — Write the oracle suite
+
+**Files:**
+- Create: `Tests/VRMMetalKitTests/RetargetingSamplersTests.swift`
+
+Written before any mutation run. The samplers are `VRMMetalKit` code, so `@testable import VRMMetalKit` reaches the now-`internal` functions and `KeyTrack`.
+
+- [ ] **Step 1: Create the test file.**
+
+Create `Tests/VRMMetalKitTests/RetargetingSamplersTests.swift` with exactly this content:
+
+```swift
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+import simd
+@testable import VRMMetalKit
+
+/// Direct unit tests for the VRMA retargeting samplers — the mutation-testing
+/// oracle suite for issue #282.
+///
+/// The samplers return closures; each test builds a single-keyframe STEP
+/// `KeyTrack`, obtains the closure, invokes it, and asserts the output.
+final class RetargetingSamplersTests: XCTestCase {
+
+    // MARK: - Track builders
+
+    /// Single-keyframe STEP quaternion track holding `q`.
+    private func quatTrack(_ q: simd_quatf) -> KeyTrack {
+        KeyTrack(times: [0],
+                 values: [q.imag.x, q.imag.y, q.imag.z, q.real],
+                 path: "rotation",
+                 interpolation: .step,
+                 componentCount: 4)
+    }
+
+    /// Single-keyframe STEP vec3 track holding `v`.
+    private func vec3Track(_ v: SIMD3<Float>) -> KeyTrack {
+        KeyTrack(times: [0],
+                 values: [v.x, v.y, v.z],
+                 path: "translation",
+                 interpolation: .step,
+                 componentCount: 3)
+    }
+
+    /// Asserts two quaternions are equal component-wise (no ± double-cover
+    /// tolerance — the retargeting formula is sign-deterministic for these
+    /// inputs, and allowing ± would let a sign-flip mutant survive).
+    private func assertQuat(_ a: simd_quatf, _ b: simd_quatf,
+                            accuracy: Float = 1e-5,
+                            _ message: String = "",
+                            file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(a.imag.x, b.imag.x, accuracy: accuracy, message, file: file, line: line)
+        XCTAssertEqual(a.imag.y, b.imag.y, accuracy: accuracy, message, file: file, line: line)
+        XCTAssertEqual(a.imag.z, b.imag.z, accuracy: accuracy, message, file: file, line: line)
+        XCTAssertEqual(a.real,   b.real,   accuracy: accuracy, message, file: file, line: line)
+    }
+
+    private func assertVec3(_ a: SIMD3<Float>, _ b: SIMD3<Float>,
+                            accuracy: Float = 1e-5,
+                            _ message: String = "",
+                            file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(a.x, b.x, accuracy: accuracy, message, file: file, line: line)
+        XCTAssertEqual(a.y, b.y, accuracy: accuracy, message, file: file, line: line)
+        XCTAssertEqual(a.z, b.z, accuracy: accuracy, message, file: file, line: line)
+    }
+
+    private let identity = simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
+
+    // MARK: - Rotation sampler: nil model rest (passthrough)
+
+    func testRotationNilModelRestPassesAnimationThrough() {
+        // nil model rest → closure returns sampleQuaternion(track) unmodified.
+        let q = simd_normalize(simd_quatf(angle: .pi / 3, axis: [0, 1, 0]))
+        let sampler = makeRotationSampler(track: quatTrack(q),
+                                          animationRestRotation: identity,
+                                          animationRestWorldRotation: identity,
+                                          modelRestRotation: nil,
+                                          modelRestWorldRotation: nil)
+        XCTAssertNotNil(sampler)
+        assertQuat(sampler!(0), q, "nil model rest must pass the animation rotation through")
+    }
+
+    // MARK: - Rotation sampler: identity rest poses
+
+    func testRotationIdentityRestPosesReturnNormalizedAnimation() {
+        // All rests identity → result = normalize(A). A is already unit, so
+        // result == A.
+        let q = simd_normalize(simd_quatf(angle: .pi / 2, axis: [1, 0, 0]))
+        let sampler = makeRotationSampler(track: quatTrack(q),
+                                          animationRestRotation: identity,
+                                          animationRestWorldRotation: identity,
+                                          modelRestRotation: identity,
+                                          modelRestWorldRotation: identity)
+        XCTAssertNotNil(sampler)
+        assertQuat(sampler!(0), q, "identity rests must reduce to result = animation rotation")
+    }
+
+    // MARK: - Rotation sampler: W_A == W_B collapse
+
+    func testRotationWorldRestsEqualCollapseToDeltaFormula() {
+        // When W_A == W_B the W terms cancel: result = L_B · L_A⁻¹ · A.
+        let L_A = simd_normalize(simd_quatf(angle: .pi / 6, axis: [0, 1, 0]))
+        let L_B = simd_normalize(simd_quatf(angle: .pi / 2, axis: [0, 1, 0]))
+        let W   = simd_normalize(simd_quatf(angle: .pi / 4, axis: [1, 0, 0]))
+        let A   = simd_normalize(simd_quatf(angle: .pi / 3, axis: [0, 0, 1]))
+
+        let sampler = makeRotationSampler(track: quatTrack(A),
+                                          animationRestRotation: L_A,
+                                          animationRestWorldRotation: W,
+                                          modelRestRotation: L_B,
+                                          modelRestWorldRotation: W)
+        XCTAssertNotNil(sampler)
+        let expected = simd_normalize(L_B * simd_inverse(L_A) * A)
+        assertQuat(sampler!(0), expected,
+                   "W_A == W_B must collapse to result = L_B · L_A⁻¹ · A")
+    }
+
+    // MARK: - Rotation sampler: full W-term change-of-basis
+
+    func testRotationDifferingWorldRestsApplyChangeOfBasis() {
+        // W_A != W_B: the W terms perform a real change of basis, so the
+        // result must differ from the W_A==W_B collapsed value. This pins
+        // that the W terms are not dead code (the VMK#269 regression).
+        let L_A = simd_normalize(simd_quatf(angle: .pi / 6, axis: [0, 1, 0]))
+        let L_B = simd_normalize(simd_quatf(angle: .pi / 2, axis: [0, 1, 0]))
+        let W_A = simd_normalize(simd_quatf(angle: .pi / 4, axis: [1, 0, 0]))
+        let W_B = simd_normalize(simd_quatf(angle: .pi / 3, axis: [0, 0, 1]))
+        let A   = simd_normalize(simd_quatf(angle: .pi / 3, axis: [0, 0, 1]))
+
+        let withChangeOfBasis = makeRotationSampler(track: quatTrack(A),
+                                                    animationRestRotation: L_A,
+                                                    animationRestWorldRotation: W_A,
+                                                    modelRestRotation: L_B,
+                                                    modelRestWorldRotation: W_B)
+        let collapsed = simd_normalize(L_B * simd_inverse(L_A) * A)
+        XCTAssertNotNil(withChangeOfBasis)
+
+        let result = withChangeOfBasis!(0)
+        let delta = abs(result.imag.x - collapsed.imag.x)
+                  + abs(result.imag.y - collapsed.imag.y)
+                  + abs(result.imag.z - collapsed.imag.z)
+                  + abs(result.real   - collapsed.real)
+        XCTAssertGreaterThan(delta, 1e-3,
+            "Differing world rests must apply a change of basis (W terms not dead code)")
+    }
+
+    func testRotationFullWTermFormulaMatchesReference() {
+        // Exact regression pin: independently recompute the documented
+        // two-step formula and assert the sampler matches it.
+        let L_A = simd_normalize(simd_quatf(angle: .pi / 6, axis: [0, 1, 0]))
+        let L_B = simd_normalize(simd_quatf(angle: .pi / 2, axis: [0, 1, 0]))
+        let W_A = simd_normalize(simd_quatf(angle: .pi / 4, axis: [1, 0, 0]))
+        let W_B = simd_normalize(simd_quatf(angle: .pi / 3, axis: [0, 0, 1]))
+        let A   = simd_normalize(simd_quatf(angle: .pi / 5, axis: [0, 1, 0]))
+
+        let sampler = makeRotationSampler(track: quatTrack(A),
+                                          animationRestRotation: L_A,
+                                          animationRestWorldRotation: W_A,
+                                          modelRestRotation: L_B,
+                                          modelRestWorldRotation: W_B)
+        XCTAssertNotNil(sampler)
+
+        // Normalized = W_A · L_A⁻¹ · A · W_A⁻¹ ; result = L_B · W_B⁻¹ · Normalized · W_B
+        let normalized = simd_normalize(W_A * simd_inverse(L_A) * A * simd_inverse(W_A))
+        let expected = simd_normalize(L_B * simd_inverse(W_B) * normalized * W_B)
+        assertQuat(sampler!(0), expected,
+                   "full W-term formula must match the documented two-step reference")
+    }
+
+    // MARK: - Translation sampler
+
+    func testTranslationNilModelRestPassesThrough() {
+        let v = SIMD3<Float>(3, -2, 7)
+        let sampler = makeTranslationSampler(track: vec3Track(v),
+                                             animationRestTranslation: SIMD3<Float>(1, 1, 1),
+                                             modelRestTranslation: nil)
+        XCTAssertNotNil(sampler)
+        assertVec3(sampler!(0), v, "nil model rest must pass translation through")
+    }
+
+    func testTranslationAppliesAdditiveDelta() {
+        // result = modelRest + (anim - animRest)
+        let sampler = makeTranslationSampler(track: vec3Track(SIMD3<Float>(3, 0, 0)),
+                                             animationRestTranslation: SIMD3<Float>(1, 0, 0),
+                                             modelRestTranslation: SIMD3<Float>(0, 5, 0))
+        XCTAssertNotNil(sampler)
+        // (0,5,0) + ((3,0,0) - (1,0,0)) = (2,5,0)
+        assertVec3(sampler!(0), SIMD3<Float>(2, 5, 0),
+                   "translation must apply modelRest + (anim - animRest)")
+    }
+
+    func testTranslationZeroDeltaWhenAnimEqualsRest() {
+        let sampler = makeTranslationSampler(track: vec3Track(SIMD3<Float>(4, 4, 4)),
+                                             animationRestTranslation: SIMD3<Float>(4, 4, 4),
+                                             modelRestTranslation: SIMD3<Float>(9, 8, 7))
+        XCTAssertNotNil(sampler)
+        assertVec3(sampler!(0), SIMD3<Float>(9, 8, 7),
+                   "anim == animRest must yield exactly modelRest")
+    }
+
+    // MARK: - Scale sampler
+
+    func testScaleNilModelRestPassesThrough() {
+        let v = SIMD3<Float>(2, 3, 4)
+        let sampler = makeScaleSampler(track: vec3Track(v),
+                                       animationRestScale: SIMD3<Float>(1, 1, 1),
+                                       modelRestScale: nil)
+        XCTAssertNotNil(sampler)
+        assertVec3(sampler!(0), v, "nil model rest must pass scale through")
+    }
+
+    func testScaleAppliesRatio() {
+        // result = modelRest * (animScale / animRest)
+        let sampler = makeScaleSampler(track: vec3Track(SIMD3<Float>(4, 4, 4)),
+                                       animationRestScale: SIMD3<Float>(2, 2, 2),
+                                       modelRestScale: SIMD3<Float>(3, 3, 3))
+        XCTAssertNotNil(sampler)
+        // (3,3,3) * ((4,4,4)/(2,2,2)) = (3,3,3) * (2,2,2) = (6,6,6)
+        assertVec3(sampler!(0), SIMD3<Float>(6, 6, 6),
+                   "scale must apply modelRest * (animScale / animRest)")
+    }
+
+    func testScaleUnitRatioWhenAnimEqualsRest() {
+        let sampler = makeScaleSampler(track: vec3Track(SIMD3<Float>(5, 5, 5)),
+                                       animationRestScale: SIMD3<Float>(5, 5, 5),
+                                       modelRestScale: SIMD3<Float>(2, 3, 4))
+        XCTAssertNotNil(sampler)
+        assertVec3(sampler!(0), SIMD3<Float>(2, 3, 4),
+                   "animScale == animRest must yield exactly modelRest")
+    }
+
+    // MARK: - safeDivide
+
+    func testSafeDivideNormal() {
+        assertVec3(safeDivide(SIMD3<Float>(4, 9, 6), by: SIMD3<Float>(2, 3, 2)),
+                   SIMD3<Float>(2, 3, 3))
+    }
+
+    func testSafeDivideByZeroFallsBackToOne() {
+        // |0| is not > epsilon → divide by 1 → numerator unchanged.
+        assertVec3(safeDivide(SIMD3<Float>(4, 4, 4), by: SIMD3<Float>(0, 0, 0)),
+                   SIMD3<Float>(4, 4, 4),
+                   "zero denominator must fall back to dividing by 1")
+    }
+
+    func testSafeDivideBelowEpsilonFallsBackToOne() {
+        // 1e-7 < 1e-6 epsilon → divide by 1.
+        assertVec3(safeDivide(SIMD3<Float>(4, 4, 4), by: SIMD3<Float>(1e-7, 1e-7, 1e-7)),
+                   SIMD3<Float>(4, 4, 4),
+                   "sub-epsilon denominator must fall back to dividing by 1")
+    }
+
+    func testSafeDivideNegativeDenominatorDivides() {
+        // |-2| > epsilon → real division, sign preserved.
+        assertVec3(safeDivide(SIMD3<Float>(4, 4, 4), by: SIMD3<Float>(-2, -2, -2)),
+                   SIMD3<Float>(-2, -2, -2),
+                   "negative denominator above epsilon must divide normally")
+    }
+}
+```
+
+- [ ] **Step 2: Build the test target.**
+
+Run:
+```bash
+swift build 2>&1 | tail -8
+```
+Expected: build succeeds. A "cannot find 'KeyTrack' / 'makeRotationSampler' in scope" error means a Task 1 Step 3 visibility promotion was missed.
+
+- [ ] **Step 3: Run the suite; all tests must pass on the unmutated source.**
+
+Run:
+```bash
+swift test --filter RetargetingSamplersTests --disable-sandbox 2>&1 | tail -20
+```
+Expected: 15 tests pass. If a test fails, the assertion's expected value is wrong (recheck the hand-computation) — fix the test. Do NOT change `RetargetingSamplers.swift`.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add Tests/VRMMetalKitTests/RetargetingSamplersTests.swift
+git commit -m "test(animation): direct oracle suite for RetargetingSamplers (#282)
+
+15 direct unit tests covering all three retargeting samplers and
+safeDivide: nil-model-rest passthrough, identity-rest collapse, the
+W_A==W_B delta-formula collapse, the full W-term change-of-basis, and
+additive/ratio/edge-case behavior. The muter target for issue #282's
+second mutation run.
+
+Issue #282
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"
+```
+
+---
+
+## Task 3: muter configuration
+
+**Files:**
+- Create: `.muter/retargeting-samplers.yml`
+
+- [ ] **Step 1: Create the config.**
+
+Create `.muter/retargeting-samplers.yml` mirroring the existing `.muter/depth-bias.yml` schema (muter v16: `executable`, `arguments`, `exclude`, `excludeCalls`, `coverageThreshold` — file scoping/format/output are CLI flags, set in the Makefile):
+
+```yaml
+executable: /usr/bin/swift
+arguments:
+- test
+- --filter
+- RetargetingSamplersTests
+- --disable-sandbox
+exclude: []
+excludeCalls: []
+coverageThreshold: 0
+```
+
+(`--disable-sandbox` is required: the project's tests need filesystem access for fixtures, and muter needs FS write access for source rewrites.)
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add .muter/retargeting-samplers.yml
+git commit -m "build(mutation-testing): muter config for RetargetingSamplers (#282)
+
+Issue #282
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"
+```
+
+---
+
+## Task 4: Restructure the Makefile mutation targets
+
+**Files:**
+- Modify: `Makefile`
+- Modify: `docs/mutation-testing/depthbiascalculator-baseline.md`
+
+- [ ] **Step 1: Replace the single `mutation-test` target with per-target + aggregate.**
+
+In `Makefile`, find the current target:
+
+```makefile
+mutation-test: $(MUTER_BIN)
+	@mkdir -p .build/mutation-testing
+	@$(MUTER_BIN) run \
+		--configuration .muter/depth-bias.yml \
+		--files-to-mutate Sources/GLTFCore/Utilities/DepthBiasCalculator.swift \
+		--skip-coverage \
+		--format json \
+		--output .build/mutation-testing/last-run.json
+```
+
+Replace it with:
+
+```makefile
+mutation-test: mutation-test-depth-bias mutation-test-retargeting
+	@echo "✅ All mutation-test targets complete"
+
+mutation-test-depth-bias: $(MUTER_BIN)
+	@mkdir -p .build/mutation-testing
+	@$(MUTER_BIN) run \
+		--configuration .muter/depth-bias.yml \
+		--files-to-mutate Sources/GLTFCore/Utilities/DepthBiasCalculator.swift \
+		--skip-coverage \
+		--format json \
+		--output .build/mutation-testing/depth-bias.json
+
+mutation-test-retargeting: $(MUTER_BIN)
+	@mkdir -p .build/mutation-testing
+	@$(MUTER_BIN) run \
+		--configuration .muter/retargeting-samplers.yml \
+		--files-to-mutate Sources/VRMMetalKit/Animation/RetargetingSamplers.swift \
+		--skip-coverage \
+		--format json \
+		--output .build/mutation-testing/retargeting-samplers.json
+```
+
+- [ ] **Step 2: Update `.PHONY` and `help:`.**
+
+Find the `.PHONY` line and replace `mutation-test` with `mutation-test mutation-test-depth-bias mutation-test-retargeting`:
+
+```makefile
+.PHONY: help shaders shaders-macos shaders-ios shaders-iossim gltf-shaders clean test docs docs-static muter-bootstrap mutation-test mutation-test-depth-bias mutation-test-retargeting
+```
+
+In the `help:` block, replace the single `make mutation-test` line with:
+
+```makefile
+	@echo "  make mutation-test - Run all mutation-test targets"
+	@echo "  make mutation-test-depth-bias - Mutation-test DepthBiasCalculator"
+	@echo "  make mutation-test-retargeting - Mutation-test RetargetingSamplers"
+```
+
+- [ ] **Step 3: Update the DepthBiasCalculator baseline doc references.**
+
+In `docs/mutation-testing/depthbiascalculator-baseline.md`:
+- Change the `Run: \`make mutation-test\`` line under the Tooling section to `Run: \`make mutation-test-depth-bias\``.
+- Change the report path `.build/mutation-testing/last-run.json` to `.build/mutation-testing/depth-bias.json`.
+
+- [ ] **Step 4: Verify the targets resolve.**
+
+Run:
+```bash
+make -n mutation-test-retargeting
+```
+Expected: prints the `muter run ...` command for the retargeting target without executing the build (dry-run). Confirms the Makefile parses and the target exists.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add Makefile docs/mutation-testing/depthbiascalculator-baseline.md
+git commit -m "build(mutation-testing): split mutation-test into per-target + aggregate (#282)
+
+mutation-test becomes an aggregate of mutation-test-depth-bias and
+mutation-test-retargeting, each writing its own JSON artifact. Mirrors
+the shaders aggregate pattern. DepthBiasCalculator baseline doc updated
+for the renamed target and report path.
+
+Issue #282
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"
+```
+
+---
+
+## Task 5: First mutation run + survivor triage
+
+**Files:**
+- Modify: `Tests/VRMMetalKitTests/RetargetingSamplersTests.swift` (survivor-driven additions)
+
+- [ ] **Step 1: First muter run.**
+
+Run:
+```bash
+make mutation-test-retargeting 2>&1 | tee /tmp/muter-retargeting-run.log
+```
+Expected: muter parses `RetargetingSamplers.swift`, generates mutants, runs `RetargetingSamplersTests` against each, writes `.build/mutation-testing/retargeting-samplers.json`. Capture: total mutants, killed/survived counts, score, wall time.
+
+If muter crashes or produces zero mutants, STOP and report BLOCKED with the error.
+
+- [ ] **Step 2: Triage every survivor.**
+
+Inspect `.build/mutation-testing/retargeting-samplers.json`. For each surviving mutant, classify:
+- **`kill-pending`** — real test gap; add a distinguishing assertion to `RetargetingSamplersTests.swift` under a new `// MARK: - Survivor-driven additions` section.
+- **`equivalent`** — semantically identical under all reachable inputs. Expected here: mutations inside or around `simd_normalize` of an already-unit quaternion, or `simd_inverse` that coincides with the conjugate for unit quaternions. Record a one-line rationale.
+- **`accepted-gap`** — real gap deliberately deferred; record rationale.
+
+- [ ] **Step 3: Add tests to kill `kill-pending` survivors.**
+
+For each `kill-pending` mutant, write a test whose expected value is hand-computed (not formula-duplicated, where possible) so it diverges on the mutated code. Re-use the `quatTrack` / `vec3Track` / `assertQuat` / `assertVec3` helpers already in the file.
+
+- [ ] **Step 4: Verify new tests pass on unmutated source.**
+
+Run:
+```bash
+swift test --filter RetargetingSamplersTests --disable-sandbox 2>&1 | tail -15
+```
+All tests must pass before re-running muter.
+
+- [ ] **Step 5: Re-run muter.**
+
+```bash
+make mutation-test-retargeting 2>&1 | tail -25
+```
+Repeat Steps 2-5 until the score is ≥80% **or** every remaining survivor is classified `equivalent` / `accepted-gap`.
+
+**Hard cap:** after 3 full cycles, STOP and report DONE_WITH_CONCERNS with the current score, full survivor list, and classifications. Do not loop indefinitely.
+
+If the score plateaus below 80% with all survivors classified `equivalent` / `accepted-gap`, that is the spec's escape hatch — record it; it is not a failure.
+
+- [ ] **Step 6: Save baseline data for Task 6.**
+
+Write the final figures to `/tmp/retargeting-baseline-data.txt`:
+```
+SCORE
+total_mutants: <N>
+killed: <N>
+survived_equivalent: <N>
+survived_accepted_gap: <N>
+final_score_percent: <NN>
+wall_time: <mm:ss>
+
+SURVIVORS
+<file:line> | <operator> | <before> -> <after> | <classification> | <rationale>
+...
+```
+
+- [ ] **Step 7: Commit the test additions.**
+
+```bash
+git add Tests/VRMMetalKitTests/RetargetingSamplersTests.swift
+git commit -m "test(animation): kill survivors from RetargetingSamplers mutation run (#282)
+
+Survivor-driven additions. <one-line summary of what was added>.
+Mutation score: <X>% -> <Y>%.
+
+Issue #282
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"
+```
+(Customize the body to the actual additions. If Step 1's run already scored ≥80% with no `kill-pending` survivors, skip this commit — there is nothing to add.)
+
+---
+
+## Task 6: Write the baseline doc with Verdict
+
+**Files:**
+- Create: `docs/mutation-testing/retargeting-samplers-baseline.md`
+
+- [ ] **Step 1: Write the baseline doc.**
+
+Create `docs/mutation-testing/retargeting-samplers-baseline.md`, filling every `<…>` from `/tmp/retargeting-baseline-data.txt`:
+
+```markdown
+# Mutation Testing Baseline — VRMA Retargeting Samplers
+
+**Issue:** [#282](https://github.com/arkavo-org/VRMMetalKit/issues/282)
+**Last run:** 2026-05-21
+**Target:** `Sources/VRMMetalKit/Animation/RetargetingSamplers.swift`
+**Oracle suite:** `Tests/VRMMetalKitTests/RetargetingSamplersTests.swift`
+
+## Tooling
+
+`muter` built from `master` at the SHA pinned in `Makefile`, with the local
+`.muter/patches/v16-schemata-content-fallback.patch` applied at bootstrap.
+
+- Bootstrap: `make muter-bootstrap`
+- Run: `make mutation-test-retargeting`
+- Report: `.build/mutation-testing/retargeting-samplers.json` (gitignored)
+
+## Mutation score
+
+| | Count |
+|---|---|
+| Total mutants generated | <N> |
+| Killed | <N> |
+| Survived (equivalent) | <N> |
+| Survived (accepted-gap) | <N> |
+
+**Score (killed / (total - equivalent)): <NN>%**
+
+Total wall time: <mm:ss>.
+
+## Survivors
+
+Every surviving mutant, classified. No unclassified survivors.
+
+| # | File:line | Operator | Before → After | Classification | Rationale |
+|---|---|---|---|---|---|
+| 1 | <…> | <…> | <…> | <…> | <…> |
+
+## Verdict
+
+Did this run surface a test-effectiveness blind spot comparable to the
+`DepthBiasCalculator` POC's priority-chain finding?
+
+<One of:>
+- **Yes — expand.** <What the blind spot was.> Recommend extending mutation
+  testing to further Animation targets; next candidates: `KeyframeSampling.swift`,
+  then the IK / constraint solvers.
+- **No — validated, not adopted.** The existing suite (or the oracle suite as
+  first written) already pinned the retargeting math; mutation testing surfaced
+  no meaningful gap. Recommend stopping at two targets — mutation testing is a
+  proven technique for this codebase but not worth standing up as a routine.
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add docs/mutation-testing/retargeting-samplers-baseline.md
+git commit -m "docs(mutation-testing): RetargetingSamplers mutation baseline (#282)
+
+Second mutation target. Score <NN>%, every survivor classified. Verdict
+section records the expand/stop recommendation for issue #282.
+
+Issue #282
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"
+```
+
+---
+
+## Task 7: Update PR #284 and push
+
+**Files:** (none)
+
+- [ ] **Step 1: Push the branch.**
+
+Confirm with the user before pushing (project convention — push triggers Xcode Cloud CI). When approved:
+```bash
+git push origin issue/282-mutation-testing
+```
+
+- [ ] **Step 2: Update PR #284's title and body for the expanded scope.**
+
+PR #284 now covers two mutation targets. Update it:
+```bash
+gh pr edit 284 --repo arkavo-org/VRMMetalKit \
+  --title "feat(testing): mutation testing on DepthBiasCalculator + retargeting samplers (#282)"
+```
+Then append a section to the PR body (via `gh pr edit 284 --body` with the full updated body) summarizing the retargeting work: the `RetargetingSamplers.swift` extraction, the new oracle suite, the second mutation score, and the baseline doc's Verdict.
+
+- [ ] **Step 3: Report the PR URL and the Verdict to the user.**
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Phase 1 extraction (new file; `private`→`internal` for `KeyTrack`/`Interpolation`/`sampleQuaternion`/`sampleVector3`; `safeDivide` moves; `makeExpressionWeightSampler` stays) → Task 1.
+- Phase 1 behavior-contract gate (full suite passes) → Task 1 Step 5.
+- Phase 2 oracle suite, all required coverage (identity collapse, `W_A==W_B` collapse, full W-term, nil passthroughs, translation/scale/`safeDivide`) → Task 2.
+- muter config → Task 3.
+- Makefile aggregate restructure + POC baseline-doc update → Task 4.
+- Survivor triage, ≥80% / classify-every-survivor, escape hatch → Task 5.
+- Baseline doc with Verdict section → Task 6.
+- All 6 acceptance criteria map: AC1→Task1, AC2→Task2, AC3→Task4+Task5, AC4/AC5→Task5+Task6, AC6→Task6.
+
+**Placeholder scan:** No TBDs. The `<…>` markers in Task 6's baseline doc and Task 5's commit-body summary are intentional run-time fill-ins (the engineer has the real numbers only after the run) — every one has an explicit source (`/tmp/retargeting-baseline-data.txt`).
+
+**Type consistency:** `KeyTrack(times:values:path:interpolation:componentCount:)` memberwise init matches the struct definition; `Interpolation.step` is a real case; `makeRotationSampler` / `makeTranslationSampler` / `makeScaleSampler` / `safeDivide` signatures are identical between Task 1 (definitions) and Task 2 (call sites); `quatTrack` / `vec3Track` / `assertQuat` / `assertVec3` helper names are consistent within the test file.

--- a/docs/superpowers/specs/2026-05-21-mutation-testing-gltfcore-design.md
+++ b/docs/superpowers/specs/2026-05-21-mutation-testing-gltfcore-design.md
@@ -1,0 +1,218 @@
+# Mutation Testing — First Target: `DepthBiasCalculator` (GLTFCore)
+
+**Status:** Approved — ready for implementation plan
+**Issue:** [#282](https://github.com/arkavo-org/VRMMetalKit/issues/282)
+**Date:** 2026-05-21
+
+## Problem
+
+Line/branch coverage tells us *which lines run*, not *which lines have assertions
+that would catch a regression*. Mutation testing closes that gap by introducing
+small syntactic changes (mutants) and asking whether the test suite kills them.
+Issue #282 scoped this work; this spec is the first concrete deliverable:
+prove the mutation-testing loop on one well-bounded GLTFCore utility before
+expanding.
+
+## Goal
+
+Land a reproducible mutation-testing workflow targeting
+`Sources/GLTFCore/Utilities/DepthBiasCalculator.swift` (253 LOC, pure math, no
+I/O) backed by a direct unit suite, and produce a durable baseline document
+that records mutation score, per-mutant classification, and a per-test-run
+performance measurement.
+
+## Non-Goals
+
+- Other GLTFCore files (`OrthographicCamera`, `GLTFError`, `GLTFLogger`, the
+  loaders) — separate follow-up issues.
+- Other modules (`Animation/`, `Renderer/`, shaders).
+- CI integration. Local-only first; CI is a future decision once we know the
+  cost.
+- Custom muter operator sets. Defaults until we have evidence to revisit.
+- Automated equivalent-mutant detection.
+
+## Design
+
+### 1. Toolchain — muter built from a pinned SHA
+
+`muter` is the only mature Swift mutation-testing tool. Its last tagged release
+is from 2023 (tag `16`); the project remains actively committed-to on `master`
+(most recent commit at writing: `99624ec` on 2026-04-27, fixing memory
+exhaustion on large codebases). Homebrew's package would install the 2023
+tag, which is unlikely to parse Swift 6.2 source. We therefore install from
+source at a pinned SHA. Approach B from brainstorming.
+
+**Layout under `.build/tools/`** (the entire `.build/` tree is already
+gitignored, so no new `.gitignore` rules needed):
+
+```
+.build/tools/
+  muter-src/          # git clone @ pinned SHA
+  bin/muter           # symlink to muter-src/.build/release/muter
+```
+
+**Makefile additions:**
+
+```makefile
+MUTER_SHA := 99624ecfde93dac3cc1f7a66ac6f7df05611091d
+MUTER_BIN := .build/tools/bin/muter
+
+$(MUTER_BIN):
+	@mkdir -p .build/tools
+	@if [ ! -d .build/tools/muter-src ]; then \
+		git clone https://github.com/muter-mutation-testing/muter.git .build/tools/muter-src; \
+	fi
+	@cd .build/tools/muter-src && git fetch && git checkout $(MUTER_SHA)
+	@cd .build/tools/muter-src && swift build -c release
+	@mkdir -p .build/tools/bin
+	@ln -sf ../muter-src/.build/release/muter $(MUTER_BIN)
+
+muter-bootstrap: $(MUTER_BIN)
+	@$(MUTER_BIN) --version
+
+mutation-test: $(MUTER_BIN)
+	@$(MUTER_BIN) run --configuration .muter/depth-bias.json
+```
+
+**Bumping the pinned SHA:** edit `MUTER_SHA`, remove `.build/tools/muter-src`,
+re-run `make muter-bootstrap`. This procedure is mirrored in the baseline doc.
+
+**SHA selection criterion at implementation time:** the implementer verifies
+the candidate SHA (`99624ec` or the latest at that moment) builds locally with
+the host's Swift 6.2 toolchain *before* committing it to the Makefile. If it
+fails to build, fall back to the most recent ancestor that does.
+
+### 2. Direct Unit Suite — Written Before muter Runs
+
+`DepthBiasCalculator` is currently exercised only incidentally by
+`Tests/VRMMetalKitTests/HipSkirtTests.swift`, which is a behavioral suite for
+the hip-skirt simulation that happens to call into the calculator. Pointing
+muter at an integration suite would dominate the report with arithmetic and
+boundary survivors the integration tests genuinely cannot distinguish — the
+classic failure mode that makes teams abandon mutation testing.
+
+**New file: `Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift`** with direct
+oracle tests on the calculator's public surface:
+- Known-input / expected-output pairs for the core calculation paths.
+- Boundary cases (zero, negative, very-large scale values).
+- Mode/configuration variants exposed by the calculator's API.
+
+Why this lives in `VRMMetalKitTests` (not a new `GLTFCoreTests` target):
+`Tests/VRMMetalKitTests/GLTFParserStateTests.swift` already sets the precedent
+for GLTFCore unit tests living under `VRMMetalKitTests`. Adding a new target is
+out of scope.
+
+muter targets only this new file's suite; `HipSkirtTests` is untouched and is
+not part of the mutation oracle.
+
+### 3. Measure Before Trusting Estimates
+
+Before kicking off the first muter run, the implementer times one
+`swift test --filter DepthBiasCalculatorTests --disable-sandbox` invocation
+cold-cache and warm-cache. The warm time is recorded in the baseline doc and
+used to sanity-check total mutation-run cost. **Acceptance gate:** if warm
+time exceeds 15 seconds per invocation, stop and revisit (operator set,
+test selection, or whether mutation testing here is cost-justified) before
+committing to the loop.
+
+### 4. muter Configuration
+
+One file: `.muter/depth-bias.json`. Schema follows muter's documented format.
+Required fields:
+
+- `executable`: path to `swift` (or `xcrun swift` if needed by muter to locate
+  the SDK; implementer determines empirically).
+- `arguments`: `["test", "--filter", "DepthBiasCalculatorTests", "--disable-sandbox"]`.
+  The `--disable-sandbox` flag is required because the project's tests need
+  filesystem access for fixtures (per CLAUDE.md convention); muter additionally
+  needs FS write access to perform source rewrites.
+- `mutate_files`: glob matching `Sources/GLTFCore/Utilities/DepthBiasCalculator.swift`.
+- `exclude_files`: empty.
+- Output: JSON report at `.build/mutation-testing/last-run.json` — a
+  deterministic path so a future CI run can publish the artifact without
+  needing further changes.
+
+Default operator set is used; tuning is a follow-up only if results justify it.
+
+### 5. Baseline Document — Durable, Not a Snapshot
+
+**File:** `docs/mutation-testing/depthbiascalculator-baseline.md`.
+
+**Required sections:**
+- Pinned muter SHA + bump instructions (mirror of §1).
+- Per-test-run time (warm), measured at run time.
+- Total mutation-test wall time observed.
+- Overall mutation score: `killed / (total - equivalent)` and the raw counts.
+- **Survivors table:** every surviving mutant listed with:
+  - file:line
+  - mutation operator
+  - mutated code snippet (before / after)
+  - classification: `kill-pending` (real gap, fix later), `equivalent`
+    (semantically identical), `accepted-gap` (real gap, deliberately
+    not fixed yet — rationale required)
+  - one-line rationale
+- Date of last run.
+
+No raw muter report is committed (the JSON at `.build/mutation-testing/last-run.json`
+is gitignored via the `.build/` rule). The committed Markdown is the only
+durable artifact.
+
+### 6. Survivor Triage Pass
+
+After the first muter run produces a baseline, the implementer:
+1. Reads through every survivor.
+2. Writes additional test cases in `DepthBiasCalculatorTests.swift` to kill
+   the highest-value real gaps (target: score climbs to ≥80%).
+3. Classifies remaining survivors as `equivalent` or `accepted-gap` with
+   rationale.
+4. Re-runs muter and updates the baseline doc with the final score and
+   classification.
+
+The plan should treat steps 1–4 as one task block — the loop only closes when
+the doc is published with a non-trivial number of `kill-pending` mutants
+actually killed.
+
+## Acceptance Criteria
+
+1. `make muter-bootstrap && make mutation-test` runs cleanly on a fresh
+   checkout. (`make muter-bootstrap` builds muter; `make mutation-test`
+   produces the JSON report.)
+2. A new unit suite `Tests/VRMMetalKitTests/DepthBiasCalculatorTests.swift`
+   exists with direct oracle tests on `DepthBiasCalculator`.
+3. The unit suite achieves a mutation score of **≥80%** on
+   `DepthBiasCalculator.swift`.
+4. **Every** surviving mutant in the final run has a classification
+   (`kill-pending` / `equivalent` / `accepted-gap`) and a one-line rationale
+   in the baseline doc — no unclassified survivors.
+5. Per-test-run warm time recorded in the baseline doc.
+
+If criterion 3 (80%) is not achievable for legitimate reasons (e.g., the
+calculator has inherent equivalent-mutant surface like `*1.0` casts that bend
+the score down), document why in the baseline doc and propose a revised bar in
+a follow-up issue. Do **not** gold-plate tests just to hit the number.
+
+## Risks
+
+- **Pinned muter SHA fails to build under Swift 6.2.** Mitigation: implementer
+  verifies the SHA builds locally before committing it; falls back to the most
+  recent ancestor that does. The Makefile uses a single `MUTER_SHA` variable
+  so the bump is one line.
+- **`DepthBiasCalculator` has inherent equivalent-mutant surface that puts
+  ≥80% out of reach.** Mitigation: acceptance criterion 3 has the documented
+  escape hatch above. The baseline doc captures *why* and proposes a revised
+  bar.
+- **Per-test-run time blows up.** Mitigation: the measure-before-trust step
+  (§3) catches this before the implementer commits to the loop.
+- **muter's JSON schema changes between SHA bumps.** Mitigation: the baseline
+  doc is Markdown, written by hand from whatever muter outputs. We do not
+  parse muter's JSON in any committed code.
+
+## Out of Scope
+
+- Other GLTFCore files (own follow-up issues).
+- Other modules.
+- CI integration.
+- Custom operator sets.
+- Automated equivalent-mutant detection.
+- A `GLTFCoreTests` SPM target (precedent says GLTFCore tests live under
+  `VRMMetalKitTests`).

--- a/docs/superpowers/specs/2026-05-21-mutation-testing-retargeting-design.md
+++ b/docs/superpowers/specs/2026-05-21-mutation-testing-retargeting-design.md
@@ -1,0 +1,197 @@
+# Mutation Testing — Second Target: VRMA Retargeting Samplers
+
+**Status:** Approved — ready for implementation plan
+**Issue:** [#282](https://github.com/arkavo-org/VRMMetalKit/issues/282)
+**Date:** 2026-05-21
+**Predecessor:** `docs/superpowers/specs/2026-05-21-mutation-testing-gltfcore-design.md` (the
+`DepthBiasCalculator` POC, shipped as PR #284)
+
+## Problem
+
+The `DepthBiasCalculator` POC proved the mutation-testing loop works and found a real
+test-effectiveness blind spot (a priority if-chain with 100% line coverage but no
+assertions that pinned its priority semantics). The open question from that POC: is
+mutation testing worth standing up as a routine, or is one validated run enough?
+
+This spec defines the **second and deciding run**. Per the agreed framing: if this run
+surfaces a blind spot as meaningful as the POC's, expansion is justified; if it merely
+confirms good coverage, mutation testing is "validated, not adopted" and we stop at two.
+
+## Goal
+
+Mutation-test the VRMA rest-pose retargeting math — the highest-signal Animation target,
+where regression VMK#269 actually occurred. Produce a ≥80 % mutation score with every
+surviving mutant classified, and a baseline document whose Verdict section feeds the
+expand / stop decision.
+
+## Non-Goals
+
+- Other Animation files (`KeyframeSampling`, `AnimationPlayer`, IK, constraints).
+- `makeExpressionWeightSampler` — it extracts a clamped weight, it is not retargeting math.
+- Mutation testing the GLTFCore keyframe interpolation that the samplers call into.
+- CI integration (still deferred — local-only).
+- Custom muter operator sets.
+
+## Background — why a refactor is required first
+
+The retargeting math lives in three functions inside `VRMAnimationLoader.swift` (977 lines):
+
+- `makeRotationSampler` — VRM 1.0 pose-normalization
+  `Normalized = W_A · L_A⁻¹ · A · W_A⁻¹`, `B = L_B · W_B⁻¹ · Normalized · W_B`.
+- `makeTranslationSampler` — additive delta `modelRest + (animTranslation - animRest)`.
+- `makeScaleSampler` — ratio form `modelRest * safeDivide(animScale, animRest)`.
+
+All three are `private`, return closures, and are interleaved with ~700 lines of GLB
+parsing / node resolution / coordinate-conversion code. muter can only scope to whole
+files, so mutating `VRMAnimationLoader.swift` would generate mutants across all the
+parser code — most surviving for lack of `.vrma` fixtures — drowning the retargeting
+signal. The math must be extracted into its own file before it can be mutation-tested
+meaningfully. The extraction is also a genuine improvement: it turns three untestable
+`private` closure-factories into an isolated, directly-testable unit.
+
+## Design
+
+### Phase 1 — Extract `RetargetingSamplers.swift` (behavior-preserving refactor)
+
+**New file `Sources/VRMMetalKit/Animation/RetargetingSamplers.swift`.** Move from
+`VRMAnimationLoader.swift`, changing `private` → `internal`:
+
+- `makeRotationSampler(track:animationRestRotation:animationRestWorldRotation:modelRestRotation:modelRestWorldRotation:)`
+- `makeTranslationSampler(track:animationRestTranslation:modelRestTranslation:)`
+- `makeScaleSampler(track:animationRestScale:modelRestScale:)`
+- `safeDivide(_:by:)` — used only by `makeScaleSampler`, moves with it.
+
+**Modified `VRMAnimationLoader.swift`.** These symbols are shared with code that stays in
+the loader (the look-at sampler, the expression-weight sampler), so they stay in place but
+change `private` → `internal` so the new file and the test target can reach them:
+
+- `struct KeyTrack`
+- `sampleQuaternion(_:at:)`, `sampleVector3(_:at:)`
+
+`makeExpressionWeightSampler` and `Interpolation.asGLTFCore` stay `private` in
+`VRMAnimationLoader.swift` — neither is retargeting math and neither is needed across the
+file boundary.
+
+**Behavior contract:** no functional change. `VRMAnimationLoader` keeps calling the same
+three functions, now cross-file within the module. The phase-1 gate is the existing VRMA
+retargeting test suite passing unchanged (`swift test --disable-sandbox`, in particular
+any `SpringBoneRegression` / animation-retargeting tests that load `.vrma` clips).
+
+### Phase 2 — Mutation testing
+
+**Oracle suite — `Tests/VRMMetalKitTests/RetargetingSamplersTests.swift`.** New file,
+written before any mutation run. The retargeting samplers are `VRMMetalKit` code, so
+`@testable import VRMMetalKit` reaches the now-`internal` functions and `KeyTrack`. Tests
+build a `KeyTrack` with known `times`/`values`, call `makeRotationSampler(...)` (etc.) to
+obtain the closure, invoke the closure at sample times, and assert the output. Required
+coverage:
+
+- **Identity rest poses** — when `animationRest == modelRest == identity`, the rotation
+  formula collapses to `B = A`; hand-verifiable.
+- **`W_A == W_B` collapse** — when animation and model share a world-rest orientation,
+  the W terms cancel and `B = L_B · L_A⁻¹ · A`; hand-verifiable.
+- **Full W-term change-of-basis** — animation rest ≠ model rest (the VMK#269 case): the
+  W terms perform a real change of basis. Use a 90° offset that is hand-computable.
+- **`nil` model-rest** — `makeRotationSampler` returns the passthrough closure
+  (`sampleQuaternion(track, at:)` unmodified).
+- **Translation** — additive delta `modelRest + (anim - animRest)`, plus the `nil`
+  passthrough.
+- **Scale** — ratio form `modelRest * (animScale / animRest)`, plus the `nil` passthrough.
+- **`safeDivide`** — denominators that are zero, below the `1e-6` epsilon, and negative.
+
+**muter config — `.muter/retargeting-samplers.yml`.** Same schema as the POC's
+`.muter/depth-bias.yml`: `executable` = swift, `arguments` =
+`["test", "--filter", "RetargetingSamplersTests", "--disable-sandbox"]`. File scoping,
+JSON format, and output path are CLI flags in the Makefile (muter v16's config schema does
+not carry them).
+
+**Makefile.** Restructure the single `mutation-test` target into the aggregate pattern
+already used by the `shaders` targets:
+
+```makefile
+mutation-test: mutation-test-depth-bias mutation-test-retargeting
+	@echo "✅ All mutation-test targets complete"
+
+mutation-test-depth-bias: $(MUTER_BIN)
+	@mkdir -p .build/mutation-testing
+	@$(MUTER_BIN) run \
+		--configuration .muter/depth-bias.yml \
+		--files-to-mutate Sources/GLTFCore/Utilities/DepthBiasCalculator.swift \
+		--skip-coverage --format json \
+		--output .build/mutation-testing/depth-bias.json
+
+mutation-test-retargeting: $(MUTER_BIN)
+	@mkdir -p .build/mutation-testing
+	@$(MUTER_BIN) run \
+		--configuration .muter/retargeting-samplers.yml \
+		--files-to-mutate Sources/VRMMetalKit/Animation/RetargetingSamplers.swift \
+		--skip-coverage --format json \
+		--output .build/mutation-testing/retargeting-samplers.json
+```
+
+The existing `mutation-test` (currently hardcoded to DepthBiasCalculator, writing
+`.build/mutation-testing/last-run.json`) is renamed to `mutation-test-depth-bias`; its
+output path changes from `last-run.json` to `depth-bias.json` so the two targets do not
+clobber each other. Update the `help:` block and `.PHONY` line accordingly. The existing
+`docs/mutation-testing/depthbiascalculator-baseline.md` is updated in lockstep: both its
+"Run" instruction (new target name `mutation-test-depth-bias`) and its report-path
+reference (`depth-bias.json`).
+
+**Baseline doc — `docs/mutation-testing/retargeting-samplers-baseline.md`.** Same
+structure as the POC baseline (tooling + SHA-bump instructions, performance, mutation
+score, every-survivor classification table) **plus a Verdict section**:
+
+> ## Verdict
+> Did this run surface a test-effectiveness blind spot comparable to the POC's
+> priority-chain finding?
+> - **If yes:** recommend expanding mutation testing to further Animation targets; name
+>   the next candidates.
+> - **If no (coverage merely confirmed):** recommend stopping at two targets — mutation
+>   testing is validated as a technique for this codebase but not adopted as a routine.
+
+### Survivor triage
+
+Identical to the POC: each survivor is classified `kill-pending` (write a distinguishing
+assertion), `equivalent` (semantically identical under all reachable inputs), or
+`accepted-gap` (real gap deliberately not closed, with rationale). Iterate until the score
+reaches ≥80 % or every remaining survivor is `equivalent` / `accepted-gap`.
+
+## Acceptance Criteria
+
+1. `RetargetingSamplers.swift` exists; `VRMAnimationLoader.swift` still compiles and the
+   full existing test suite passes unchanged after the Phase-1 extraction.
+2. `Tests/VRMMetalKitTests/RetargetingSamplersTests.swift` exists with direct oracle tests
+   for all three samplers and `safeDivide`.
+3. `make mutation-test-retargeting` runs cleanly and writes
+   `.build/mutation-testing/retargeting-samplers.json`.
+4. Mutation score ≥ 80 % on `RetargetingSamplers.swift`.
+5. Every surviving mutant is classified with a one-line rationale in the baseline doc —
+   no unclassified survivors.
+6. The baseline doc's Verdict section gives a clear expand / stop recommendation.
+
+If criterion 4 is unreachable for legitimate reasons — quaternion math has inherent
+equivalent-mutant surface (`simd_normalize` of an already-normal value, `simd_inverse`
+that equals the conjugate for unit quaternions) — document why in the baseline and propose
+a revised bar. Do not gold-plate tests to hit the number.
+
+## Risks
+
+- **Quaternion oracle values are order-sensitive.** A wrong hand-computed expected value
+  makes a test pass on mutated code by luck. Mitigation: anchor tests on the documented
+  collapse cases (identity rest poses; `W_A == W_B`) where the formula simplifies to a
+  hand-verifiable expression, and only then add the full W-term case.
+- **Higher equivalent-mutant surface than the POC.** `simd_normalize` / `simd_inverse`
+  calls mean some mutations are genuinely equivalent. Mitigation: criterion-4 escape
+  hatch; classify rather than chase.
+- **Phase-1 extraction changes visibility.** Promoting `KeyTrack` / `sampleQuaternion` /
+  `sampleVector3` to `internal` widens the module-internal surface slightly. Acceptable —
+  they remain `internal`, never `public`; no external API change.
+- **muter patch fragility.** Unchanged from the POC: the v16 schemata patch is applied at
+  bootstrap. No new exposure here; this run reuses the already-bootstrapped muter.
+
+## Out of Scope
+
+- Other Animation files; the GLTFCore keyframe samplers.
+- CI integration.
+- Custom operator sets.
+- Any behavior change to the retargeting math itself — Phase 1 is a pure move.


### PR DESCRIPTION
Closes #282

Stands up mutation testing for VRMMetalKit and runs it against two targets to answer issue #282's scoping question: is mutation testing worth adopting as a routine?

## Target 1 — `DepthBiasCalculator` (POC)
- Bootstraps `muter` from a pinned `master` SHA into `.build/tools/`, with a local patch for a v16 schemata-identity bug (`.muter/patches/v16-schemata-content-fallback.patch`) that otherwise made every run report 0% killed.
- 32-test direct oracle suite. **87% mutation score** (7/8 killed); the lone survivor is a Metal GPU side-effect, classified accepted-gap.
- Finding: the original tests had 100% line coverage of the priority if-chain but killed nothing — the partial-match safety net masked the mutants. Multi-keyword tests that exercise the priority chain fixed it.

## Target 2 — VRMA retargeting samplers
- Extracts `makeRotationSampler` / `makeTranslationSampler` / `makeScaleSampler` from the 977-line `VRMAnimationLoader.swift` into a testable `RetargetingSamplers.swift` (behavior-preserving refactor).
- 15-test direct oracle suite. **100% mutation score** (6/6 killed).
- Finding that matters more than the score: all 6 mutants landed in the `safeDivide` guard helper. The quaternion/SIMD retargeting math generated **zero mutants** — muter v16's four scalar operators (relational / side-effect / logical / ternary) have nothing to grab in `simd`-based code.

## Verdict (see `docs/mutation-testing/retargeting-samplers-baseline.md`)
**Validated, not adopted — lean stop.** Mutation testing has real value for scalar control-flow code but is nearly blind to the `simd` math that makes up most of VRMMetalKit's core. Recommendation: do not adopt as a routine/CI gate; keep it as an opt-in spot-check for scalar-logic-heavy files. Infrastructure stays in place (`make mutation-test-*`) for future use.

## Out of scope
- Other modules; CI integration; custom muter operators (considered and rejected — maintenance not justified).

## Test plan
- [x] `make muter-bootstrap` builds patched muter from the pinned SHA
- [x] `make mutation-test-depth-bias` → 7/8 killed (87%)
- [x] `make mutation-test-retargeting` → 6/6 killed (100%)
- [x] `swift test --filter DepthBiasCalculatorTests --disable-sandbox` — 32 pass
- [x] `swift test --filter RetargetingSamplersTests --disable-sandbox` — 15 pass
- [x] `RetargetingSamplers` extraction is behavior-preserving — full suite unchanged
- [x] Both baseline docs classify every surviving mutant

🤖 Generated with [Claude Code](https://claude.com/claude-code)