### PR TITLE
fix(springbone): respect authored VRM 0.x gravityPower=0 instead of forcing 1.0 (#326)

### DIFF
--- a/Sources/VRMMetalKit/Loader/VRMExtensionParser.swift
+++ b/Sources/VRMMetalKit/Loader/VRMExtensionParser.swift
@@ -995,20 +995,6 @@ public class VRMExtensionParser {
 
     // MARK: - VRM 0.0 Secondary Animation Support
 
-    /// Returns true when a 0.x spring chain is a bust/breast jiggle chain, by
-    /// group comment or any of its bone-node names. Such chains are anchored to
-    /// the chest and author `gravityPower = 0` deliberately, so they are exempt
-    /// from the 0→1.0 gravity substitution below (see #306).
-    private func isBustChain(comment: String?, boneNodes: [Int], document: GLTFDocument) -> Bool {
-        func matches(_ s: String?) -> Bool {
-            guard let s = s?.lowercased() else { return false }
-            return s.contains("bust") || s.contains("breast")
-        }
-        if matches(comment) { return true }
-        for node in boneNodes where matches(document.nodes?[safe: node]?.name) { return true }
-        return false
-    }
-
     private func parseSecondaryAnimation(_ dict: [String: Any], document: GLTFDocument) -> VRMSpringBone {
         var springBone = VRMSpringBone()
         springBone.specVersion = "0.0"  // Mark as VRM 0.0 format
@@ -1022,13 +1008,6 @@ public class VRMExtensionParser {
                 if let center = groupDict["center"] as? Int {
                     spring.center = center
                 }
-
-                // Bust/breast chains keep their authored (zero) gravity; all other
-                // 0.x chains receive the 0→1.0 substitution below.
-                let chainIsBust = isBustChain(
-                    comment: groupDict["comment"] as? String,
-                    boneNodes: groupDict["bones"] as? [Int] ?? [],
-                    document: document)
 
                 // Bones array becomes joints
                 if let bones = groupDict["bones"] as? [Int] {
@@ -1051,37 +1030,22 @@ public class VRMExtensionParser {
                             joint.stiffness = 1.0  // Default only if not found at all
                         }
 
-                        // VRM 0.x quirk: many real-world models export gravityPower=0 (or omit it)
-                        // but clearly expect gravity to work (hair falls, skirts swing). The VRM 0.x
-                        // spec did not define a meaningful default, so authors relied on runtime
-                        // behavior that defaulted to gravity-on. Forcing 0→1.0 preserves that
-                        // real-world behavior for VRM 0.x only; VRM 1.0 respects explicit 0.0.
-                        //
-                        // ⚠️ LOAD-BEARING: this 0→1.0 substitution is paired with the
-                        // INERTIA COMPENSATION block inside the `springBonePredict`
-                        // Metal kernel. AvatarSample_A's hair tuning
-                        // (`stiffness=0.85, gravityPower=0, dragForce=0.4`) is
-                        // calibrated against THIS combination; touching either side
-                        // in isolation visibly breaks the model. Intent is the
-                        // VRM 0.x author tuning — not the test — but the local
-                        // characterization gate `SpringBoneRegressionTests` freezes
-                        // the resulting trajectory and will trip on any drift. If a
-                        // change here is intentional (e.g. matching three-vrm
-                        // post-conformance), regenerate the baseline alongside it.
-                        // See #162 for the equilibrium analysis.
-                        let rawGravityPower: Float
+                        // VRM 0.x gravityPower is respected as authored, matching
+                        // UniVRM (the 0.x reference) and three-vrm: gravityPower=0
+                        // means an inert chain (#326). The earlier 0→1.0 substitution
+                        // over-applied gravity to chains the artist deliberately
+                        // authored as inert (e.g. bangs meant to lie flat), parting
+                        // them — a visible divergence from every other VRM renderer.
+                        // Absent key defaults to 0 (inert), same as VRM 1.0.
                         if let gpFloat = groupDict["gravityPower"] as? Float {
-                            rawGravityPower = gpFloat
+                            joint.gravityPower = gpFloat
                         } else if let gpDouble = groupDict["gravityPower"] as? Double {
-                            rawGravityPower = Float(gpDouble)
+                            joint.gravityPower = Float(gpDouble)
                         } else if let gpNum = groupDict["gravityPower"] as? NSNumber {
-                            rawGravityPower = gpNum.floatValue
+                            joint.gravityPower = gpNum.floatValue
                         } else {
-                            rawGravityPower = 0.0
+                            joint.gravityPower = 0.0
                         }
-                        // Bust/breast chains keep authored gravity (commonly 0) so they
-                        // do not droop; other chains fall back to 1.0 when authored 0 (#306).
-                        joint.gravityPower = (chainIsBust || rawGravityPower > 0) ? rawGravityPower : 1.0
 
                         if let dragFloat = groupDict["dragForce"] as? Float {
                             joint.dragForce = dragFloat

--- a/Sources/VRMMetalKit/Shaders/SpringBonePredict.metal
+++ b/Sources/VRMMetalKit/Shaders/SpringBonePredict.metal
@@ -112,12 +112,11 @@ kernel void springBonePredict(
     // constraint pulls child up, and that becomes upward velocity that pumps the chain
     // into sustained oscillation (the flutter signature).
     //
-    // ⚠️ LOAD-BEARING: this compensation block is paired with the VRM 0.x
-    // gravityPower=0→1.0 substitution in `parseSecondaryAnimation`
-    // (VRMExtensionParser). AvatarSample_A's tuning is calibrated against the
-    // combination; changing either in isolation breaks the model. The local
-    // regression gate `SpringBoneRegressionTests` freezes the trajectory and
-    // will trip on drift; see #162 for the equilibrium analysis.
+    // This compensation is general-purpose Verlet inertia handling, independent
+    // of any per-joint gravity. (#326 removed the old VRM 0.x gravityPower=0→1.0
+    // substitution; authored gravityPower is now respected verbatim.) The local
+    // regression gate `SpringBoneRegressionTests` freezes the AvatarSample_A_1.0
+    // trajectory and will trip on drift here.
     //
     // SETTLING PERIOD: Skip compensation during initial frames to let bones settle naturally
     // with gravity. Otherwise compensation fights the settling and bones stay in bind pose.

--- a/Tests/VRMMetalKitTests/SpringBoneSpecComplianceTests.swift
+++ b/Tests/VRMMetalKitTests/SpringBoneSpecComplianceTests.swift
@@ -183,9 +183,12 @@ final class SpringBoneSpecComplianceTests: XCTestCase {
         }
     }
 
-    /// VRM 0.x: explicit gravityPower=0.0 must be forced to 1.0 (real-world quirk fix).
-    /// Many VRM 0.x models export gravityPower=0 but expect gravity to work.
-    func testVRM0ExplicitGravityPowerZeroIsForcedToOne() throws {
+    /// VRM 0.x: explicit gravityPower=0.0 must be respected as inert (#326),
+    /// matching UniVRM (the 0.x reference) and three-vrm. The old VMK quirk
+    /// forced 0→1.0, which over-applied gravity to chains the artist authored
+    /// inert (e.g. bangs meant to lie flat), parting them — a visible divergence
+    /// from every other VRM renderer.
+    func testVRM0ExplicitGravityPowerZeroIsRespected() throws {
         let (vrmDict, document) = makeMinimalVRM0Dict(secondaryAnimation: [
             "boneGroups": [[
                 "comment": "Hair",
@@ -202,9 +205,9 @@ final class SpringBoneSpecComplianceTests: XCTestCase {
             return
         }
         for joint in spring.joints {
-            XCTAssertEqual(joint.gravityPower, 1.0, accuracy: 0.0001,
-                "VRM 0.x gravityPower=0 must be forced to 1.0 (real-world quirk: many " +
-                "VRM 0.x models export 0 but expect gravity to work).")
+            XCTAssertEqual(joint.gravityPower, 0.0, accuracy: 0.0001,
+                "VRM 0.x gravityPower=0 must stay inert (no 0→1.0 substitution, #326) — " +
+                "matches UniVRM/three-vrm.")
         }
     }
 

--- a/Tests/VRMMetalKitTests/VRMExtensionParserTests.swift
+++ b/Tests/VRMMetalKitTests/VRMExtensionParserTests.swift
@@ -706,12 +706,14 @@ final class VRMExtensionParserTests: XCTestCase {
         XCTAssertEqual(model.springBone?.springs.first?.joints.count, 3)
     }
 
-    /// Regression for #306: VRM 0.x bust/breast chains author `gravityPower = 0`
-    /// deliberately (they are anchored to the chest and must not droop). VMK's
-    /// 0.x quirk substitutes `0 → 1.0` so hanging chains (hair, skirts) fall;
-    /// that substitution must NOT apply to bust chains, or the load-time
-    /// warmup collapses the bust. Hair keeps the substitution.
-    func testVRM0BustChainRespectsZeroGravityWhileHairDoesNot() throws {
+    /// Regression for #326: VRM 0.x chains that author `gravityPower = 0` must
+    /// stay inert, matching UniVRM/three-vrm. The old VMK quirk substituted
+    /// `0 → 1.0` for non-bust chains (so hair/skirts fell), which over-applied
+    /// gravity to chains the artist authored as inert (e.g. bangs the artist
+    /// wants flat against the forehead). The substitution is removed: authored
+    /// values are respected for every chain. Bust already kept 0 (#306); hair
+    /// now keeps 0 too. Authored non-zero values pass through unchanged.
+    func testVRM0RespectsAuthoredZeroGravityForAllChains() throws {
         let humanBones: [[String: Any]] = [
             ["bone": "hips", "node": 0], ["bone": "leftUpperLeg", "node": 1],
             ["bone": "rightUpperLeg", "node": 2], ["bone": "leftLowerLeg", "node": 3],
@@ -733,24 +735,30 @@ final class VRMExtensionParserTests: XCTestCase {
                     ["comment": "Bust", "bones": [19], "stiffness": 0.75,
                      "gravityPower": 0.0, "dragForce": 0.05],
                     ["comment": "Hair", "bones": [20], "stiffness": 0.85,
-                     "gravityPower": 0.0, "dragForce": 0.4]
+                     "gravityPower": 0.0, "dragForce": 0.4],
+                    ["comment": "Skirt", "bones": [21], "stiffness": 0.2,
+                     "gravityPower": 0.5, "dragForce": 0.3]
                 ]
             ]
         ]
 
         let document = createMinimalGLTFDocument(
-            nodes: 21,
-            nodeNames: [19: "J_Sec_L_Bust1", 20: "J_Sec_Hair1_01"])
+            nodes: 22,
+            nodeNames: [19: "J_Sec_L_Bust1", 20: "J_Sec_Hair1_01", 21: "J_Sec_Skirt1"])
         let model = try parser.parseVRMExtension(vrmDict, document: document)
 
         let springs = try XCTUnwrap(model.springBone?.springs)
         let bust = try XCTUnwrap(springs.first { $0.joints.contains { $0.node == 19 } })
         let hair = try XCTUnwrap(springs.first { $0.joints.contains { $0.node == 20 } })
+        let skirt = try XCTUnwrap(springs.first { $0.joints.contains { $0.node == 21 } })
 
         XCTAssertEqual(bust.joints.first?.gravityPower, 0.0,
-                       "Bust chain must keep authored gravityPower = 0 (no 0→1.0 substitution)")
-        XCTAssertEqual(hair.joints.first?.gravityPower, 1.0,
-                       "Hair chain must keep the 0→1.0 substitution so it still falls")
+                       "Bust chain must keep authored gravityPower = 0")
+        XCTAssertEqual(hair.joints.first?.gravityPower, 0.0,
+                       "Hair authored gravityPower = 0 must stay inert (no 0→1.0 substitution, #326) " +
+                       "— matches UniVRM/three-vrm")
+        XCTAssertEqual(skirt.joints.first?.gravityPower, 0.5,
+                       "Authored non-zero gravityPower must pass through unchanged")
     }
 
     // MARK: - Error Handling Tests


### PR DESCRIPTION
Closes #326

## Root cause of the "hair still looks wrong" report

After rc.4 (#324) fixed the 9.8× gravity *magnitude*, Muse still saw wrong hair on a VRM 0.0 avatar. This is why: VMK's 0.x loader substitutes `gravityPower = 0 → 1.0` for every non-bust chain (`parseSecondaryAnimation`). UniVRM (the 0.x reference) and three-vrm treat `gravityPower = 0` as **inert**, so the substitution over-applies gravity to chains the artist authored as inert — most visibly **bangs meant to lie flat get parted/lifted**.

rc.4 corrected the magnitude; the substitution still handed those 0-power chains full *spec-scale* gravity. Necessary-but-not-sufficient — this PR removes the source.

## Change
- Respect authored `gravityPower` verbatim for VRM 0.x (absent key → `0`, same as VRM 1.0).
- Remove the substitution and the now-subsumed **bust exemption** (#306: bust authored `0` → stays `0` naturally; no special-case needed).
- The `springBonePredict` inertia-compensation block is general-purpose Verlet handling, unaffected; corrected its stale "paired with the substitution" comment.

## Per #326's decision matrix
Lands in the one fix-forcing row: **divergent from the oracle AND visibly wrong on real Muse content.** Oracle (UniVRM/three-vrm) leaves `gravityPower=0` inert; VMK diverged; the bangs defect is clearly visible.

## Validation
- **Parser tests flipped to spec behavior** (authored `0` stays inert for *all* chains incl. hair; non-zero preserved) — RED before, GREEN after. `testVRM0RespectsAuthoredZeroGravityForAllChains`, `testVRM0ExplicitGravityPowerZeroIsRespected`.
- **Regression baselines unaffected:** `SpringBoneRegressionTests` runs on `AvatarSample_A_1.0` (the 1.0 path never hit the 0.x substitution) → no drift, no regen.
- **Float check (headless):** AvatarSample_A_0.0 and the Muse 0.0 avatar do **not** float without the forced gravity. Muse bangs go **parted → flat** (matches three-vrm). Side hair hangs naturally.
- Full suite green except the pre-existing `MToonShaderGPUTests.testShaderSourceHashMatchesKnownGood` stale-hash (unrelated; `MToonShader.metal` untouched).

## Follow-on
After merge: cut `0.17.0-rc.5` (pre-release; behaviour change) and bump Muse's pin. Stays pre-release pending Muse validation per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)