### PR TITLE
fix(springbone): exempt VRM 0.x bust chains from gravity 0→1.0 substitution (#306)

### DIFF
--- a/Sources/VRMMetalKit/Loader/VRMExtensionParser.swift
+++ b/Sources/VRMMetalKit/Loader/VRMExtensionParser.swift
@@ -188,7 +188,7 @@ public class VRMExtensionParser {
         }
         // VRM 0.0 uses secondaryAnimation in the main VRM extension
         else if let secondaryAnimation = vrmDict["secondaryAnimation"] as? [String: Any] {
-            model.springBone = parseSecondaryAnimation(secondaryAnimation)
+            model.springBone = parseSecondaryAnimation(secondaryAnimation, document: document)
         }
 
         // Parse VRM 0.x materialProperties (MToon data at document level)
@@ -995,7 +995,21 @@ public class VRMExtensionParser {
 
     // MARK: - VRM 0.0 Secondary Animation Support
 
-    private func parseSecondaryAnimation(_ dict: [String: Any]) -> VRMSpringBone {
+    /// Returns true when a 0.x spring chain is a bust/breast jiggle chain, by
+    /// group comment or any of its bone-node names. Such chains are anchored to
+    /// the chest and author `gravityPower = 0` deliberately, so they are exempt
+    /// from the 0→1.0 gravity substitution below (see #306).
+    private func isBustChain(comment: String?, boneNodes: [Int], document: GLTFDocument) -> Bool {
+        func matches(_ s: String?) -> Bool {
+            guard let s = s?.lowercased() else { return false }
+            return s.contains("bust") || s.contains("breast")
+        }
+        if matches(comment) { return true }
+        for node in boneNodes where matches(document.nodes?[safe: node]?.name) { return true }
+        return false
+    }
+
+    private func parseSecondaryAnimation(_ dict: [String: Any], document: GLTFDocument) -> VRMSpringBone {
         var springBone = VRMSpringBone()
         springBone.specVersion = "0.0"  // Mark as VRM 0.0 format
 
@@ -1008,6 +1022,13 @@ public class VRMExtensionParser {
                 if let center = groupDict["center"] as? Int {
                     spring.center = center
                 }
+
+                // Bust/breast chains keep their authored (zero) gravity; all other
+                // 0.x chains receive the 0→1.0 substitution below.
+                let chainIsBust = isBustChain(
+                    comment: groupDict["comment"] as? String,
+                    boneNodes: groupDict["bones"] as? [Int] ?? [],
+                    document: document)
 
                 // Bones array becomes joints
                 if let bones = groupDict["bones"] as? [Int] {
@@ -1058,7 +1079,9 @@ public class VRMExtensionParser {
                         } else {
                             rawGravityPower = 0.0
                         }
-                        joint.gravityPower = rawGravityPower > 0 ? rawGravityPower : 1.0
+                        // Bust/breast chains keep authored gravity (commonly 0) so they
+                        // do not droop; other chains fall back to 1.0 when authored 0 (#306).
+                        joint.gravityPower = (chainIsBust || rawGravityPower > 0) ? rawGravityPower : 1.0
 
                         if let dragFloat = groupDict["dragForce"] as? Float {
                             joint.dragForce = dragFloat

--- a/Tests/VRMMetalKitTests/VRMExtensionParserTests.swift
+++ b/Tests/VRMMetalKitTests/VRMExtensionParserTests.swift
@@ -706,6 +706,53 @@ final class VRMExtensionParserTests: XCTestCase {
         XCTAssertEqual(model.springBone?.springs.first?.joints.count, 3)
     }
 
+    /// Regression for #306: VRM 0.x bust/breast chains author `gravityPower = 0`
+    /// deliberately (they are anchored to the chest and must not droop). VMK's
+    /// 0.x quirk substitutes `0 → 1.0` so hanging chains (hair, skirts) fall;
+    /// that substitution must NOT apply to bust chains, or the load-time
+    /// warmup collapses the bust. Hair keeps the substitution.
+    func testVRM0BustChainRespectsZeroGravityWhileHairDoesNot() throws {
+        let humanBones: [[String: Any]] = [
+            ["bone": "hips", "node": 0], ["bone": "leftUpperLeg", "node": 1],
+            ["bone": "rightUpperLeg", "node": 2], ["bone": "leftLowerLeg", "node": 3],
+            ["bone": "rightLowerLeg", "node": 4], ["bone": "leftFoot", "node": 5],
+            ["bone": "rightFoot", "node": 6], ["bone": "spine", "node": 7],
+            ["bone": "chest", "node": 8], ["bone": "neck", "node": 9],
+            ["bone": "head", "node": 10], ["bone": "leftShoulder", "node": 11],
+            ["bone": "rightShoulder", "node": 12], ["bone": "leftUpperArm", "node": 13],
+            ["bone": "rightUpperArm", "node": 14], ["bone": "leftLowerArm", "node": 15],
+            ["bone": "rightLowerArm", "node": 16], ["bone": "leftHand", "node": 17],
+            ["bone": "rightHand", "node": 18]
+        ]
+        let vrmDict: [String: Any] = [
+            "version": "0.0",
+            "meta": ["title": "Test", "author": "Test"],
+            "humanoid": ["humanBones": humanBones],
+            "secondaryAnimation": [
+                "boneGroups": [
+                    ["comment": "Bust", "bones": [19], "stiffness": 0.75,
+                     "gravityPower": 0.0, "dragForce": 0.05],
+                    ["comment": "Hair", "bones": [20], "stiffness": 0.85,
+                     "gravityPower": 0.0, "dragForce": 0.4]
+                ]
+            ]
+        ]
+
+        let document = createMinimalGLTFDocument(
+            nodes: 21,
+            nodeNames: [19: "J_Sec_L_Bust1", 20: "J_Sec_Hair1_01"])
+        let model = try parser.parseVRMExtension(vrmDict, document: document)
+
+        let springs = try XCTUnwrap(model.springBone?.springs)
+        let bust = try XCTUnwrap(springs.first { $0.joints.contains { $0.node == 19 } })
+        let hair = try XCTUnwrap(springs.first { $0.joints.contains { $0.node == 20 } })
+
+        XCTAssertEqual(bust.joints.first?.gravityPower, 0.0,
+                       "Bust chain must keep authored gravityPower = 0 (no 0→1.0 substitution)")
+        XCTAssertEqual(hair.joints.first?.gravityPower, 1.0,
+                       "Hair chain must keep the 0→1.0 substitution so it still falls")
+    }
+
     // MARK: - Error Handling Tests
 
     func testMissingMetaThrowsError() {
@@ -1181,7 +1228,7 @@ final class VRMExtensionParserTests: XCTestCase {
 
     // MARK: - Helper Methods
 
-    private func createMinimalGLTFDocument(nodes: Int = 1, extensions: [String: Any]? = nil) -> GLTFDocument {
+    private func createMinimalGLTFDocument(nodes: Int = 1, extensions: [String: Any]? = nil, nodeNames: [Int: String] = [:]) -> GLTFDocument {
         // Create a minimal GLTF document as JSON and decode it
         // Include all required humanoid bones for validation
         let requiredBones = [
@@ -1199,7 +1246,7 @@ final class VRMExtensionParserTests: XCTestCase {
             "scene": 0,
             "scenes": [["nodes": Array(0..<nodeCount)]],
             "nodes": (0..<nodeCount).map { i in
-                ["name": "node_\(i)"]
+                ["name": nodeNames[i] ?? "node_\(i)"]
             }
         ]
         


### PR DESCRIPTION
Fixes #306.

## Problem
The same VRoid model exported to VRM 0.x and VRM 1.0 rendered a **collapsed bust** in 0.x while 1.0 was correct.

## Root cause
`parseSecondaryAnimation` applies a VRM 0.x quirk that substitutes `gravityPower 0 → 1.0` so chains that author zero gravity (hair, skirts) still fall. Bust/breast chains author `gravityPower = 0` **deliberately** — anchored to the chest, they must not droop. The forced gravity plus the unconditional load-time `warmupPhysics(steps: 30)` settled the bust into a sag.

The cross-body chain topology (`[L_Bust1, R_Bust1]` merged into one chain) was a red herring — splitting it produced **zero render change**; respecting authored gravity made the bust **pixel-identical** to the no-warmup ground truth.

## Fix
Exempt bust/breast chains (by group comment or bone-node name) from the `0→1.0` substitution; preserve it for every other chain. This is deliberately surgical: the substitution is load-bearing for hair (`AvatarSample_A`'s hair is calibrated against it, frozen by `SpringBoneRegressionTests`).

## ⚠️ Behaviour change
VRM 0.x bust/breast spring chains now honour authored `gravityPower` (commonly `0`) instead of being forced to `1.0`. Static droop is removed; motion-driven jiggle is preserved.

## Verification
- New test `testVRM0BustChainRespectsZeroGravityWhileHairDoesNot` (RED→GREEN).
- `SpringBoneRegressionTests` (frozen `AvatarSample_A` trajectory) still passes — hair untouched.
- Full suite green.
- **Static:** `AvatarSample_K_0.0` bust now matches its `1.0` export (pixel-identical NdotL).
- **Dynamic (jiggle):** Jumping-Jacks VRMA, spring bones on — bust travels ~36–39 mm, **identical** amplitudes between 0.x and 1.0 for every shared mesh-driving bone. `gravityPower=0` removed the droop without killing inertia-driven jiggle.

## Follow-up (separate, not blocking)
VRM 0.x `boneGroups[].bones` lists independent chain roots, but the parser concatenates them into one chain (e.g. 6-root coat-skirt groups). No visible effect today; incorrect per spec. Worth a dedicated fix + descendant-walking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
