### PR TITLE
fix(lookat): correct turned-head gaze and wall-eye from discarded eye rest rotation

### DIFF
--- a/Sources/VRMMetalKit/Animation/VRMLookAtController.swift
+++ b/Sources/VRMMetalKit/Animation/VRMLookAtController.swift
@@ -397,8 +397,26 @@ public class VRMLookAtController {
             return
         }
 
-        // Calculate direction vector
-        let direction = normalize(targetPos - eyePosition)
+        // Compute the gaze direction in HEAD-LOCAL space. The yaw/pitch produced
+        // here are written to the eye bone as a *local* rotation, so they must be
+        // expressed relative to the head's frame — not world space. Bringing the
+        // world-space target through the head's inverse world matrix strips the
+        // head's (and any root/body) rotation; computing the angles in world space
+        // and stamping them onto a local bone points the eyes off by the head's
+        // yaw whenever the head is turned (e.g. body rotated at the root).
+        let direction: SIMD3<Float>
+        if let headMatrix = headWorldMatrix {
+            let localTarget4 = headMatrix.inverse * SIMD4<Float>(targetPos, 1)
+            let localTarget = SIMD3<Float>(localTarget4.x, localTarget4.y, localTarget4.z)
+            // The gaze origin in head-local space is the head bone's own origin
+            // (zero) plus the authored offset; the head's world translation is
+            // already removed by the inverse transform above.
+            let gazeOrigin = lookAtData?.offsetFromHeadBone ?? .zero
+            direction = normalize(localTarget - gazeOrigin)
+        } else {
+            // No head bone wired up — fall back to the world-space origin.
+            direction = normalize(targetPos - eyePosition)
+        }
 
         // Convert to yaw/pitch angles
         // Yaw: rotation around Y axis (horizontal)

--- a/Sources/VRMMetalKit/Animation/VRMLookAtController.swift
+++ b/Sources/VRMMetalKit/Animation/VRMLookAtController.swift
@@ -510,7 +510,13 @@ public class VRMLookAtController {
 
             let pitchQuat = simd_quatf(angle: mappedPitchRad, axis: [1, 0, 0])
             let yawQuat = simd_quatf(angle: mappedYawRad, axis: [0, 1, 0])
-            node.rotation = pitchQuat * yawQuat
+            // Compose the gaze deviation on top of the eye bone's authored rest
+            // rotation (the bind-pose baseline the eyeball mesh is skinned to).
+            // Overwriting with the bare gaze quaternion discards rest, which on
+            // VRoid-style rigs (large mirrored outward eye rest) snaps the eyes
+            // wall-eyed at center; pre-multiplying makes the rest cancel in the
+            // skinning delta so both eyes track in parallel.
+            node.rotation = pitchQuat * yawQuat * node.initialRotation
 
             if debugFrameCount % 60 == 0 {
                 vrmLog("[LookAt BONE] Left eye node \(leftIndex) yaw=\(mappedYawDeg)° pitch=\(mappedPitchDeg)°")
@@ -534,7 +540,7 @@ public class VRMLookAtController {
 
             let pitchQuat = simd_quatf(angle: mappedPitchRad, axis: [1, 0, 0])
             let yawQuat = simd_quatf(angle: mappedYawRad, axis: [0, 1, 0])
-            node.rotation = pitchQuat * yawQuat
+            node.rotation = pitchQuat * yawQuat * node.initialRotation
 
             if debugFrameCount % 60 == 0 {
                 vrmLog("[LookAt BONE] Right eye node \(rightIndex) yaw=\(mappedYawDeg)° pitch=\(mappedPitchDeg)°")
@@ -644,6 +650,15 @@ public class VRMLookAtController {
     public func applyToAnimationState(_ animationState: VRMAnimationState) {
         guard mode == .bone, let lookAt = lookAtData else { return }
 
+        // `VRMAnimationState.applyToModel` stamps these rotations onto the nodes
+        // absolutely (no rest compose), so bake the eye bone's rest rotation in
+        // here — same composition as `applyToBones`. Without it, VRoid-style
+        // mirrored eye rests are discarded and the eyes go wall-eyed.
+        let leftRest = leftEyeBoneIndex.flatMap { model?.nodes[$0].initialRotation }
+            ?? simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
+        let rightRest = rightEyeBoneIndex.flatMap { model?.nodes[$0].initialRotation }
+            ?? simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
+
         // Left eye: yaw > 0 (right) is inner (toward nose), yaw < 0 (left) is outer
         if leftEyeBoneIndex != nil {
             let horizontalMap = currentYaw > 0 ? lookAt.rangeMapHorizontalInner : lookAt.rangeMapHorizontalOuter
@@ -652,7 +667,7 @@ public class VRMLookAtController {
             let mappedPitchRad = VRMLookAtController.rangeMapOutput(currentPitch, map: verticalMap) * (.pi / 180.0)
             let eyeRotation = simd_quatf(angle: mappedPitchRad, axis: [1, 0, 0]) * simd_quatf(angle: mappedYawRad, axis: [0, 1, 0])
             var transform = animationState.bones[.leftEye] ?? VRMAnimationState.BoneTransform()
-            transform.rotation = eyeRotation
+            transform.rotation = eyeRotation * leftRest
             animationState.bones[.leftEye] = transform
         }
 
@@ -664,7 +679,7 @@ public class VRMLookAtController {
             let mappedPitchRad = VRMLookAtController.rangeMapOutput(currentPitch, map: verticalMap) * (.pi / 180.0)
             let eyeRotation = simd_quatf(angle: mappedPitchRad, axis: [1, 0, 0]) * simd_quatf(angle: mappedYawRad, axis: [0, 1, 0])
             var transform = animationState.bones[.rightEye] ?? VRMAnimationState.BoneTransform()
-            transform.rotation = eyeRotation
+            transform.rotation = eyeRotation * rightRest
             animationState.bones[.rightEye] = transform
         }
     }

--- a/Sources/VRMMetalKit/Animation/VRMLookAtController.swift
+++ b/Sources/VRMMetalKit/Animation/VRMLookAtController.swift
@@ -647,6 +647,16 @@ public class VRMLookAtController {
     /// (e.g. when retargeting from a manually authored pose) instead of
     /// being applied to the model directly. No-op in expression mode or
     /// when the model's `lookAt` block is missing.
+    /// Eye bone's bind-pose rotation, or identity if the index is missing or no
+    /// longer fits the current model's node array. Bounds-checked to match
+    /// ``applyToBones`` so a stale index skips rather than traps.
+    private func eyeRestRotation(_ index: Int?) -> simd_quatf {
+        guard let index, let model, index < model.nodes.count else {
+            return simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
+        }
+        return model.nodes[index].initialRotation
+    }
+
     public func applyToAnimationState(_ animationState: VRMAnimationState) {
         guard mode == .bone, let lookAt = lookAtData else { return }
 
@@ -654,10 +664,10 @@ public class VRMLookAtController {
         // absolutely (no rest compose), so bake the eye bone's rest rotation in
         // here — same composition as `applyToBones`. Without it, VRoid-style
         // mirrored eye rests are discarded and the eyes go wall-eyed.
-        let leftRest = leftEyeBoneIndex.flatMap { model?.nodes[$0].initialRotation }
-            ?? simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
-        let rightRest = rightEyeBoneIndex.flatMap { model?.nodes[$0].initialRotation }
-            ?? simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
+        // Bounds-guard the index like `applyToBones` does (line 500/524): a
+        // stale eye-bone index from a swapped/rebuilt model must skip, not trap.
+        let leftRest = eyeRestRotation(leftEyeBoneIndex)
+        let rightRest = eyeRestRotation(rightEyeBoneIndex)
 
         // Left eye: yaw > 0 (right) is inner (toward nose), yaw < 0 (left) is outer
         if leftEyeBoneIndex != nil {

--- a/Sources/VRMRender/main.swift
+++ b/Sources/VRMRender/main.swift
@@ -100,6 +100,8 @@ struct RenderOptions {
     var expressionWeight: Float = 1.0
     var silhouette: Bool = false
     var rimPower: Float = 5.0
+    var gaze: String? = nil
+    var bodyYaw: Float = 0
 }
 
 // MARK: - Errors
@@ -156,6 +158,14 @@ func printUsage() {
                                    with an additive directional rim
         --rim-power <float>        Fresnel exponent for silhouette rim
                                    (typical 4..12, default: 5)
+        --gaze <dir>               Drive eye look-at. <dir> is one of:
+                                   center, left, right, up, down (head-local),
+                                   camera (track the camera), or x,y,z
+                                   (an explicit head-local point)
+        --body-yaw <deg>           Rotate the whole avatar around Y by <deg>,
+                                   turning the head away from world-forward.
+                                   Combine with --gaze camera to verify eyes
+                                   track correctly on a turned head.
         --list-debug               List all debug modes
         --help                     Show this help message
     
@@ -257,6 +267,16 @@ func parseArguments() -> RenderOptions? {
             i += 1
             if i < args.count, let val = Float(args[i]) {
                 options.rimPower = max(0, val)
+            }
+        case "--gaze":
+            i += 1
+            if i < args.count {
+                options.gaze = args[i]
+            }
+        case "--body-yaw":
+            i += 1
+            if i < args.count, let val = Float(args[i]) {
+                options.bodyYaw = val
             }
         default:
             if !arg.hasPrefix("-") {
@@ -399,6 +419,54 @@ struct VRMRenderCLI {
                     print("  ⚠️ Unknown expression: \(expressionName)")
                     print("     Available: happy, angry, sad, relaxed, surprised, aa, ih, ou, ee, oh, blink, neutral")
                 }
+            }
+
+            // Turn the whole avatar around Y so the head no longer faces
+            // world-forward. This is what exercises the head-local look-at path:
+            // with a turned head, a world-space gaze must be resolved into the
+            // head's frame or the eyes point off by the body yaw.
+            if options.bodyYaw != 0 {
+                let yawRad = options.bodyYaw * .pi / 180.0
+                let yawQuat = simd_quatf(angle: yawRad, axis: SIMD3<Float>(0, 1, 0))
+                for node in model.nodes where node.parent == nil {
+                    node.rotation = yawQuat * node.rotation
+                    node.updateLocalMatrix()
+                }
+                model.updateNodeTransforms()
+                print("  ✓ Body yaw: \(options.bodyYaw)°")
+            }
+
+            // Drive the eye look-at. The renderer's draw loop calls
+            // lookAtController.update() each frame from controller.target and
+            // refreshes cameraPosition from the view matrix, so we only need to
+            // set the target here. Snap smoothing/saccades off for a static frame.
+            if let gaze = options.gaze, let lookAt = renderer.lookAtController {
+                lookAt.smoothing = 0
+                lookAt.saccadeEnabled = false
+                lookAt.enabled = true
+                switch gaze.lowercased() {
+                case "center", "forward":
+                    lookAt.target = .forward
+                case "left":
+                    lookAt.target = .headLocalPoint(SIMD3<Float>(-0.6, 0, 1))
+                case "right":
+                    lookAt.target = .headLocalPoint(SIMD3<Float>(0.6, 0, 1))
+                case "up":
+                    lookAt.target = .headLocalPoint(SIMD3<Float>(0, 0.6, 1))
+                case "down":
+                    lookAt.target = .headLocalPoint(SIMD3<Float>(0, -0.6, 1))
+                case "camera":
+                    lookAt.target = .camera
+                default:
+                    let parts = gaze.split(separator: ",").compactMap { Float($0) }
+                    if parts.count == 3 {
+                        lookAt.target = .headLocalPoint(SIMD3<Float>(parts[0], parts[1], parts[2]))
+                    } else {
+                        print("  ⚠️ Unrecognized --gaze '\(gaze)'; using center")
+                        lookAt.target = .forward
+                    }
+                }
+                print("  ✓ Gaze: \(gaze) (mode: \(lookAt.mode))")
             }
 
             // Set up camera matrices

--- a/Tests/VRMMetalKitTests/VRMALookAtIntegrationTests.swift
+++ b/Tests/VRMMetalKitTests/VRMALookAtIntegrationTests.swift
@@ -117,11 +117,19 @@ final class VRMALookAtIntegrationTests: XCTestCase {
     /// so `update(deltaTime:)` is deterministic. The eye nodes are returned so
     /// the caller can read `localRotation` after `update`.
     private func makeRig(
-        headWorld: simd_float4x4
+        headWorld: simd_float4x4,
+        leftEyeRest: simd_quatf = simd_quatf(ix: 0, iy: 0, iz: 0, r: 1),
+        rightEyeRest: simd_quatf = simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
     ) throws -> (model: VRMModel, controller: VRMLookAtController, leftEye: VRMNode, rightEye: VRMNode) {
         let head = try VRMNode(index: 0, gltfNode: makeGLTFNode(name: "head"))
         let leftEye = try VRMNode(index: 1, gltfNode: makeGLTFNode(name: "leftEye"))
         let rightEye = try VRMNode(index: 2, gltfNode: makeGLTFNode(name: "rightEye"))
+        // VRoid-style rigs author the eye bones with a large, mirrored outward
+        // rest rotation; the eyeball mesh is bound at that orientation. The
+        // look-at controller must compose gaze on top of this rest, not discard
+        // it. initialRotation is the bind-pose baseline retargeting composes against.
+        leftEye.rotation = leftEyeRest;  leftEye.initialRotation = leftEyeRest;  leftEye.updateLocalMatrix()
+        rightEye.rotation = rightEyeRest; rightEye.initialRotation = rightEyeRest; rightEye.updateLocalMatrix()
         head.worldMatrix = headWorld
         // Note: setting `head.localMatrix` directly was load-bearing before
         // #206; post-fix `updateWorldTransform()` re-derives `localMatrix`
@@ -250,6 +258,82 @@ final class VRMALookAtIntegrationTests: XCTestCase {
                         "left eye must stay centered when the gaze target lies along head-local forward")
         assertQuatEqual(rig.rightEye.rotation, centered, accuracy: 1e-4,
                         "right eye must stay centered when the gaze target lies along head-local forward")
+    }
+
+    // MARK: - Eye-bone rest rotation (wall-eye regression)
+
+    /// Mirrored outward rest rotations matching a real VRoid rig
+    /// (`J_Adj_*_FaceEye`, ~±22° about Y).
+    private var leftEyeOutwardRest: simd_quatf  { simd_quatf(angle:  22 * .pi / 180, axis: SIMD3<Float>(0, 1, 0)) }
+    private var rightEyeOutwardRest: simd_quatf { simd_quatf(angle: -22 * .pi / 180, axis: SIMD3<Float>(0, 1, 0)) }
+
+    /// The eyeball mesh is bound to the eye bone at its authored rest rotation,
+    /// so "look straight ahead" means leaving each eye bone AT its rest rotation
+    /// — not snapping it to identity. The controller wrote an absolute
+    /// `pitchQuat * yawQuat` (identity at center), discarding the ±22° mirrored
+    /// rest and rotating each eyeball outward by the rest amount: wall-eyed
+    /// divergence visible as whites-in-the-middle on VRoid models. At center
+    /// gaze each eye bone must equal its rest rotation.
+    func testCenterGazePreservesEyeRestRotation() throws {
+        let rig = try makeRig(headWorld: matrix_identity_float4x4,
+                              leftEyeRest: leftEyeOutwardRest,
+                              rightEyeRest: rightEyeOutwardRest)
+        rig.controller.target = .forward
+        rig.controller.update(deltaTime: 1.0 / 60.0)
+
+        assertQuatEqual(rig.leftEye.rotation,  leftEyeOutwardRest,  accuracy: 1e-4,
+                        "center gaze must leave the left eye at its rest rotation, not identity")
+        assertQuatEqual(rig.rightEye.rotation, rightEyeOutwardRest, accuracy: 1e-4,
+                        "center gaze must leave the right eye at its rest rotation, not identity")
+    }
+
+    /// With mirrored outward rest rotations, a shared gaze must still drive both
+    /// eyes the SAME way (parallel), not pull them apart. The skinning delta the
+    /// eyeball actually sees is `boneRotation * inverse(restRotation)`; both
+    /// eyes' deltas must share the same yaw sign. Pre-fix, dropping the rest made
+    /// the deltas `gaze * inverse(±rest)` — opposite signs → divergence.
+    func testGazeKeepsMirroredRestEyesParallelNotDivergent() throws {
+        let rig = try makeRig(headWorld: matrix_identity_float4x4,
+                              leftEyeRest: leftEyeOutwardRest,
+                              rightEyeRest: rightEyeOutwardRest)
+        rig.controller.target = .headLocalPoint(SIMD3<Float>(0.6, 0, 1)) // look toward +X
+        rig.controller.update(deltaTime: 1.0 / 60.0)
+
+        // The rotation the eyeball mesh sees, with the bind-pose rest removed.
+        let leftDelta  = rig.leftEye.rotation  * rig.leftEye.initialRotation.inverse
+        let rightDelta = rig.rightEye.rotation * rig.rightEye.initialRotation.inverse
+
+        XCTAssertGreaterThan(abs(leftDelta.imag.y), 1e-3, "left eye must actually rotate for a non-zero gaze")
+        XCTAssertGreaterThan(abs(rightDelta.imag.y), 1e-3, "right eye must actually rotate for a non-zero gaze")
+        XCTAssertEqual(leftDelta.imag.y.sign, rightDelta.imag.y.sign,
+                       "both eyes must yaw the same direction (parallel), not diverge (wall-eyed)")
+    }
+
+    /// The retarget path (`applyToAnimationState`) writes eye rotations into a
+    /// `VRMAnimationState`, which `applyToModel` later stamps onto the node
+    /// **absolutely** (`node.rotation = transform.rotation`, no rest compose).
+    /// So this path must bake the eye bone's rest rotation in itself, exactly
+    /// like `applyToBones`. At center gaze the stored eye rotation must equal
+    /// the rest rotation, not identity — otherwise animation playback reproduces
+    /// the wall-eye on VRoid rigs.
+    func testApplyToAnimationStateCenterPreservesEyeRestRotation() throws {
+        let rig = try makeRig(headWorld: matrix_identity_float4x4,
+                              leftEyeRest: leftEyeOutwardRest,
+                              rightEyeRest: rightEyeOutwardRest)
+        rig.controller.target = .forward
+        rig.controller.update(deltaTime: 1.0 / 60.0) // establishes currentYaw/pitch = 0
+
+        let state = VRMAnimationState()
+        rig.controller.applyToAnimationState(state)
+
+        let left = try XCTUnwrap(state.bones[.leftEye]?.rotation,
+                                 "left eye must be written to the animation state in bone mode")
+        let right = try XCTUnwrap(state.bones[.rightEye]?.rotation,
+                                  "right eye must be written to the animation state in bone mode")
+        assertQuatEqual(left,  leftEyeOutwardRest,  accuracy: 1e-4,
+                        "animation-state center gaze must store the left eye's rest rotation, not identity")
+        assertQuatEqual(right, rightEyeOutwardRest, accuracy: 1e-4,
+                        "animation-state center gaze must store the right eye's rest rotation, not identity")
     }
 
     /// `AnimationPlayer.time` must expose the internal `currentTime` so consumers

--- a/Tests/VRMMetalKitTests/VRMALookAtIntegrationTests.swift
+++ b/Tests/VRMMetalKitTests/VRMALookAtIntegrationTests.swift
@@ -224,6 +224,34 @@ final class VRMALookAtIntegrationTests: XCTestCase {
                         "identity-head fixture: right eye paths must agree")
     }
 
+    /// A gaze target sitting along the head's *own* local forward (+Z) means
+    /// "look straight ahead" — so the eye's LOCAL rotation must stay ~identity no
+    /// matter how the head is turned in world space. Pre-fix, `updateTargetAngles`
+    /// computed yaw/pitch in WORLD space (`atan2(direction.x, direction.z)` on a
+    /// world-space direction) and stamped the result into the eye bone's LOCAL
+    /// rotation without subtracting the head's world orientation, so any rig whose
+    /// head was turned (e.g. a body rotated at the root) drove the eyes off by the
+    /// head's yaw. The existing head-local resolution test only checks that
+    /// `.point(head_world*p)` and `.headLocalPoint(p)` agree — both go through the
+    /// same world-space path, so they can be consistently wrong; this test pins the
+    /// absolute correctness those two miss.
+    func testHeadLocalForwardKeepsEyesCenteredRegardlessOfHeadYaw() throws {
+        // Head translated up and turned 60° around world Y (as a body rotated at
+        // the root would turn the head).
+        let rotation  = float4x4(simd_quatf(angle: .pi / 3, axis: SIMD3<Float>(0, 1, 0)))
+        let headWorld = float4x4(translation: SIMD3<Float>(0, 1.6, 0)) * rotation
+
+        let rig = try makeRig(headWorld: headWorld)
+        rig.controller.target = .headLocalPoint(SIMD3<Float>(0, 0, 1)) // straight ahead, head-local
+        rig.controller.update(deltaTime: 1.0 / 60.0)
+
+        let centered = simd_quatf(angle: 0, axis: SIMD3<Float>(0, 1, 0))
+        assertQuatEqual(rig.leftEye.rotation,  centered, accuracy: 1e-4,
+                        "left eye must stay centered when the gaze target lies along head-local forward")
+        assertQuatEqual(rig.rightEye.rotation, centered, accuracy: 1e-4,
+                        "right eye must stay centered when the gaze target lies along head-local forward")
+    }
+
     /// `AnimationPlayer.time` must expose the internal `currentTime` so consumers
     /// who want to drive the controller manually (e.g. via a different sampler)
     /// can read where playback currently sits.


### PR DESCRIPTION
Two root causes behind broken VRM eye look-at, both fixed with tests.

## 1. World-space gaze on a turned head (`d8c3ea3`)
`updateTargetAngles` computed yaw/pitch in **world space** (`atan2` on a world-space direction) and wrote the result as a **local** eye-bone rotation, without removing the head's world orientation. Any rig whose head is turned — e.g. a body rotated at the root — drove the eyes off by the head's yaw. `.headLocalPoint` was equally affected (it round-tripped the local point out to world and back through the same math).

**Fix:** resolve the target through `headWorldMatrix.inverse` so yaw/pitch are expressed in the head's frame, with `offsetFromHeadBone` as the local gaze origin. Falls back to the world-space origin only when no head bone is wired.

## 2. Discarded eye-bone rest rotation → wall-eye (`440258c`)
`applyToBones` / `applyToAnimationState` overwrote the eye bones with a bare gaze quaternion (`pitchQuat * yawQuat`), discarding the authored rest rotation. VRoid rigs (`J_Adj_*_FaceEye`) carry a large **mirrored outward** eye rest (~±22° about Y) and bind the eyeball mesh at that orientation. Forcing identity at center made the skinning delta `inverse(rest)` = ∓22° per eye — the eyes splayed **wall-eyed**, whites in the middle — and stacked gaze offsets on that wrong baseline.

**Fix:** pre-multiply by `initialRotation` so the rest cancels in the skinning delta (`rotation * inverse(rest) = gaze`): parallel tracking, exact straight-ahead at center. This is the project's own `modelRest * delta` retargeting rule, which look-at was violating. `applyToAnimationState` is fixed the same way (its consumer `VRMAnimationState.applyToModel` stamps rotations absolutely).

> Note: `AvatarSample_A` has the identical mirrored rest and was wall-eyed too — its eyes render as featureless white sclera, so it hid the bug. It was never a valid baseline. **Use `vroid_default_F_1_0.vrm` for gaze checks.**

## Tooling (`659b0a5`)
`VRMRender` gains `--gaze <center|left|right|up|down|camera|x,y,z>` and `--body-yaw <deg>` — the diagnostic flags used to render and verify the variations.

## Tests
All written failing-first:
- 60°-turned head gazing along head-local forward must leave eyes centered (frame fix).
- Center gaze must equal the eye bone's rest rotation, not identity — both bone and animation-state paths (wall-eye fix).
- A non-zero gaze must keep both eyes' skinning-delta yaw same-signed (parallel, not divergent).

Look-at suite: **36/36 green**.

## Visual
Corrected center gaze (was wall-eyed, whites in the middle; now parallel and forward):

<img width="384" height="384" alt="lookat_eyes_fixed" src="https://github.com/user-attachments/assets/e5097996-c2fd-4076-a550-1a4ce0eb1062" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)