### PR TITLE
test(renderer): behavioral A2C edge-alpha guard (#266)

### DIFF
--- a/Tests/VRMMetalKitTests/MSAAAlphaToCoverageTests.swift
+++ b/Tests/VRMMetalKitTests/MSAAAlphaToCoverageTests.swift
@@ -380,8 +380,106 @@ final class MSAAAlphaToCoverageTests: XCTestCase {
         XCTAssertFalse(renderer1x.usesMultisampling, "1x renderer should not report MSAA")
     }
     
+    // MARK: - Behavioral integration test (#266)
+
+    /// #266: Behavioral guard that the A2C path produces a *visible* change in
+    /// rendered output, not just a selectable pipeline. Both renders use 4x MSAA
+    /// so geometry-edge antialiasing is identical between them — the only
+    /// variable is `alphaToCoverageForMASK`. Any pixel difference is therefore
+    /// attributable to alpha-to-coverage softening MASK cutout edges (gradient
+    /// coverage) instead of the hard binary alpha test.
+    ///
+    /// This is RED if A2C is ever silently disconnected at draw time
+    /// (unconditional `discard_fragment()` re-introduced, the MASK→alphaMode 3
+    /// remap removed, the A2C PSO routing reverted): the two renders collapse to
+    /// identical output and the difference count goes to ~0.
+    func testAlphaToCoverageProducesNonBinaryEdgeAlpha() async throws {
+        let modelPath = "\(modelsDirectory)/AvatarSample_A_1.0.vrm.glb"
+        try XCTSkipIf(!FileManager.default.fileExists(atPath: modelPath),
+                      "Test model not found")
+
+        let size = 384
+        let sampleCount = 4
+        let clear = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 1)
+
+        func render(alphaToCoverage: Bool) async throws -> [UInt8] {
+            var config = RendererConfig(strict: .off, sampleCount: sampleCount)
+            config.alphaToCoverageForMASK = alphaToCoverage
+            config.synchronousSpringBone = true
+            let renderer = VRMRenderer(device: device, config: config)
+
+            let model = try await VRMModel.load(
+                from: URL(fileURLWithPath: modelPath), device: device)
+            renderer.loadModel(model)
+
+            renderer.projectionMatrix = RenderTestSupport.makePerspective(
+                fovRadians: 30 * .pi / 180, aspect: 1, near: 0.05, far: 100)
+            // Close-up on the head: eyelash / eyebrow MASK cutouts are the
+            // finest alpha edges and dominate this framing.
+            renderer.viewMatrix = RenderTestSupport.makeLookAt(
+                eye: SIMD3<Float>(0, 1.45, 1.5),
+                center: SIMD3<Float>(0, 1.45, 0),
+                up: SIMD3<Float>(0, 1, 0))
+
+            return try RenderTestSupport.renderFrameMSAA(
+                renderer: renderer, device: device, size: size,
+                sampleCount: sampleCount, pixelFormat: .bgra8Unorm, clearColor: clear)
+        }
+
+        let off = try await render(alphaToCoverage: false)
+        // Control: a second A2C-off render must be bitwise identical to the
+        // first. This proves the render path is deterministic, so the `changed`
+        // count below is attributable to A2C alone and not frame jitter — a raw
+        // pixel diff is only a valid detector once this holds.
+        let off2 = try await render(alphaToCoverage: false)
+        let on = try await render(alphaToCoverage: true)
+
+        func luma(_ b: [UInt8], _ i: Int) -> Float {
+            // bgra8Unorm: byte order B,G,R,A
+            RenderTestSupport.rec709Luma(r: b[i + 2], g: b[i + 1], b: b[i])
+        }
+
+        let floor: Float = 0.02       // above the black clear
+        let changeEps: Float = 0.012  // per-channel ~3/255
+
+        var changed = 0
+        var softened = 0   // changed pixels where A2C value is an intermediate blend
+        var changedControl = 0
+        for p in stride(from: 0, to: size * size * 4, by: 4) {
+            let lo = luma(off, p)
+            let ln = luma(on, p)
+            if abs(luma(off2, p) - lo) > changeEps { changedControl += 1 }
+            if abs(ln - lo) > changeEps {
+                changed += 1
+                if ln > floor && ln < max(lo, floor) {
+                    softened += 1
+                }
+            }
+        }
+
+        print("[#266 A2C] changed=\(changed) softened=\(softened) changedControl=\(changedControl)")
+
+        XCTAssertEqual(changedControl, 0,
+            "Two A2C-off renders must be identical; a non-zero control means the " +
+            "render path is non-deterministic and the diff below is meaningless.")
+
+        // ~69 changed / 57 softened observed locally (Apple Silicon, this
+        // framing). Threshold is set well below that for cross-GPU headroom; the
+        // regression this guards against collapses `changed` to ~0 (A2C PSO
+        // routing reverted, MASK→alphaMode 3 remap removed, or unconditional
+        // discard re-introduced), so any positive floor catches it.
+        XCTAssertGreaterThan(changed, 10,
+            "A2C must visibly change MASK cutout edges vs the hard-cutout path " +
+            "(changed=\(changed)). ~0 means A2C is disconnected at draw time.")
+
+        XCTAssertGreaterThan(softened, changed / 2,
+            "Most A2C changes must be intermediate partial-coverage values " +
+            "(softened=\(softened)/\(changed)) — the non-binary edge alpha #266 " +
+            "requires, not hard on/off flips.")
+    }
+
     // MARK: - Helper Methods
-    
+
     private var modelsDirectory: String {
         ProcessInfo.processInfo.environment["VRM_MODELS_PATH"] ?? getProjectRoot()
     }

--- a/Tests/VRMMetalKitTests/RenderTestSupport.swift
+++ b/Tests/VRMMetalKitTests/RenderTestSupport.swift
@@ -57,6 +57,77 @@ enum RenderTestSupport {
         return bytes
     }
 
+    /// Renders one frame through an MSAA color attachment with a resolve
+    /// target and returns the resolved single-sample RGBA bytes.
+    ///
+    /// `drawOffscreenHeadless` forwards the caller's render pass descriptor to
+    /// `drawCore`, so supplying a multisample attachment + `.multisampleResolve`
+    /// store action exercises the same MSAA path the on-screen `MTKView` driver
+    /// uses. The renderer's pipeline states must already be built for
+    /// `sampleCount` (i.e. `RendererConfig.sampleCount == sampleCount`), or
+    /// Metal will reject the attachment/PSO sample-count mismatch.
+    @MainActor
+    static func renderFrameMSAA(
+        renderer: VRMRenderer,
+        device: MTLDevice,
+        size: Int,
+        sampleCount: Int,
+        pixelFormat: MTLPixelFormat,
+        clearColor: MTLClearColor
+    ) throws -> [UInt8] {
+        let msColorDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: pixelFormat, width: size, height: size, mipmapped: false)
+        msColorDesc.textureType = .type2DMultisample
+        msColorDesc.sampleCount = sampleCount
+        msColorDesc.usage = .renderTarget
+        msColorDesc.storageMode = .private
+
+        let resolveDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: pixelFormat, width: size, height: size, mipmapped: false)
+        resolveDesc.usage = [.renderTarget, .shaderRead]
+        resolveDesc.storageMode = .shared
+
+        let depthDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .depth32Float, width: size, height: size, mipmapped: false)
+        depthDesc.textureType = .type2DMultisample
+        depthDesc.sampleCount = sampleCount
+        depthDesc.usage = .renderTarget
+        depthDesc.storageMode = .private
+
+        guard let msColor = device.makeTexture(descriptor: msColorDesc),
+              let resolveTex = device.makeTexture(descriptor: resolveDesc),
+              let msDepth = device.makeTexture(descriptor: depthDesc),
+              let queue = device.makeCommandQueue(),
+              let cb = queue.makeCommandBuffer() else {
+            throw XCTSkip("Could not allocate MSAA render targets")
+        }
+
+        let rpd = MTLRenderPassDescriptor()
+        rpd.colorAttachments[0].texture = msColor
+        rpd.colorAttachments[0].resolveTexture = resolveTex
+        rpd.colorAttachments[0].loadAction = .clear
+        rpd.colorAttachments[0].clearColor = clearColor
+        rpd.colorAttachments[0].storeAction = .multisampleResolve
+        rpd.depthAttachment.texture = msDepth
+        rpd.depthAttachment.loadAction = .clear
+        rpd.depthAttachment.clearDepth = 1.0
+        rpd.depthAttachment.storeAction = .dontCare
+
+        renderer.drawOffscreenHeadless(
+            to: msColor, depth: msDepth,
+            commandBuffer: cb, renderPassDescriptor: rpd
+        )
+        cb.commit()
+        cb.waitUntilCompleted()
+
+        var bytes = [UInt8](repeating: 0, count: size * size * 4)
+        bytes.withUnsafeMutableBytes { buf in
+            resolveTex.getBytes(buf.baseAddress!, bytesPerRow: size * 4,
+                                from: MTLRegionMake2D(0, 0, size, size), mipmapLevel: 0)
+        }
+        return bytes
+    }
+
     static func meanChannelRGBA(
         _ bytes: [UInt8],
         size: Int,


### PR DESCRIPTION
## What

Closes #266. Adds the behavioral regression test the MSAA alpha-to-coverage suite was missing — it only checked that the parts exist (PSO objects, descriptor flags, routing), never that A2C produces a visible change at draw time (the failure mode where A2C was dead at draw time for an extended period with the suite green).

`testAlphaToCoverageProducesNonBinaryEdgeAlpha`: render AvatarSample_A at 4× MSAA twice, identical except `alphaToCoverageForMASK`. Geometry-edge MSAA is therefore constant between the two renders, so any pixel difference isolates A2C softening MASK cutout edges (gradient coverage) vs the hard binary alpha test.

- A **determinism control** (A2C-off vs A2C-off → bitwise identical) is asserted first, so the changed-pixel count is the A2C effect, not frame jitter — a raw pixel diff is only a valid detector once this holds.
- Asserts `changed > 10` (observed ~69) and `softened > changed/2` (observed ~57) — most changes are intermediate partial-coverage values, the non-binary edge alpha the issue requires.
- **RED-verified**: neutralizing the opt-in collapses `changed → 0` and both assertions fail.

Adds `RenderTestSupport.renderFrameMSAA` (multisample attachment + resolve readback); the existing helper was single-sample only.

Note: the A2C feature itself (routing + MASK→`alphaMode 3` remap + fractional alpha output) is already fully wired — this PR is the missing guard. Retroactively satisfies the behavioral-test acceptance of the already-closed #264.

## Verification

`MSAAAlphaToCoverageTests` + `AlphaToCoverageTests` pass locally (24 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)