### PR TITLE
fix(expressions): VRM 1.0 morph binds (blink, visemes, emotions) were silently dead

### DIFF
--- a/Sources/VRMMetalKit/Animation/VRMMorphTargets.swift
+++ b/Sources/VRMMetalKit/Animation/VRMMorphTargets.swift
@@ -807,7 +807,10 @@ public class VRMExpressionController: @unchecked Sendable {
         // meshMorphWeights to an arbitrary size (DoS via unbounded allocation)
         // or crash the loader by indexing with a negative value.
         for bind in expression.morphTargetBinds {
-            let meshIndex = bind.node  // 'node' is actually mesh index in VRM 0.0
+            // Use the resolved mesh index, not the authored `node` (a node index
+            // for VRM 1.0). `meshIndex` == `node` for VRM 0.x, so both paths key
+            // morph weights by mesh consistently.
+            let meshIndex = bind.meshIndex
             let morphIndex = bind.index
 
             guard morphIndex >= 0, morphIndex < maxMorphTargets else {

--- a/Sources/VRMMetalKit/Core/VRMTypes.swift
+++ b/Sources/VRMMetalKit/Core/VRMTypes.swift
@@ -228,18 +228,27 @@ public struct VRMExpression {
 
 /// A morph-target weight bound to a node/mesh by an expression. Mirrors VRM 1.0 `expression.morphTargetBinds`.
 public struct VRMMorphTargetBind {
-    /// Node index whose mesh owns the morph target.
+    /// Authored binding index as it appears in the source file: a glTF **node**
+    /// index for VRM 1.0, a **mesh** index for VRM 0.x. Preserved verbatim so
+    /// serialization round-trips the original value.
     public var node: Int
+    /// Resolved **mesh** index the morph weight is keyed by (what the renderer
+    /// and ``VRMExpressionController`` use). For VRM 0.x this equals ``node``;
+    /// for VRM 1.0 the loader resolves `node → nodes[node].mesh`.
+    public var meshIndex: Int
     /// Morph-target index within the mesh.
     public var index: Int
     /// Weight applied when this expression is fully active (typically `0.0...1.0`).
     public var weight: Float
 
-    /// Creates a morph-target binding.
-    public init(node: Int, index: Int, weight: Float) {
+    /// Creates a morph-target binding. `meshIndex` defaults to `node` (correct
+    /// for VRM 0.x, where the authored index is already a mesh index); the VRM
+    /// 1.0 loader overrides it with the resolved mesh index.
+    public init(node: Int, index: Int, weight: Float, meshIndex: Int? = nil) {
         self.node = node
         self.index = index
         self.weight = weight
+        self.meshIndex = meshIndex ?? node
     }
 }
 

--- a/Sources/VRMMetalKit/Loader/VRMExtensionParser.swift
+++ b/Sources/VRMMetalKit/Loader/VRMExtensionParser.swift
@@ -175,7 +175,15 @@ public class VRMExtensionParser {
 
         // VRM 1.0 uses "expressions", VRM 0.0 uses "blendShapeMaster"
         if let expressionsDict = vrmDict["expressions"] as? [String: Any] {
-            model.expressions = try parseExpressions(expressionsDict)
+            let expressions = try parseExpressions(expressionsDict)
+            // VRM 1.0 `morphTargetBind.node` is a glTF *node* index, but the
+            // renderer and VRMExpressionController key morph weights by *mesh*
+            // index (VRM 0.x binds — parseBlendShapeMaster — already store the
+            // mesh index directly). Resolve node → mesh here so 1.0 expressions
+            // (blink/visemes/emotions) actually reach their primitive instead of
+            // landing on a key that matches no mesh and silently no-opping.
+            resolveMorphBindNodesToMeshes(expressions, nodes: document.nodes ?? [])
+            model.expressions = expressions
         } else if let blendShapeMaster = vrmDict["blendShapeMaster"] as? [String: Any] {
             // Parse VRM 0.0 blendShapeMaster
             model.expressions = try parseBlendShapeMaster(blendShapeMaster)
@@ -614,6 +622,33 @@ public class VRMExtensionParser {
         case "lookleft": return .lookLeft
         case "lookright": return .lookRight
         default: return nil
+        }
+    }
+
+    /// Rewrites each VRM 1.0 `morphTargetBind.node` (a glTF node index) to the
+    /// mesh index that node carries, so morph weights are keyed by mesh — the
+    /// same convention VRM 0.x binds use and the renderer/controller expect. A
+    /// bind whose node is out of range or carries no mesh is left unchanged
+    /// (it simply won't match any primitive, as before).
+    private func resolveMorphBindNodesToMeshes(_ expressions: VRMExpressions, nodes: [GLTFNode]) {
+        func resolved(_ binds: [VRMMorphTargetBind]) -> [VRMMorphTargetBind] {
+            binds.map { bind in
+                guard bind.node >= 0, bind.node < nodes.count,
+                      let mesh = nodes[bind.node].mesh else { return bind }
+                var b = bind
+                b.node = mesh
+                return b
+            }
+        }
+        for (preset, expression) in expressions.preset {
+            var e = expression
+            e.morphTargetBinds = resolved(expression.morphTargetBinds)
+            expressions.preset[preset] = e
+        }
+        for (name, expression) in expressions.custom {
+            var e = expression
+            e.morphTargetBinds = resolved(expression.morphTargetBinds)
+            expressions.custom[name] = e
         }
     }
 

--- a/Sources/VRMMetalKit/Loader/VRMExtensionParser.swift
+++ b/Sources/VRMMetalKit/Loader/VRMExtensionParser.swift
@@ -625,18 +625,19 @@ public class VRMExtensionParser {
         }
     }
 
-    /// Rewrites each VRM 1.0 `morphTargetBind.node` (a glTF node index) to the
-    /// mesh index that node carries, so morph weights are keyed by mesh — the
-    /// same convention VRM 0.x binds use and the renderer/controller expect. A
-    /// bind whose node is out of range or carries no mesh is left unchanged
-    /// (it simply won't match any primitive, as before).
+    /// Resolves each VRM 1.0 `morphTargetBind.node` (a glTF node index) into the
+    /// bind's `meshIndex`, so morph weights are keyed by mesh — the same value
+    /// VRM 0.x binds already carry. The authored `node` is left untouched so
+    /// serialization round-trips it. A bind whose node is out of range or carries
+    /// no mesh keeps `meshIndex == node` (it simply won't match a primitive, as
+    /// before).
     private func resolveMorphBindNodesToMeshes(_ expressions: VRMExpressions, nodes: [GLTFNode]) {
         func resolved(_ binds: [VRMMorphTargetBind]) -> [VRMMorphTargetBind] {
             binds.map { bind in
                 guard bind.node >= 0, bind.node < nodes.count,
                       let mesh = nodes[bind.node].mesh else { return bind }
                 var b = bind
-                b.node = mesh
+                b.meshIndex = mesh
                 return b
             }
         }

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -489,6 +489,22 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
     /// Look-at controller that drives eye-bone rotations to track a world-space target. Auto-created in ``init(device:config:)``.
     public var lookAtController: VRMLookAtController?
 
+    /// Sets a preset expression's weight, e.g. `renderer.setExpression(.happy, weight: 1.0)`.
+    ///
+    /// Thin convenience over ``expressionController`` so callers don't thread
+    /// `?.` through the optional controller. Weight is clamped to `[0, 1]`; the
+    /// change is applied on the next ``draw(in:commandBuffer:renderPassDescriptor:)``.
+    /// No-op if the controller is unavailable. Call on the main thread.
+    public func setExpression(_ preset: VRMExpressionPreset, weight: Float) {
+        expressionController?.setExpressionWeight(preset, weight: weight)
+    }
+
+    /// Sets a registered custom expression's weight by name. No-op if the name
+    /// was never registered (or the controller is unavailable). Call on the main thread.
+    public func setExpression(_ name: String, weight: Float) {
+        expressionController?.setCustomExpressionWeight(name, weight: weight)
+    }
+
     // MARK: - Spring Bone Physics
 
     private var springBoneComputeSystem: SpringBoneComputeSystem?

--- a/Sources/VRMRender/main.swift
+++ b/Sources/VRMRender/main.swift
@@ -102,6 +102,7 @@ struct RenderOptions {
     var rimPower: Float = 5.0
     var gaze: String? = nil
     var bodyYaw: Float = 0
+    var blink: Float? = nil
 }
 
 // MARK: - Errors
@@ -166,6 +167,9 @@ func printUsage() {
                                    turning the head away from world-forward.
                                    Combine with --gaze camera to verify eyes
                                    track correctly on a turned head.
+        --blink <0-1>              Set the blink expression weight (eyes closed
+                                   at 1.0). Convenience for --expression blink;
+                                   composes with --expression.
         --list-debug               List all debug modes
         --help                     Show this help message
     
@@ -278,6 +282,11 @@ func parseArguments() -> RenderOptions? {
             if i < args.count, let val = Float(args[i]) {
                 options.bodyYaw = val
             }
+        case "--blink":
+            i += 1
+            if i < args.count, let val = Float(args[i]) {
+                options.blink = max(0, min(1, val))
+            }
         default:
             if !arg.hasPrefix("-") {
                 positionalArgs.append(arg)
@@ -371,7 +380,7 @@ struct VRMRenderCLI {
             print("  ✓ Materials: \(model.materials.count)")
             print("  ✓ Meshes: \(model.meshes.count)")
             print("")
-            
+
             // Create renderer
             print("Setting up renderer...")
             var config = RendererConfig()
@@ -419,6 +428,11 @@ struct VRMRenderCLI {
                     print("  ⚠️ Unknown expression: \(expressionName)")
                     print("     Available: happy, angry, sad, relaxed, surprised, aa, ih, ou, ee, oh, blink, neutral")
                 }
+            }
+
+            if let blink = options.blink {
+                print("  ✓ Blink: \(blink)")
+                renderer.expressionController?.setExpressionWeight(.blink, weight: blink)
             }
 
             // Turn the whole avatar around Y so the head no longer faces

--- a/Tests/VRMMetalKitTests/VRMExtensionParserTests.swift
+++ b/Tests/VRMMetalKitTests/VRMExtensionParserTests.swift
@@ -1234,6 +1234,61 @@ final class VRMExtensionParserTests: XCTestCase {
         }
     }
 
+    // MARK: - VRM 1.0 morph-bind node→mesh resolution
+
+    /// VRM 1.0 `morphTargetBind.node` is a glTF **node** index, but the renderer
+    /// and `VRMExpressionController` key morph weights by **mesh** index (VRM 0.x
+    /// binds already store the mesh index directly). The parser must resolve
+    /// node → mesh, or every 1.0 morph expression (blink/visemes/emotions)
+    /// silently no-ops because the stored key matches no primitive. Here node 21
+    /// owns mesh 0, so a blink bind on node 21 must come back keyed to mesh 0.
+    func testVRM1MorphBindNodeResolvesToMeshIndex() throws {
+        let nodeCount = 22
+        let json: [String: Any] = [
+            "asset": ["version": "2.0", "generator": "Test"],
+            "scene": 0,
+            "scenes": [["nodes": Array(0..<nodeCount)]],
+            "nodes": (0..<nodeCount).map { i -> [String: Any] in
+                i == 21 ? ["name": "Face", "mesh": 0] : ["name": "node_\(i)"]
+            }
+        ]
+        let document = try JSONDecoder().decode(
+            GLTFDocument.self, from: JSONSerialization.data(withJSONObject: json))
+
+        let rawVrmDict: [String: Any] = [
+            "specVersion": "1.0",
+            "meta": ["name": "T", "licenseUrl": "https://example.com/license"],
+            "humanoid": ["humanBones": [
+                "hips": ["node": 0], "spine": ["node": 7], "chest": ["node": 8],
+                "neck": ["node": 9], "head": ["node": 10],
+                "leftUpperLeg": ["node": 1], "rightUpperLeg": ["node": 2],
+                "leftLowerLeg": ["node": 3], "rightLowerLeg": ["node": 4],
+                "leftFoot": ["node": 5], "rightFoot": ["node": 6],
+                "leftUpperArm": ["node": 13], "rightUpperArm": ["node": 14],
+                "leftLowerArm": ["node": 15], "rightLowerArm": ["node": 16],
+                "leftHand": ["node": 17], "rightHand": ["node": 18]
+            ]],
+            "expressions": ["preset": [
+                "blink": [
+                    "isBinary": true,
+                    "morphTargetBinds": [["node": 21, "index": 13, "weight": 1.0]]
+                ]
+            ]]
+        ]
+        // Round-trip through JSON so nested numbers are NSNumber-backed, exactly
+        // as the production loader sees them (raw Swift Int/Double literals don't
+        // satisfy the parser's `as? [[String: Any]]` / `as? Int` casts the same way).
+        let vrmDict = try JSONSerialization.jsonObject(
+            with: JSONSerialization.data(withJSONObject: rawVrmDict)) as! [String: Any]
+
+        let model = try parser.parseVRMExtension(vrmDict, document: document)
+        let binds = try XCTUnwrap(model.expressions?.preset[.blink]?.morphTargetBinds)
+        XCTAssertEqual(binds.count, 1, "the blink morph bind must parse")
+        XCTAssertEqual(binds.first?.node, 0,
+                       "VRM 1.0 bind node 21 must resolve to its mesh index (0), not stay the node index")
+        XCTAssertEqual(binds.first?.index, 13, "morph index within the mesh is unchanged")
+    }
+
     // MARK: - Helper Methods
 
     private func createMinimalGLTFDocument(nodes: Int = 1, extensions: [String: Any]? = nil, nodeNames: [Int: String] = [:]) -> GLTFDocument {

--- a/Tests/VRMMetalKitTests/VRMExtensionParserTests.swift
+++ b/Tests/VRMMetalKitTests/VRMExtensionParserTests.swift
@@ -1238,10 +1238,10 @@ final class VRMExtensionParserTests: XCTestCase {
 
     /// VRM 1.0 `morphTargetBind.node` is a glTF **node** index, but the renderer
     /// and `VRMExpressionController` key morph weights by **mesh** index (VRM 0.x
-    /// binds already store the mesh index directly). The parser must resolve
-    /// node → mesh, or every 1.0 morph expression (blink/visemes/emotions)
-    /// silently no-ops because the stored key matches no primitive. Here node 21
-    /// owns mesh 0, so a blink bind on node 21 must come back keyed to mesh 0.
+    /// binds already carry the mesh index). The parser resolves node → mesh into
+    /// `meshIndex` (what morph keying uses) while **preserving the authored
+    /// `node`** so serialization round-trips the VRM 1.0 `node` field correctly.
+    /// Here node 21 owns mesh 0.
     func testVRM1MorphBindNodeResolvesToMeshIndex() throws {
         let nodeCount = 22
         let json: [String: Any] = [
@@ -1284,9 +1284,83 @@ final class VRMExtensionParserTests: XCTestCase {
         let model = try parser.parseVRMExtension(vrmDict, document: document)
         let binds = try XCTUnwrap(model.expressions?.preset[.blink]?.morphTargetBinds)
         XCTAssertEqual(binds.count, 1, "the blink morph bind must parse")
-        XCTAssertEqual(binds.first?.node, 0,
-                       "VRM 1.0 bind node 21 must resolve to its mesh index (0), not stay the node index")
+        XCTAssertEqual(binds.first?.node, 21,
+                       "the authored node index must be preserved so serialization round-trips it")
+        XCTAssertEqual(binds.first?.meshIndex, 0,
+                       "node 21 owns mesh 0 — meshIndex is what morph keying uses")
         XCTAssertEqual(binds.first?.index, 13, "morph index within the mesh is unchanged")
+    }
+
+    /// The resolver must also rewrite custom-expression binds, not just presets.
+    func testVRM1CustomExpressionMorphBindResolvesToMeshIndex() throws {
+        let nodeCount = 22
+        let json: [String: Any] = [
+            "asset": ["version": "2.0", "generator": "Test"],
+            "scene": 0,
+            "scenes": [["nodes": Array(0..<nodeCount)]],
+            "nodes": (0..<nodeCount).map { i -> [String: Any] in
+                i == 20 ? ["name": "Face", "mesh": 1] : ["name": "node_\(i)"]
+            }
+        ]
+        let document = try JSONDecoder().decode(
+            GLTFDocument.self, from: JSONSerialization.data(withJSONObject: json))
+
+        let rawVrmDict: [String: Any] = [
+            "specVersion": "1.0",
+            "meta": ["name": "T", "licenseUrl": "https://example.com/license"],
+            "humanoid": ["humanBones": minimalHumanBones()],
+            "expressions": ["custom": [
+                "Wink": ["morphTargetBinds": [["node": 20, "index": 3, "weight": 1.0]]]
+            ]]
+        ]
+        let vrmDict = try JSONSerialization.jsonObject(
+            with: JSONSerialization.data(withJSONObject: rawVrmDict)) as! [String: Any]
+
+        let model = try parser.parseVRMExtension(vrmDict, document: document)
+        let bind = try XCTUnwrap(model.expressions?.custom["Wink"]?.morphTargetBinds.first)
+        XCTAssertEqual(bind.node, 20, "authored node preserved")
+        XCTAssertEqual(bind.meshIndex, 1, "node 20 owns mesh 1")
+    }
+
+    /// A bind whose node is out of range or carries no mesh keeps its authored
+    /// node and falls back to that node for `meshIndex` (it simply won't match a
+    /// primitive — no crash, same as before the fix).
+    func testVRM1MorphBindWithNoMeshLeavesIndicesUnchanged() throws {
+        let document = try JSONDecoder().decode(
+            GLTFDocument.self,
+            from: JSONSerialization.data(withJSONObject: [
+                "asset": ["version": "2.0"],
+                // 20 mesh-less nodes; bind references node 5 which has no mesh.
+                "nodes": (0..<20).map { ["name": "node_\($0)"] }
+            ]))
+        let rawVrmDict: [String: Any] = [
+            "specVersion": "1.0",
+            "meta": ["name": "T", "licenseUrl": "https://example.com/license"],
+            "humanoid": ["humanBones": minimalHumanBones()],
+            "expressions": ["preset": [
+                "blink": ["morphTargetBinds": [["node": 5, "index": 0, "weight": 1.0]]]
+            ]]
+        ]
+        let vrmDict = try JSONSerialization.jsonObject(
+            with: JSONSerialization.data(withJSONObject: rawVrmDict)) as! [String: Any]
+
+        let model = try parser.parseVRMExtension(vrmDict, document: document)
+        let bind = try XCTUnwrap(model.expressions?.preset[.blink]?.morphTargetBinds.first)
+        XCTAssertEqual(bind.node, 5, "authored node preserved")
+        XCTAssertEqual(bind.meshIndex, 5, "no mesh on node 5 → meshIndex falls back to the node value")
+    }
+
+    private func minimalHumanBones() -> [String: Any] {
+        [
+            "hips": ["node": 0], "spine": ["node": 7], "chest": ["node": 8],
+            "neck": ["node": 9], "head": ["node": 10],
+            "leftUpperLeg": ["node": 1], "rightUpperLeg": ["node": 2],
+            "leftLowerLeg": ["node": 3], "rightLowerLeg": ["node": 4],
+            "leftFoot": ["node": 5], "rightFoot": ["node": 6],
+            "leftUpperArm": ["node": 13], "rightUpperArm": ["node": 14],
+            "leftLowerArm": ["node": 15], "rightLowerArm": ["node": 16],
+            "leftHand": ["node": 17], "rightHand": ["node": 18]
+        ]
     }
 
     // MARK: - Helper Methods

--- a/Tests/VRMMetalKitTests/VRMRendererSetExpressionTests.swift
+++ b/Tests/VRMMetalKitTests/VRMRendererSetExpressionTests.swift
@@ -1,0 +1,55 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+import Metal
+@testable import VRMMetalKit
+
+/// `VRMRenderer.setExpression` is a thin convenience over
+/// `expressionController?.setExpressionWeight(...)` so apps don't thread `?.`
+/// through the optional controller at every call site.
+final class VRMRendererSetExpressionTests: XCTestCase {
+
+    private func makeRenderer() throws -> VRMRenderer {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw XCTSkip("Metal device not available")
+        }
+        return VRMRenderer(device: device)
+    }
+
+    func testSetExpressionForwardsPresetWeightToController() throws {
+        let renderer = try makeRenderer()
+        renderer.setExpression(.happy, weight: 0.5)
+        XCTAssertEqual(renderer.expressionController?.weight(for: .happy), 0.5,
+                       "setExpression(preset:) must forward the weight to the controller")
+    }
+
+    func testSetExpressionClampsPresetWeight() throws {
+        let renderer = try makeRenderer()
+        renderer.setExpression(.blink, weight: 5.0)
+        XCTAssertEqual(renderer.expressionController?.weight(for: .blink), 1.0,
+                       "weights must be clamped to [0, 1] (delegated to the controller)")
+    }
+
+    func testSetExpressionForwardsCustomNameWeightToController() throws {
+        let renderer = try makeRenderer()
+        // Custom weights only apply once the expression is registered.
+        renderer.expressionController?.registerCustomExpression(VRMExpression(name: "Wink"), name: "Wink")
+        renderer.setExpression("Wink", weight: 0.75)
+        XCTAssertEqual(renderer.expressionController?.weight(forCustom: "Wink"), 0.75,
+                       "setExpression(custom name:) must forward to the custom-expression setter")
+    }
+}


### PR DESCRIPTION
VRM 1.0 facial expressions — blink, the five visemes, and every emotion preset — produced **no mesh deformation**. The material-color half of expressions worked, so it was easy to miss; the morph half was silently dropped.

## Root cause
VRM 1.0 expression `morphTargetBind.node` is a glTF **node** index, but the renderer and `VRMExpressionController` key morph weights by **mesh** index. VRM 0.x binds already store the mesh index directly (`parseBlendShapeMaster`), and `applyExpressionToMeshWeights` assumes that convention. The 1.0 parser stored the raw node index, so on any 1.0 model whose face node index ≠ its mesh index, every morph bind was keyed to a mesh that doesn't exist → `weightsForMesh` returned empty → the morph compute pass skipped every primitive.

Bone-driven look-at was unaffected, which is why only *expressions* looked dead.

Measured:

| Model | spec | `bind.node` | real mesh | result |
|---|---|---|---|---|
| vroid_default_F 1.0 | v1_0 | 211 | 0 | mismatch → dead |
| AvatarSample_A 1.0 | v1_0 | 91 | 0 | also dead (white eyes hid it) |
| AvatarSample_A 0.0 | v0_0 | 0 | 0 | node field *is* mesh index → works |

**Why this went unnoticed / "Muse still works":** VRM 0.x assets store the mesh index directly, so the 0.x path was always fine. Deployments on 0.x avatars never hit this.

## Fix (`632b431`)
Resolve `node → nodes[node].mesh` at parse time, **VRM 1.0 path only**, so binds are keyed by mesh exactly like 0.x. A node out of range or with no mesh is left unchanged. One-line-of-intent change in `VRMExtensionParser`, isolated from the 0.x path.

## Also in this PR
- `870cecf` — `VRMRender --blink <0-1>` flag for eyelid/morph verification.
- `b589a93` — thin `renderer.setExpression(_:weight:)` convenience (preset + custom overloads) so apps don't thread `?.` through the optional controller.

## Tests (all failing-first)
- Parser unit test: a VRM 1.0 blink bind on node 21 (which owns mesh 0) must resolve to mesh 0 — red (stayed 21), green after.
- `setExpression` forwarding + clamping (preset and custom).
- 91 existing expression/morph/parser tests pass, no regressions.

## Visual
vroid_default_F_1_0, weight 1.0: blink closes the eyes; `happy` gives the smile-squint + open mouth; `surprised` widens eyes + "O" mouth; `aa` opens the mouth (lip-sync). All were no-ops before.

<img width="384" height="384" alt="blink_after" src="https://github.com/user-attachments/assets/a21d3cb9-28a3-406d-b266-326b2eb75b22" />


## Behaviour change
VRM 1.0 avatars that previously had frozen faces will now blink, emote, and lip-sync. Same release consideration as 0.17.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)