### PR TITLE
feat(bench): VRMBenchmark CI render-perf regression gate (#156)

### DIFF
--- a/.benchmark-baseline.json
+++ b/.benchmark-baseline.json
@@ -1,0 +1,65 @@
+{
+  "config" : {
+    "height" : 1024,
+    "lighting" : "standard",
+    "loading" : "default",
+    "mode" : "render",
+    "sampleCount" : 1,
+    "springBoneQuality" : "ultra",
+    "width" : 1024
+  },
+  "input" : {
+    "frames" : 500,
+    "vrm" : "AvatarSample_A_1.0.vrm.glb",
+    "warmup" : 30
+  },
+  "label" : "ci-baseline",
+  "schemaVersion" : 1,
+  "stats" : {
+    "animation" : {
+      "count" : 500,
+      "maxMs" : 4.1676685214042664e-05,
+      "meanMs" : 9.499606676399708e-06,
+      "medianMs" : 0,
+      "minMs" : 0,
+      "p95Ms" : 4.1676685214042664e-05,
+      "p99Ms" : 4.1676685214042664e-05,
+      "stddevMs" : 1.748022180776577e-05
+    },
+    "encode" : {
+      "count" : 500,
+      "maxMs" : 0.3299583331681788,
+      "meanMs" : 0.21439650119282305,
+      "medianMs" : 0.20558334654197097,
+      "minMs" : 0.18720829393714666,
+      "p95Ms" : 0.2552916994318366,
+      "p99Ms" : 0.27641665656119585,
+      "stddevMs" : 0.023452531229164325
+    },
+    "render" : {
+      "count" : 500,
+      "maxMs" : 0.7300833240151405,
+      "meanMs" : 0.5273938343161717,
+      "medianMs" : 0.5250416579656303,
+      "minMs" : 0.4528750432655215,
+      "p95Ms" : 0.6405416643247008,
+      "p99Ms" : 0.6715416675433517,
+      "stddevMs" : 0.045933004981669315
+    },
+    "wait" : {
+      "count" : 500,
+      "maxMs" : 0.4766250494867563,
+      "meanMs" : 0.31293558154720813,
+      "medianMs" : 0.30479166889563203,
+      "minMs" : 0.255583378020674,
+      "p95Ms" : 0.4329583025537431,
+      "p99Ms" : 0.4567500436678529,
+      "stddevMs" : 0.04309844512528688
+    }
+  },
+  "system" : {
+    "host" : "pauls-mac-studio-128.local",
+    "os" : "macOS"
+  },
+  "timestamp" : "2026-06-07T19:20:00Z"
+}

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -138,6 +138,10 @@ jobs:
     needs: gate
     runs-on: [self-hosted, macOS]
     timeout-minutes: 30
+    # Serialize refreshes so two main pushes can't race the baseline commit.
+    concurrency:
+      group: bench-refresh-main
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,10 +1,43 @@
 name: Bench
 
-# Manual-trigger only for now (issue #156, phase 1).
-# A follow-up PR will add a pull_request trigger + committed baseline +
-# perf-override label once we have a few real runs to set thresholds against.
+# Performance regression gate (issue #156).
+#
+# SECURITY — self-hosted runner, PUBLIC repo:
+# This workflow runs on a self-hosted macOS runner so the committed absolute
+# frame-time baseline is captured on, and compared against, fixed hardware.
+# Because the repo is public, it MUST NOT trigger on `pull_request`: a fork PR
+# would run arbitrary code (build scripts, the benchmark, SwiftPM plugins) on
+# the runner host. The gate therefore triggers on `push` only — branches the
+# maintainer pushes are trusted code. Fork PRs are still covered by the
+# GitHub-hosted lint/codeql workflows; they just don't get the perf gate.
+#
+# Modes (by event):
+#   • push (any branch) → GATE: benchmark the committed reference model against
+#     the committed .benchmark-baseline.json; fail if render.median/p95 regress
+#     past threshold. Bypass with `[perf-override]` in the commit message.
+#   • push to main → REFRESH (needs: gate): if the gate passed and render.median
+#     moved beyond the noise floor, commit an updated baseline. Gating before
+#     refresh means a regression never silently raises the bar.
+#   • workflow_dispatch → AD-HOC: benchmark an arbitrary URL-fetched model.
+#
+# The reference model AvatarSample_A_1.0.vrm.glb is committed (whitelisted in
+# .gitignore), so no network fetch is needed for the gate.
+#
+# Runner: register a self-hosted runner with labels [self-hosted, macOS]. The
+# host should hold no secrets reachable from the workflow. Until one is
+# registered, push runs queue.
 
 on:
+  push:
+    branches: ["**"]
+    paths:
+      - "Sources/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - "Makefile"
+      - "**/*.metal"
+      - ".benchmark-baseline.json"
+      - ".github/workflows/bench.yaml"
   workflow_dispatch:
     inputs:
       frames:
@@ -32,42 +65,151 @@ on:
         required: false
         default: ""
 
+# Least privilege at the workflow level; the refresh job opts up to write.
 permissions:
   contents: read
 
-# All workflow_dispatch inputs are user-supplied and reach shell commands via
-# env vars only — never via ${{ … }} interpolation inside run: scripts.
-# That keeps untrusted strings from being parsed by the shell.
+# Gate / refresh tunables. Median is the stable headline metric (~4.5 % run-to-
+# run on the reference hardware); p95 is noisier (~15 %), so it gets more head-
+# room. Only the `render` total phase is gated (--gate-phase render); the
+# encode/wait/animation sub-phases are skipped (see issue #156).
+env:
+  BASELINE_FILE: .benchmark-baseline.json
+  REFERENCE_MODEL: AvatarSample_A_1.0.vrm.glb
+  GATE_FRAMES: "500"
+  GATE_WARMUP: "30"
+  GATE_THRESHOLD: "10:20"     # median +10 %, p95 +20 %
+  REFRESH_MIN_MOVE_PCT: "5"   # only re-commit the baseline when median moves > this
 
 jobs:
-  bench:
-    name: Run VRMBenchmark
-    runs-on: macos-latest
+  # --------------------------------------------------------------------------
+  # GATE — every push. Read-only token.
+  # --------------------------------------------------------------------------
+  gate:
+    name: Perf gate
+    if: github.event_name == 'push'
+    runs-on: [self-hosted, macOS]
     timeout-minutes: 30
-
+    permissions:
+      contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
+      - uses: actions/checkout@v4
       - name: Select Xcode with Swift 6.2
         run: |
           XCODE=$(ls -d /Applications/Xcode_26* /Applications/Xcode_27* 2>/dev/null | sort -V | tail -1)
           if [ -z "$XCODE" ]; then
-            echo "::error::No Xcode 26 (or newer) found"
-            ls /Applications | grep -i Xcode || true
-            exit 1
+            echo "::error::No Xcode 26 (or newer) found"; exit 1
           fi
           sudo xcode-select -s "$XCODE/Contents/Developer"
+      - run: swift package resolve
+      - run: make shaders
+      - run: swift build -c release --product VRMBenchmark
+      - name: Run gate
+        env:
+          OVERRIDE: ${{ contains(github.event.head_commit.message, '[perf-override]') }}
+        run: |
+          set -uo pipefail
+          if [ ! -f "$BASELINE_FILE" ]; then
+            echo "::warning::$BASELINE_FILE not found on this ref — skipping gate."
+            exit 0
+          fi
+          set +e
+          .build/release/VRMBenchmark "$REFERENCE_MODEL" \
+            --mode render --frames "$GATE_FRAMES" --warmup "$GATE_WARMUP" \
+            --width 1024 --height 1024 --label "push-${GITHUB_SHA:0:12}" \
+            --baseline "$BASELINE_FILE" --gate-phase render --threshold "$GATE_THRESHOLD"
+          code=$?
+          set -e
+          if [ "$OVERRIDE" = "true" ]; then
+            echo "::notice::[perf-override] in commit message — regression (if any) not blocking."
+            exit 0
+          fi
+          if [ "$code" -ne 0 ]; then
+            echo "::error::render frame-time regressed past $GATE_THRESHOLD vs $BASELINE_FILE. If intentional, put [perf-override] in the commit message and refresh the baseline."
+          fi
+          exit $code
 
-      - name: Resolve dependencies
-        run: swift package resolve
+  # --------------------------------------------------------------------------
+  # REFRESH — main only, after the gate passes. Write token scoped to this job.
+  # --------------------------------------------------------------------------
+  refresh:
+    name: Refresh baseline
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: gate
+    runs-on: [self-hosted, macOS]
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode with Swift 6.2
+        run: |
+          XCODE=$(ls -d /Applications/Xcode_26* /Applications/Xcode_27* 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE" ]; then
+            echo "::error::No Xcode 26 (or newer) found"; exit 1
+          fi
+          sudo xcode-select -s "$XCODE/Contents/Developer"
+      - run: swift package resolve
+      - run: make shaders
+      - run: swift build -c release --product VRMBenchmark
+      - name: Measure and refresh
+        run: |
+          set -euo pipefail
+          .build/release/VRMBenchmark "$REFERENCE_MODEL" \
+            --mode render --frames "$GATE_FRAMES" --warmup "$GATE_WARMUP" \
+            --width 1024 --height 1024 --label "main-${GITHUB_SHA:0:12}" \
+            --json .bench-new.json >/dev/null
 
-      - name: Compile shaders
-        run: make shaders
+          # All JSON parsing + arithmetic happens INSIDE python, reading paths
+          # from env and coercing to float (raises on non-numeric) — no value
+          # is ever spliced into shell or python source.
+          DECISION=$(NEW_FILE=.bench-new.json python3 - <<'PY'
+          import json, os, sys
+          new = float(json.load(open(os.environ["NEW_FILE"]))["stats"]["render"]["medianMs"])
+          base_path = os.environ["BASELINE_FILE"]
+          if not os.path.exists(base_path):
+              print("REFRESH"); sys.exit(0)
+          old = float(json.load(open(base_path))["stats"]["render"]["medianMs"])
+          move = abs(new - old) / old * 100.0 if old > 0 else 100.0
+          min_move = float(os.environ["REFRESH_MIN_MOVE_PCT"])
+          sys.stderr.write(f"render.median old={old:.4f}ms new={new:.4f}ms move={move:.2f}%\n")
+          print("REFRESH" if move > min_move else "KEEP")
+          PY
+          )
+          echo "decision: $DECISION"
+          if [ "$DECISION" != "REFRESH" ]; then
+            echo "Within ±${REFRESH_MIN_MOVE_PCT}% noise floor — baseline unchanged."
+            exit 0
+          fi
+          mv .bench-new.json "$BASELINE_FILE"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$BASELINE_FILE"
+          git commit -m "chore(bench): refresh render baseline [skip ci]"
+          git push
 
-      - name: Build VRMBenchmark (release)
-        run: swift build -c release --product VRMBenchmark
-
+  # --------------------------------------------------------------------------
+  # AD-HOC — manual benchmark of an arbitrary URL model. Read-only token.
+  # --------------------------------------------------------------------------
+  adhoc:
+    name: Ad-hoc benchmark
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, macOS]
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode with Swift 6.2
+        run: |
+          XCODE=$(ls -d /Applications/Xcode_26* /Applications/Xcode_27* 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE" ]; then
+            echo "::error::No Xcode 26 (or newer) found"; exit 1
+          fi
+          sudo xcode-select -s "$XCODE/Contents/Developer"
+      - run: swift package resolve
+      - run: make shaders
+      - run: swift build -c release --product VRMBenchmark
       - name: Fetch sample VRM
         id: fetch
         env:
@@ -77,17 +219,15 @@ jobs:
           set -euo pipefail
           mkdir -p .bench-assets
           if [ -z "$VRM_URL" ]; then
-            echo "::warning::No vrm_url input — skipping the run. Re-trigger with a vrm_url to collect a sample."
+            echo "::warning::No vrm_url input — skipping the run."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # curl handles the URL itself; we do not interpolate it into shell.
           curl -fsSL --max-time 120 "$VRM_URL" -o .bench-assets/sample.vrm
           if [ -n "$VRMA_URL" ]; then
             curl -fsSL --max-time 120 "$VRMA_URL" -o .bench-assets/sample.vrma
           fi
           ls -lh .bench-assets/
-
       - name: Run benchmark
         if: steps.fetch.outputs.skip != 'true'
         env:
@@ -99,24 +239,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .bench-out
-          # Derive label from input or fall back to "ci-<sha>". Quoting via
-          # env-var indirection avoids shell parsing of user input.
-          if [ -n "$BENCH_LABEL_INPUT" ]; then
-            LABEL="$BENCH_LABEL_INPUT"
-          else
-            LABEL="ci-$BENCH_SHA"
-          fi
-          ARGS=()
-          ARGS+=(--mode "$BENCH_MODE")
-          ARGS+=(--frames "$BENCH_FRAMES")
-          ARGS+=(--warmup "$BENCH_WARMUP")
-          ARGS+=(--label "$LABEL")
-          ARGS+=(--json .bench-out/benchmark.json)
-          if [ -f .bench-assets/sample.vrma ]; then
-            ARGS+=(--vrma .bench-assets/sample.vrma)
-          fi
+          if [ -n "$BENCH_LABEL_INPUT" ]; then LABEL="$BENCH_LABEL_INPUT"; else LABEL="ci-$BENCH_SHA"; fi
+          ARGS=(--mode "$BENCH_MODE" --frames "$BENCH_FRAMES" --warmup "$BENCH_WARMUP" --label "$LABEL" --json .bench-out/benchmark.json)
+          if [ -f .bench-assets/sample.vrma ]; then ARGS+=(--vrma .bench-assets/sample.vrma); fi
           .build/release/VRMBenchmark .bench-assets/sample.vrm "${ARGS[@]}"
-
       - name: Upload benchmark report
         if: steps.fetch.outputs.skip != 'true'
         uses: actions/upload-artifact@v4

--- a/Sources/VRMBenchmark/main.swift
+++ b/Sources/VRMBenchmark/main.swift
@@ -46,6 +46,7 @@ struct BenchmarkOptions {
     var baselinePath: String? = nil          // --baseline FILE
     var thresholdMedianPct: Double = 10.0    // --threshold MEDIAN:P95
     var thresholdP95Pct: Double = 15.0
+    var gatePhases: Set<String>? = nil       // --gate-phase NAME (repeatable/comma-sep); nil = gate all phases
 }
 
 func usage() {
@@ -85,6 +86,10 @@ func usage() {
                        metric regresses past --threshold.
       --threshold M:P  Regression thresholds as "MEDIAN:P95" percent
                        (default 10:15 → median +10 %, p95 +15 %).
+      --gate-phase N   Restrict --baseline gating to phase N (repeatable or
+                       comma-separated, e.g. "render"). Default gates every
+                       phase; the CI gate uses "render" to skip the noisy
+                       encode/wait and near-zero animation sub-phases.
 
     Recommended invocation:
       swift run -c release VRMBenchmark <vrm-path> --vrma <vrma-path> --frames 500
@@ -187,6 +192,12 @@ func parseArguments() -> BenchmarkOptions? {
             }
             opts.thresholdMedianPct = m
             opts.thresholdP95Pct = p
+        case "--gate-phase":
+            guard let v = nextValue(for: a) else { return nil }
+            // Accept comma-separated values and/or repeated flags.
+            let names = v.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }
+                         .filter { !$0.isEmpty }
+            opts.gatePhases = (opts.gatePhases ?? []).union(names)
         default:
             if opts.inputPath.isEmpty && !a.hasPrefix("--") {
                 opts.inputPath = a
@@ -379,7 +390,8 @@ private func finalizeReport(opts: BenchmarkOptions, report: BenchmarkReport) -> 
             medianPercent: opts.thresholdMedianPct,
             p95Percent: opts.thresholdP95Pct)
         let comparison = BenchmarkComparison.compare(
-            baseline: baseline, current: report, threshold: threshold)
+            baseline: baseline, current: report, threshold: threshold,
+            gatedPhases: opts.gatePhases)
         print("\nBaseline comparison (\(basePath))")
         print(comparison.renderTable())
         if comparison.passed {

--- a/Sources/VRMBenchmark/main.swift
+++ b/Sources/VRMBenchmark/main.swift
@@ -197,6 +197,13 @@ func parseArguments() -> BenchmarkOptions? {
             // Accept comma-separated values and/or repeated flags.
             let names = v.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }
                          .filter { !$0.isEmpty }
+            // Reject an empty value (e.g. "--gate-phase ," or "--gate-phase ' '").
+            // A non-nil but empty phase set would make the gate vacuously pass.
+            // Exit non-zero (not nil → exit 0) so a malformed gate flag fails CI.
+            guard !names.isEmpty else {
+                FileHandle.standardError.write(Data("ERROR: --gate-phase requires a non-empty phase name (e.g. render)\n".utf8))
+                exit(2)
+            }
             opts.gatePhases = (opts.gatePhases ?? []).union(names)
         default:
             if opts.inputPath.isEmpty && !a.hasPrefix("--") {
@@ -392,6 +399,16 @@ private func finalizeReport(opts: BenchmarkOptions, report: BenchmarkReport) -> 
         let comparison = BenchmarkComparison.compare(
             baseline: baseline, current: report, threshold: threshold,
             gatedPhases: opts.gatePhases)
+        // A comparison with zero gated metrics must NOT report PASS — that would
+        // turn the CI gate into a silent no-op (typo'd --gate-phase, a phase
+        // absent from the baseline, or fully disjoint reports). Fail loudly.
+        if comparison.deltas.isEmpty {
+            let want = opts.gatePhases.map { " for --gate-phase \($0.sorted().joined(separator: ","))" } ?? ""
+            let present = Set(baseline.stats.keys).intersection(report.stats.keys).sorted().joined(separator: ", ")
+            FileHandle.standardError.write(Data(
+                "ERROR: no gated metrics\(want); phases common to baseline and current: [\(present)]. Refusing to report PASS.\n".utf8))
+            return 1
+        }
         print("\nBaseline comparison (\(basePath))")
         print(comparison.renderTable())
         if comparison.passed {

--- a/Sources/VRMMetalKit/Performance/BenchmarkReport.swift
+++ b/Sources/VRMMetalKit/Performance/BenchmarkReport.swift
@@ -184,15 +184,25 @@ public struct BenchmarkComparison: Equatable, Sendable {
     public var passed: Bool { deltas.allSatisfy(\.passed) }
 
     /// Compares the median and p95 of every phase present in BOTH reports.
-    /// Phases in only one report are skipped (and recorded in ``skippedPhases``).
+    /// Phases in only one report are skipped.
+    ///
+    /// - Parameter gatedPhases: When non-nil, restrict gating to these phase
+    ///   names (intersected with the phases common to both reports). Used by the
+    ///   CI regression gate (issue #156) to gate only the stable `render` total
+    ///   and skip the noisy `encode`/`wait`/near-zero `animation` sub-phases.
+    ///   When nil (default), every common phase is gated — the original behavior.
     public static func compare(
         baseline: BenchmarkReport,
         current: BenchmarkReport,
-        threshold: Threshold = .default
+        threshold: Threshold = .default,
+        gatedPhases: Set<String>? = nil
     ) -> BenchmarkComparison {
         var deltas: [StatDelta] = []
-        let commonPhases = Set(baseline.stats.keys).intersection(current.stats.keys).sorted()
-        for phase in commonPhases {
+        var commonPhases = Set(baseline.stats.keys).intersection(current.stats.keys)
+        if let gatedPhases {
+            commonPhases.formIntersection(gatedPhases)
+        }
+        for phase in commonPhases.sorted() {
             guard let base = baseline.stats[phase], let cur = current.stats[phase] else { continue }
             deltas.append(makeDelta(metric: "\(phase).median",
                                     base: base.medianMs, current: cur.medianMs,

--- a/Tests/VRMMetalKitTests/BenchmarkReportTests.swift
+++ b/Tests/VRMMetalKitTests/BenchmarkReportTests.swift
@@ -200,14 +200,17 @@ final class BenchmarkReportTests: XCTestCase {
         XCTAssertEqual(all.deltas.count, 4)
     }
 
-    func testGatedPhasesUnknownNameGatesNothing() {
+    func testGatedPhasesUnknownNameProducesNoDeltas() {
         let base    = makeReport(label: "base",    render: (1.5, 3.0), encode: (1.0, 2.0))
         let current = makeReport(label: "current", render: (9.9, 9.9), encode: (9.9, 9.9))
-        // A phase name absent from both reports → no metrics gated → vacuously passes.
+        // A phase name absent from both reports → no metrics gated. The pure
+        // comparator yields empty deltas (and `passed` is vacuously true); the
+        // CLI (`finalizeReport`) treats empty deltas as a gate ERROR so a
+        // typo'd --gate-phase can't silently pass every regression.
         let none = BenchmarkComparison.compare(
             baseline: base, current: current, gatedPhases: ["does-not-exist"])
-        XCTAssertTrue(none.passed)
-        XCTAssertTrue(none.deltas.isEmpty)
+        XCTAssertTrue(none.deltas.isEmpty,
+                      "unknown phase must gate nothing — caller is responsible for treating this as an error")
     }
 
     func testZeroBaselineDoesNotDivideByZero() {

--- a/Tests/VRMMetalKitTests/BenchmarkReportTests.swift
+++ b/Tests/VRMMetalKitTests/BenchmarkReportTests.swift
@@ -173,6 +173,43 @@ final class BenchmarkReportTests: XCTestCase {
         XCTAssertTrue(comparison.passed)
     }
 
+    // MARK: - Comparator: phase-restricted gating (issue #156 CI gate)
+
+    func testGatedPhasesRestrictsComparisonToNamedPhases() {
+        // encode regresses +50 % (noisy sub-phase), render is flat.
+        // Gating only "render" must PASS despite the encode blow-up.
+        let base    = makeReport(label: "base",    render: (1.5, 3.0), encode: (1.0, 2.0))
+        let current = makeReport(label: "current", render: (1.5, 3.0), encode: (1.5, 3.0))
+
+        // Sanity: gating everything (default) FAILS because encode regressed.
+        XCTAssertFalse(BenchmarkComparison.compare(baseline: base, current: current).passed)
+
+        // Restricting to render only → just render.{median,p95} are gated.
+        let renderOnly = BenchmarkComparison.compare(
+            baseline: base, current: current, gatedPhases: ["render"])
+        XCTAssertTrue(renderOnly.passed)
+        XCTAssertEqual(renderOnly.deltas.count, 2)
+        XCTAssertTrue(renderOnly.deltas.allSatisfy { $0.metricName.hasPrefix("render.") })
+    }
+
+    func testGatedPhasesNilGatesAllCommonPhases() {
+        let base    = makeReport(label: "base",    render: (1.5, 3.0), encode: (1.0, 2.0))
+        let current = makeReport(label: "current", render: (1.5, 3.0), encode: (1.0, 2.0))
+        // nil (default) keeps the existing behavior: every common phase gated.
+        let all = BenchmarkComparison.compare(baseline: base, current: current, gatedPhases: nil)
+        XCTAssertEqual(all.deltas.count, 4)
+    }
+
+    func testGatedPhasesUnknownNameGatesNothing() {
+        let base    = makeReport(label: "base",    render: (1.5, 3.0), encode: (1.0, 2.0))
+        let current = makeReport(label: "current", render: (9.9, 9.9), encode: (9.9, 9.9))
+        // A phase name absent from both reports → no metrics gated → vacuously passes.
+        let none = BenchmarkComparison.compare(
+            baseline: base, current: current, gatedPhases: ["does-not-exist"])
+        XCTAssertTrue(none.passed)
+        XCTAssertTrue(none.deltas.isEmpty)
+    }
+
     func testZeroBaselineDoesNotDivideByZero() {
         // A baseline median of 0 ms (degenerate) should not crash the comparator.
         let base = BenchmarkReport(

--- a/docs/PERF_ROADMAP.md
+++ b/docs/PERF_ROADMAP.md
@@ -9,19 +9,59 @@ live on each issue.
 
 ## Prerequisite
 
-| Issue | Title |
-|-------|-------|
-| [#156](https://github.com/arkavo-org/VRMMetalKit/issues/156) | Benchmark CI regression gate — **must land first** |
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#156](https://github.com/arkavo-org/VRMMetalKit/issues/156) | Benchmark CI regression gate | ✅ **landed** — see [Benchmark gate](#benchmark-gate-156) |
 
-Romero / Carmack rule: never optimise anything you haven't measured. Every
-optimisation below claims an impact; none of those claims are verifiable
-until #156 produces a baseline.
+Romero / Carmack rule: never optimise anything you haven't measured. The gate
+below now produces a tracked baseline (`render.median` on the reference model),
+so the optimisation claims that follow are verifiable against it.
+
+## Benchmark gate (#156)
+
+`.github/workflows/bench.yaml` gates per-frame render cost on every push.
+
+- **Trigger:** `push` only — **never `pull_request`**. The repo is public and
+  the runner is self-hosted, so a fork PR must never execute code on the runner
+  host. Pushes are the maintainer's own (trusted) code. Fork PRs are still
+  covered by the GitHub-hosted lint/codeql checks.
+- **Metric:** `render.median` (+10 %) and `render.p95` (+20 %) of `VRMBenchmark`
+  in `--mode render` against the committed reference model
+  `AvatarSample_A_1.0.vrm.glb` (1024², 500 frames, release). Only the `render`
+  total phase is gated (`--gate-phase render`); the `encode`/`wait`/near-zero
+  `animation` sub-phases are skipped because their run-to-run noise (up to ~28 %
+  on `wait.p95`) would false-fire. `render.median` is ~4.5 % stable.
+- **Baseline:** `.benchmark-baseline.json` at the repo root, captured on the
+  CI hardware. After the gate passes on a `main` push, the `refresh` job
+  re-measures and auto-commits a new baseline **only when `render.median` moves
+  more than ±5 %** — gating before refreshing means a regression never silently
+  raises the bar.
+- **Override:** put `[perf-override]` in the commit message to land an
+  intentional regression (e.g. a new feature with known cost). The gate still
+  runs and reports, but does not block; refresh the baseline afterward.
+- **Runner:** requires a **self-hosted macOS runner** (labels `[self-hosted,
+  macOS]`) holding no workflow-reachable secrets — a committed absolute
+  frame-time baseline is only meaningful on fixed hardware. Runs queue until one
+  is registered. Token scope is least-privilege: `contents: read` everywhere
+  except the `refresh` job (`contents: write`).
+
+### Updating the baseline manually
+
+```bash
+swift build -c release --product VRMBenchmark
+.build/release/VRMBenchmark AvatarSample_A_1.0.vrm.glb \
+  --mode render --frames 500 --warmup 30 --label ci-baseline \
+  --json .benchmark-baseline.json
+git add .benchmark-baseline.json && git commit -m "chore(bench): refresh baseline"
+```
+
+Run it on the same machine class as the CI runner, or the comparison is noise.
 
 ## Optimisations (priority order)
 
 | # | Area | Issue | Notes |
 |---|------|-------|-------|
-| 1 | Baselines | [#156](https://github.com/arkavo-org/VRMMetalKit/issues/156) | prerequisite, already filed |
+| 1 | Baselines | [#156](https://github.com/arkavo-org/VRMMetalKit/issues/156) | ✅ landed — render-median gate + auto-refreshed baseline |
 | 2 | Outline pass merge (tile memory / instanced draws) | [#192](https://github.com/arkavo-org/VRMMetalKit/issues/192) | alternative to [#88](https://github.com/arkavo-org/VRMMetalKit/issues/88) (ICBs) — pick one |
 | 3 | SpringBone sleep gate | [#149](https://github.com/arkavo-org/VRMMetalKit/issues/149) | already filed |
 | 4 | MToon shader specialisation via `[[function_constant]]` | [#193](https://github.com/arkavo-org/VRMMetalKit/issues/193) | |


### PR DESCRIPTION
Wires the existing `VRMBenchmark` into a CI performance regression gate, the prerequisite the perf roadmap (#200) blocks on.

## What
- **Gate (push, any branch):** benchmark the committed reference model `AvatarSample_A_1.0.vrm.glb` (1024², 500 frames, release) against the committed `.benchmark-baseline.json`. Fails if `render.median` (+10%) or `render.p95` (+20%) regress.
- **Refresh (main push, `needs: gate`):** re-measures and auto-commits a new baseline only when `render.median` moves >5%. Gating before refresh means a regression never silently raises the bar.
- **Ad-hoc (`workflow_dispatch`):** the original URL-fetch benchmark, preserved.
- **`[perf-override]`** in a commit message bypasses the gate for intentional regressions.

## Why `--gate-phase`
The comparator gates median+p95 of *every* phase, but measured run-to-run variance on the runner hardware is: `render.median` **4.6%** (stable), `render.p95` 15%, `encode.median` 11.5%, `wait.p95` **28%**, `animation` near-zero (∞% amplification). Gating all phases at default thresholds would false-fire. New `VRMBenchmark --gate-phase render` restricts gating to the stable headline metric; `BenchmarkComparison.compare(gatedPhases:)` defaults to `nil` (prior behavior). Unit-tested (14/14).

## Security (public repo + self-hosted runner)
- **No `pull_request` trigger** — a fork PR must never execute code on the runner host; gate runs on `push` (trusted) only.
- Least-privilege token: workflow `contents: read`, `contents: write` scoped to the `refresh` job alone.
- Baseline math runs inside one `python3` process (paths via env, `float()`-coerced) — no JSON value spliced into shell/python source.

## Operator setup required
- Register a **self-hosted macOS runner** (labels `[self-hosted, macOS]`) holding no workflow-reachable secrets. Until then, the gate job queues. An absolute frame-time baseline is only valid on fixed hardware.

## Test
- `swift test --filter BenchmarkReportTests` → 14/14.
- Gate verified end-to-end locally against the committed baseline (PASS); refresh decision heredoc verified locally.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)