### PR TITLE
fix(lookat): VRM 1.0 preset namespace

### DIFF
--- a/Sources/VRMMetalKit/Animation/VRMLookAtController.swift
+++ b/Sources/VRMMetalKit/Animation/VRMLookAtController.swift
@@ -215,7 +215,16 @@ public class VRMLookAtController {
             eyesAreRigid = true
         }
 
-        // Check if we have LookAt expressions - with detailed diagnostics
+        // Check if we have LookAt expressions - with detailed diagnostics.
+        //
+        // VMK#297: check both namespaces — the VRM 1.0 spec preset
+        // namespace (`expressions.preset[.lookLeft]`, lowercase) and the
+        // legacy VRM 0.x custom namespace
+        // (`expressions.custom["LookLeft"]`, PascalCase). Either one
+        // having non-empty morph binds counts as "expression mode is
+        // available." Pre-fix the check was custom-only, so
+        // spec-compliant VRM 1.0 assets fell through to bone-mode
+        // detection or the no-eye-bones fallback (#297).
         if let expressions = model.expressions {
             vrmLog("[VRMLookAtController] Expression diagnostics:")
             vrmLog("  - Total custom expressions: \(expressions.custom.count)")
@@ -223,34 +232,23 @@ public class VRMLookAtController {
                 vrmLog("    Custom '\(name)': \(expr.morphTargetBinds.count) binds")
             }
 
-            // Check if LookAt expressions have actual morph target binds
             var workingLookAtExpressions = 0
-            if let left = expressions.custom["LookLeft"], !left.morphTargetBinds.isEmpty {
-                workingLookAtExpressions += 1
-                vrmLog("    LookLeft: \(left.morphTargetBinds.count) binds ✅")
-            } else if expressions.custom["LookLeft"] != nil {
-                vrmLog("    LookLeft: 0 binds ❌ (empty)")
+            let lookPresets: [VRMExpressionPreset] = [.lookLeft, .lookRight, .lookUp, .lookDown]
+            for preset in lookPresets {
+                if let expr = expressions.preset[preset], !expr.morphTargetBinds.isEmpty {
+                    workingLookAtExpressions += 1
+                    vrmLog("    preset.\(preset): \(expr.morphTargetBinds.count) binds ✅")
+                } else if expressions.preset[preset] != nil {
+                    vrmLog("    preset.\(preset): 0 binds ❌ (empty)")
+                }
             }
-
-            if let right = expressions.custom["LookRight"], !right.morphTargetBinds.isEmpty {
-                workingLookAtExpressions += 1
-                vrmLog("    LookRight: \(right.morphTargetBinds.count) binds ✅")
-            } else if expressions.custom["LookRight"] != nil {
-                vrmLog("    LookRight: 0 binds ❌ (empty)")
-            }
-
-            if let up = expressions.custom["LookUp"], !up.morphTargetBinds.isEmpty {
-                workingLookAtExpressions += 1
-                vrmLog("    LookUp: \(up.morphTargetBinds.count) binds ✅")
-            } else if expressions.custom["LookUp"] != nil {
-                vrmLog("    LookUp: 0 binds ❌ (empty)")
-            }
-
-            if let down = expressions.custom["LookDown"], !down.morphTargetBinds.isEmpty {
-                workingLookAtExpressions += 1
-                vrmLog("    LookDown: \(down.morphTargetBinds.count) binds ✅")
-            } else if expressions.custom["LookDown"] != nil {
-                vrmLog("    LookDown: 0 binds ❌ (empty)")
+            for name in ["LookLeft", "LookRight", "LookUp", "LookDown"] {
+                if let expr = expressions.custom[name], !expr.morphTargetBinds.isEmpty {
+                    workingLookAtExpressions += 1
+                    vrmLog("    custom['\(name)']: \(expr.morphTargetBinds.count) binds ✅")
+                } else if expressions.custom[name] != nil {
+                    vrmLog("    custom['\(name)']: 0 binds ❌ (empty)")
+                }
             }
 
             if workingLookAtExpressions > 0 {
@@ -537,6 +535,17 @@ public class VRMLookAtController {
         guard model != nil else { return }
         guard let lookAt = lookAtData else { return }
 
+        // VMK#297: write to BOTH the VRM 1.0 spec preset namespace
+        // (lookLeft/lookRight/lookUp/lookDown lowercase) and the legacy
+        // VRM 0.x custom namespace (PascalCase). Each setter is a no-op
+        // when its target isn't registered, so spec-compliant assets land
+        // in `expressions.preset[.lookLeft]` and legacy assets land in
+        // `expressions.custom["LookLeft"]` — without the controller
+        // needing to know which.
+        expressionController?.setExpressionWeight(.lookLeft, weight: 0)
+        expressionController?.setExpressionWeight(.lookRight, weight: 0)
+        expressionController?.setExpressionWeight(.lookUp, weight: 0)
+        expressionController?.setExpressionWeight(.lookDown, weight: 0)
         expressionController?.setCustomExpressionWeight("LookLeft", weight: 0)
         expressionController?.setCustomExpressionWeight("LookRight", weight: 0)
         expressionController?.setCustomExpressionWeight("LookUp", weight: 0)
@@ -545,15 +554,17 @@ public class VRMLookAtController {
         if abs(currentYaw) > 0.02 {
             if currentYaw > 0 {
                 let weight = abs(VRMLookAtController.rangeMapOutput(currentYaw, map: lookAt.rangeMapHorizontalOuter))
+                expressionController?.setExpressionWeight(.lookRight, weight: weight)
                 expressionController?.setCustomExpressionWeight("LookRight", weight: weight)
                 if debugFrameCount % 60 == 0 {
-                    vrmLog("[LookAt EXPRESSION] LookRight weight: \(weight)")
+                    vrmLog("[LookAt EXPRESSION] lookRight weight: \(weight)")
                 }
             } else {
                 let weight = abs(VRMLookAtController.rangeMapOutput(currentYaw, map: lookAt.rangeMapHorizontalOuter))
+                expressionController?.setExpressionWeight(.lookLeft, weight: weight)
                 expressionController?.setCustomExpressionWeight("LookLeft", weight: weight)
                 if debugFrameCount % 60 == 0 {
-                    vrmLog("[LookAt EXPRESSION] LookLeft weight: \(weight)")
+                    vrmLog("[LookAt EXPRESSION] lookLeft weight: \(weight)")
                 }
             }
         }
@@ -561,15 +572,17 @@ public class VRMLookAtController {
         if abs(currentPitch) > 0.02 {
             if currentPitch > 0 {
                 let weight = abs(VRMLookAtController.rangeMapOutput(currentPitch, map: lookAt.rangeMapVerticalUp))
+                expressionController?.setExpressionWeight(.lookUp, weight: weight)
                 expressionController?.setCustomExpressionWeight("LookUp", weight: weight)
                 if debugFrameCount % 60 == 0 {
-                    vrmLog("[LookAt EXPRESSION] LookUp weight: \(weight)")
+                    vrmLog("[LookAt EXPRESSION] lookUp weight: \(weight)")
                 }
             } else {
                 let weight = abs(VRMLookAtController.rangeMapOutput(currentPitch, map: lookAt.rangeMapVerticalDown))
+                expressionController?.setExpressionWeight(.lookDown, weight: weight)
                 expressionController?.setCustomExpressionWeight("LookDown", weight: weight)
                 if debugFrameCount % 60 == 0 {
-                    vrmLog("[LookAt EXPRESSION] LookDown weight: \(weight)")
+                    vrmLog("[LookAt EXPRESSION] lookDown weight: \(weight)")
                 }
             }
         }

--- a/Sources/VRMMetalKit/Loader/VRMExtensionParser.swift
+++ b/Sources/VRMMetalKit/Loader/VRMExtensionParser.swift
@@ -604,6 +604,15 @@ public class VRMExtensionParser {
         case "u": return .ou
         case "e": return .ee
         case "o": return .oh
+        // VMK#297: VRM 0.x's gaze BlendShapeGroups map to VRM 1.0's
+        // preset look-direction expressions. Without these the
+        // VRM 0.x parser dropped them into `expressions.custom`
+        // (PascalCase preserved), bypassing the spec preset
+        // namespace.
+        case "lookup": return .lookUp
+        case "lookdown": return .lookDown
+        case "lookleft": return .lookLeft
+        case "lookright": return .lookRight
         default: return nil
         }
     }

--- a/Tests/VRMMetalKitTests/VRMLookAtExpressionNamespaceTests.swift
+++ b/Tests/VRMMetalKitTests/VRMLookAtExpressionNamespaceTests.swift
@@ -1,0 +1,337 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+
+import XCTest
+import simd
+@testable import VRMMetalKit
+
+/// VMK#297 — `VRMLookAtController.applyToExpressions` historically only
+/// wrote to the custom-namespace PascalCase `"LookLeft"`/`"LookRight"`/
+/// `"LookUp"`/`"LookDown"`, but the VRM 1.0 spec defines these as
+/// **preset** expressions (`expressions.preset.lookLeft`, lowercase).
+/// Spec-compliant VRM 1.0 assets with `lookAt.type = expression` and
+/// preset look-direction binds would render with no gaze deviation
+/// because the controller's writes landed in an orphan custom name.
+///
+/// These tests cover both namespaces — the spec-compliant preset path
+/// (which was broken pre-#297) and the legacy custom path that VRM 0.x
+/// assets continue to depend on through the
+/// `VRMExtensionParser.mapVRM0PresetToVRM1` mapping.
+final class VRMLookAtExpressionNamespaceTests: XCTestCase {
+
+    private func makeMinimalGLTF() -> GLTFDocument {
+        let json: [String: Any] = ["asset": ["version": "2.0", "generator": "Test"]]
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return try! JSONDecoder().decode(GLTFDocument.self, from: data)
+    }
+
+    private func makeGLTFNode(name: String) throws -> GLTFNode {
+        let json: [String: Any] = ["name": name]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(GLTFNode.self, from: data)
+    }
+
+    /// Builds an expression-mode rig with `expressions.preset[.lookLeft]`
+    /// etc. populated (spec-compliant VRM 1.0 path). Each preset
+    /// expression carries a non-empty morphTargetBinds list so
+    /// `setup()`'s "working expressions" detection passes.
+    private func makePresetNamespaceRig() throws -> (model: VRMModel, controller: VRMLookAtController, expressions: VRMExpressionController) {
+        let head = try VRMNode(index: 0, gltfNode: makeGLTFNode(name: "head"))
+
+        let humanoid = VRMHumanoid()
+        humanoid.humanBones[.head] = VRMHumanoid.VRMHumanBone(node: 0)
+
+        let model = VRMModel(
+            specVersion: .v1_0,
+            meta: VRMMeta(licenseUrl: ""),
+            humanoid: humanoid,
+            gltf: makeMinimalGLTF()
+        )
+        model.nodes = [head]
+        model.lookAt = VRMLookAt()
+        model.lookAt?.type = .expression
+
+        // Spec-compliant: lookLeft/lookRight/lookUp/lookDown are PRESET
+        // expressions. Authored binds aren't actually consumed by the
+        // controller — they're inspected by setup() to detect that
+        // expression mode has working targets.
+        let modelExpressions = VRMExpressions()
+        for preset in [VRMExpressionPreset.lookLeft, .lookRight, .lookUp, .lookDown] {
+            var expr = VRMExpression(preset: preset)
+            expr.morphTargetBinds = [VRMMorphTargetBind(node: 0, index: 0, weight: 1.0)]
+            modelExpressions.preset[preset] = expr
+        }
+        model.expressions = modelExpressions
+
+        let expressionController = VRMExpressionController()
+        // Register the same presets on the controller so the apply path
+        // has somewhere to write.
+        for preset in [VRMExpressionPreset.lookLeft, .lookRight, .lookUp, .lookDown] {
+            expressionController.registerExpression(VRMExpression(preset: preset), for: preset)
+        }
+
+        let controller = VRMLookAtController()
+        controller.smoothing = 0
+        controller.saccadeEnabled = false
+        controller.setup(model: model, expressionController: expressionController)
+        controller.mode = .expression
+
+        return (model, controller, expressionController)
+    }
+
+    /// Builds a VRM 0.x legacy rig with custom-namespace `"LookLeft"`
+    /// etc. (PascalCase) — the namespace the broken
+    /// `mapVRM0PresetToVRM1` puts VRM 0.x BlendShapeGroups in. Authored
+    /// binds populate `expressions.custom["LookLeft"]`.
+    private func makeCustomNamespaceLegacyRig() throws -> (model: VRMModel, controller: VRMLookAtController, expressions: VRMExpressionController) {
+        let head = try VRMNode(index: 0, gltfNode: makeGLTFNode(name: "head"))
+
+        let humanoid = VRMHumanoid()
+        humanoid.humanBones[.head] = VRMHumanoid.VRMHumanBone(node: 0)
+
+        let model = VRMModel(
+            specVersion: .v0_0,
+            meta: VRMMeta(licenseUrl: ""),
+            humanoid: humanoid,
+            gltf: makeMinimalGLTF()
+        )
+        model.nodes = [head]
+        model.lookAt = VRMLookAt()
+        model.lookAt?.type = .expression
+
+        let modelExpressions = VRMExpressions()
+        for name in ["LookLeft", "LookRight", "LookUp", "LookDown"] {
+            var expr = VRMExpression(name: name)
+            expr.morphTargetBinds = [VRMMorphTargetBind(node: 0, index: 0, weight: 1.0)]
+            modelExpressions.custom[name] = expr
+        }
+        model.expressions = modelExpressions
+
+        let expressionController = VRMExpressionController()
+        for name in ["LookLeft", "LookRight", "LookUp", "LookDown"] {
+            expressionController.registerCustomExpression(VRMExpression(name: name), name: name)
+        }
+
+        let controller = VRMLookAtController()
+        controller.smoothing = 0
+        controller.saccadeEnabled = false
+        controller.setup(model: model, expressionController: expressionController)
+        controller.mode = .expression
+
+        return (model, controller, expressionController)
+    }
+
+    // MARK: - Apply path
+
+    /// VMK#297 — spec path: with `expressions.preset[.lookRight]`
+    /// populated (and no custom-namespace entry), driving the gaze
+    /// rightward must produce a non-zero weight on the preset enum.
+    /// Pre-fix the controller wrote to `setCustomExpressionWeight("LookRight", …)`
+    /// which is a no-op on an unregistered custom name, so this assertion
+    /// fails.
+    func testApplyToExpressionsWritesPresetLookRightForRightwardGaze() throws {
+        let rig = try makePresetNamespaceRig()
+
+        // Head is at origin; point gaze to the right of the head.
+        rig.controller.target = .point(SIMD3<Float>(1, 0, 0))
+        rig.controller.update(deltaTime: 1.0 / 60.0)
+
+        let lookRight = rig.expressions.weight(for: .lookRight)
+        XCTAssertGreaterThan(lookRight, 0,
+            "VMK#297: expressions.preset[.lookRight] weight must be > 0 after a " +
+            "rightward gaze update on a spec-compliant VRM 1.0 rig. Got \(lookRight). " +
+            "Zero means the controller is writing to the custom namespace " +
+            "(`setCustomExpressionWeight(\"LookRight\", …)`) instead of the preset " +
+            "namespace (`setExpressionWeight(.lookRight, …)`).")
+
+        // Sanity: the other three axes should be zero or near-zero.
+        XCTAssertEqual(rig.expressions.weight(for: .lookLeft), 0, accuracy: 1e-6)
+        XCTAssertEqual(rig.expressions.weight(for: .lookUp), 0, accuracy: 1e-6)
+        XCTAssertEqual(rig.expressions.weight(for: .lookDown), 0, accuracy: 1e-6)
+    }
+
+    /// VMK#297 — same axis coverage for the remaining three direction
+    /// presets so a one-sided fix doesn't pass the suite.
+    func testApplyToExpressionsWritesPresetLookLeftLookUpLookDown() throws {
+        let cases: [(target: SIMD3<Float>, preset: VRMExpressionPreset)] = [
+            (SIMD3<Float>(-1, 0, 0), .lookLeft),
+            (SIMD3<Float>(0,  1, 0), .lookUp),
+            (SIMD3<Float>(0, -1, 0), .lookDown),
+        ]
+        for (target, preset) in cases {
+            let rig = try makePresetNamespaceRig()
+            rig.controller.target = .point(target)
+            rig.controller.update(deltaTime: 1.0 / 60.0)
+
+            let weight = rig.expressions.weight(for: preset)
+            XCTAssertGreaterThan(weight, 0,
+                "VMK#297: gaze toward \(target) must drive preset .\(preset) " +
+                "weight > 0. Got \(weight) — controller is still writing to the " +
+                "custom namespace instead of the preset enum.")
+        }
+    }
+
+    /// Regression-guard for the VRM 0.x legacy path: assets whose
+    /// expressions live in `custom["LookRight"]` (because the pre-#297
+    /// `mapVRM0PresetToVRM1` didn't recognise the look-direction names)
+    /// must continue to be driven correctly. The fix writes to both
+    /// namespaces, so this assertion passes today AND after the fix.
+    func testApplyToExpressionsWritesCustomLookRightLegacyPath() throws {
+        let rig = try makeCustomNamespaceLegacyRig()
+
+        rig.controller.target = .point(SIMD3<Float>(1, 0, 0))
+        rig.controller.update(deltaTime: 1.0 / 60.0)
+
+        let lookRight = rig.expressions.weight(forCustom: "LookRight") ?? 0
+        XCTAssertGreaterThan(lookRight, 0,
+            "VMK#297 regression guard: custom-namespace \"LookRight\" must " +
+            "still be driven for VRM 0.x legacy assets that landed in the " +
+            "custom namespace (the pre-fix path). Got \(lookRight).")
+    }
+
+    // MARK: - Setup-time detection
+
+    /// VMK#297 — with preset look-direction expressions registered (and
+    /// no custom entries), the controller's auto-detection at `setup`
+    /// should pick `.expression` mode. Pre-fix the detection only checked
+    /// `expressions.custom["LookLeft"]` and missed the preset entries.
+    ///
+    /// The fixture deliberately includes non-rigid eye bones and sets
+    /// `lookAt.type = .bone` so that the existing fallback branches
+    /// (`eyesAreRigid`, `type == .expression || no-eye-bones`) cannot
+    /// carry the test — only the preset detection can produce
+    /// `mode == .expression`.
+    func testSetupDetectsExpressionModeForPresetNamespace() throws {
+        let head = try VRMNode(index: 0, gltfNode: makeGLTFNode(name: "head"))
+        let leftEye = try VRMNode(index: 1, gltfNode: makeGLTFNode(name: "leftEye"))
+        let rightEye = try VRMNode(index: 2, gltfNode: makeGLTFNode(name: "rightEye"))
+
+        let humanoid = VRMHumanoid()
+        humanoid.humanBones[.head] = VRMHumanoid.VRMHumanBone(node: 0)
+        humanoid.humanBones[.leftEye] = VRMHumanoid.VRMHumanBone(node: 1)
+        humanoid.humanBones[.rightEye] = VRMHumanoid.VRMHumanBone(node: 2)
+
+        let model = VRMModel(
+            specVersion: .v1_0,
+            meta: VRMMeta(licenseUrl: ""),
+            humanoid: humanoid,
+            gltf: makeMinimalGLTF()
+        )
+        model.nodes = [head, leftEye, rightEye]
+        model.lookAt = VRMLookAt()
+        model.lookAt?.type = .bone   // disables the type-based fallback
+
+        let modelExpressions = VRMExpressions()
+        for preset in [VRMExpressionPreset.lookLeft, .lookRight, .lookUp, .lookDown] {
+            var expr = VRMExpression(preset: preset)
+            expr.morphTargetBinds = [VRMMorphTargetBind(node: 0, index: 0, weight: 1.0)]
+            modelExpressions.preset[preset] = expr
+        }
+        model.expressions = modelExpressions
+
+        let expressionController = VRMExpressionController()
+        for preset in [VRMExpressionPreset.lookLeft, .lookRight, .lookUp, .lookDown] {
+            expressionController.registerExpression(VRMExpression(preset: preset), for: preset)
+        }
+
+        let controller = VRMLookAtController()
+        controller.setup(model: model, expressionController: expressionController)
+
+        XCTAssertEqual(controller.mode, .expression,
+            "VMK#297: setup() must detect expression mode when preset " +
+            "look-direction expressions are registered on " +
+            "expressions.preset. Pre-fix the detection only looked at " +
+            "expressions.custom[\"LookLeft\"] and missed the spec path.")
+    }
+
+    // MARK: - VRM 0.x BlendShapeGroup preset mapping
+
+    /// VMK#297 — VRM 0.x `LookLeft`/`LookRight`/`LookUp`/`LookDown`
+    /// BlendShapeGroups must land in `expressions.preset[.lookLeft]`
+    /// etc., not in `expressions.custom["LookLeft"]`. Pre-fix
+    /// `mapVRM0PresetToVRM1` had no entries for the four look-direction
+    /// names, so they fell into the `else` branch and were stored as
+    /// custom expressions.
+    func testParserMapsVRM0LookDirectionsToPresetNamespace() throws {
+        let parser = VRMExtensionParser()
+        let vrmDict: [String: Any] = [
+            "version": "0.0",
+            "meta": ["title": "VMK297-test"],
+            "humanoid": [
+                "humanBones": [
+                    ["bone": "hips", "node": 0],
+                    ["bone": "leftUpperLeg", "node": 0],
+                    ["bone": "rightUpperLeg", "node": 0],
+                    ["bone": "leftLowerLeg", "node": 0],
+                    ["bone": "rightLowerLeg", "node": 0],
+                    ["bone": "leftFoot", "node": 0],
+                    ["bone": "rightFoot", "node": 0],
+                    ["bone": "spine", "node": 0],
+                    ["bone": "head", "node": 0],
+                    ["bone": "leftUpperArm", "node": 0],
+                    ["bone": "rightUpperArm", "node": 0],
+                    ["bone": "leftLowerArm", "node": 0],
+                    ["bone": "rightLowerArm", "node": 0],
+                    ["bone": "leftHand", "node": 0],
+                    ["bone": "rightHand", "node": 0],
+                ],
+            ],
+            "blendShapeMaster": [
+                "blendShapeGroups": [
+                    [
+                        "name": "LookLeft",
+                        "presetName": "LookLeft",
+                        "binds": [
+                            ["mesh": 0, "index": 0, "weight": 100.0],
+                        ],
+                    ],
+                    [
+                        "name": "LookRight",
+                        "presetName": "LookRight",
+                        "binds": [
+                            ["mesh": 0, "index": 1, "weight": 100.0],
+                        ],
+                    ],
+                    [
+                        "name": "LookUp",
+                        "presetName": "LookUp",
+                        "binds": [
+                            ["mesh": 0, "index": 2, "weight": 100.0],
+                        ],
+                    ],
+                    [
+                        "name": "LookDown",
+                        "presetName": "LookDown",
+                        "binds": [
+                            ["mesh": 0, "index": 3, "weight": 100.0],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+        let document = try JSONDecoder().decode(
+            GLTFDocument.self,
+            from: JSONSerialization.data(withJSONObject: ["asset": ["version": "2.0", "generator": "Test"]])
+        )
+        let model = try parser.parseVRMExtension(vrmDict, document: document)
+
+        XCTAssertNotNil(model.expressions?.preset[.lookLeft],
+            "VMK#297: VRM 0.x `LookLeft` BlendShapeGroup must map to expressions.preset[.lookLeft]")
+        XCTAssertNotNil(model.expressions?.preset[.lookRight],
+            "VMK#297: VRM 0.x `LookRight` BlendShapeGroup must map to expressions.preset[.lookRight]")
+        XCTAssertNotNil(model.expressions?.preset[.lookUp],
+            "VMK#297: VRM 0.x `LookUp` BlendShapeGroup must map to expressions.preset[.lookUp]")
+        XCTAssertNotNil(model.expressions?.preset[.lookDown],
+            "VMK#297: VRM 0.x `LookDown` BlendShapeGroup must map to expressions.preset[.lookDown]")
+        // None of these should have leaked into the custom namespace.
+        XCTAssertNil(model.expressions?.custom["LookLeft"],
+            "VMK#297: post-fix, VRM 0.x `LookLeft` should NOT appear in expressions.custom")
+    }
+}


### PR DESCRIPTION
## Summary

`VRMLookAtController.applyToExpressions` was writing to **custom-namespace** `setCustomExpressionWeight("LookLeft", …)` (PascalCase), but the VRM 1.0 spec defines `lookLeft` / `lookRight` / `lookUp` / `lookDown` as **preset** expressions on `expressions.preset` (lowercase). Spec-compliant VRM 1.0 avatars with `lookAt.type = expression` and preset gaze binds rendered with no gaze deviation — the controller's writes went to an orphan custom name that didn't exist on the asset.

A second gap in `VRMExtensionParser.mapVRM0PresetToVRM1` (missing entries for the four look-direction names) masked this for VRM 0.x assets: their `LookLeft` BlendShapeGroups fell into `expressions.custom["LookLeft"]` (PascalCase preserved), which happened to match what the controller wrote to.

Closes #297

## Fix

End-to-end. Three call sites, all on this branch:

- **`VRMLookAtController.applyToExpressions`** (`VRMLookAtController.swift:540-578`) — writes to BOTH the preset enum (`setExpressionWeight(.lookLeft, …)`) and the legacy custom name (`setCustomExpressionWeight("LookLeft", …)`). Each setter is a no-op when its target isn't registered, so spec assets land in preset and legacy assets keep working in custom — no controller-side branching.

- **`VRMLookAtController.setup`** detection block (`:218-264`) — now checks `expressions.preset[.lookLeft]` AND `expressions.custom["LookLeft"]`. Pre-fix, spec-compliant assets only reached expression mode via the no-eye-bones fallback, which doesn't fire for rigs that DO have eye bones.

- **`VRMExtensionParser.mapVRM0PresetToVRM1`** (`VRMExtensionParser.swift:590-615`) — adds `lookup` / `lookdown` / `lookleft` / `lookright` → preset enum mappings so VRM 0.x BlendShapeGroups land in the spec preset namespace going forward.

## TDD

`VRMLookAtExpressionNamespaceTests` (new file, 5 tests):

- `testApplyToExpressionsWritesPresetLookRightForRightwardGaze` — spec path, RED pre-fix.
- `testApplyToExpressionsWritesPresetLookLeftLookUpLookDown` — three remaining axes, RED pre-fix.
- `testApplyToExpressionsWritesCustomLookRightLegacyPath` — legacy VRM 0.x custom path, regression guard.
- `testSetupDetectsExpressionModeForPresetNamespace` — setup auto-detect for preset namespace (RED pre-fix; rig deliberately includes eye bones + `lookAt.type = .bone` so the existing fallbacks can't carry the test).
- `testParserMapsVRM0LookDirectionsToPresetNamespace` — VRM 0.x `LookLeft` lands in `expressions.preset[.lookLeft]`, not custom.

Full suite (`swift test --parallel`) stays green post-fix.

## Test plan

- [x] `swift test --filter VRMLookAtExpressionNamespaceTests` — 5/5 pass
- [x] `swift test --parallel --num-workers 14 -j 16 --disable-sandbox` — zero unexpected failures
- [ ] Suite-side asset extension to add a spec-compliant `vrma_lookat_*` corpus that uses preset gaze (validation across cross-impl)

## Crossref

- VMK#294 — offline `applyClip` lookAt resolve (closed in 0.16.0-rc.4). Same external symptom (10-plan PNG collapse) but different root cause; #294 unblocked the offline tick, this fixes which expression that tick writes to.
- VMK#286 — VRMA rotation-channel lookAt parsing (closed in 0.16.0-rc.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)