### PR TITLE
feat(locomotion): VRMAProcess ingest tool + LocomotionBlendLayer (M1 engine)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -106,7 +106,7 @@ let package = Package(
         ),
         .testTarget(
             name: "VRMMetalKitTests",
-            dependencies: ["VRMMetalKit"],
+            dependencies: ["VRMMetalKit", "VRMAProcessKit"],
             resources: [
                 .copy("TestData")
             ]

--- a/Package.swift
+++ b/Package.swift
@@ -76,6 +76,18 @@ let package = Package(
             name: "VRMAValidator",
             dependencies: ["VRMMetalKit"]
         ),
+        .target(
+            name: "VRMAProcessKit",
+            dependencies: []
+        ),
+        .executableTarget(
+            name: "VRMAProcess",
+            dependencies: ["VRMAProcessKit"]
+        ),
+        .testTarget(
+            name: "VRMAProcessKitTests",
+            dependencies: ["VRMAProcessKit"]
+        ),
         .executableTarget(
             name: "VRMRender",
             dependencies: ["VRMMetalKit"]

--- a/Sources/VRMAProcess/main.swift
+++ b/Sources/VRMAProcess/main.swift
@@ -1,0 +1,2 @@
+import VRMAProcessKit
+print("VRMAProcess (locomotion ingest) — see --help (Task 8)")

--- a/Sources/VRMAProcess/main.swift
+++ b/Sources/VRMAProcess/main.swift
@@ -1,2 +1,29 @@
+import Foundation
 import VRMAProcessKit
-print("VRMAProcess (locomotion ingest) — see --help (Task 8)")
+
+// VRMAProcess — locomotion ingest (GameOfMods locomotion design 2026-06-10 §3).
+// The input file is never modified; producer truth stays on disk.
+
+let args = CommandLine.arguments
+guard args.count >= 3 else {
+    print("""
+    Usage: VRMAProcess <input.vrma> <output.vrma> [--idle|--walk]
+      Measures stride speed, writes extras.arkavo (version 1), strips hips
+      XZ (in-place clips), strips non-humanoid baked tracks, loop-trims by
+      pose similarity. --idle/--walk force classification (default: auto,
+      idle below \(LocomotionIngest.idleThreshold) m/s).
+    """)
+    exit(2)
+}
+let mode: LocomotionIngest.Mode = args.contains("--idle") ? .idle : (args.contains("--walk") ? .walk : .auto)
+do {
+    let input = try Data(contentsOf: URL(fileURLWithPath: args[1]))
+    let output = try LocomotionIngest.process(glb: input, mode: mode)
+    try output.write(to: URL(fileURLWithPath: args[2]))
+    if let meta = LocomotionExtras.read(from: try GLBContainer(data: output)) {
+        print("VRMAProcess: \(args[2]) strideSpeed=\(meta.strideSpeed) inPlace=\(meta.inPlace) sourceHipsHeight=\(meta.sourceHipsHeight)")
+    }
+} catch {
+    FileHandle.standardError.write(Data("VRMAProcess: ERROR \(error)\n".utf8))
+    exit(1)
+}

--- a/Sources/VRMAProcess/main.swift
+++ b/Sources/VRMAProcess/main.swift
@@ -4,24 +4,60 @@ import VRMAProcessKit
 // VRMAProcess — locomotion ingest (GameOfMods locomotion design 2026-06-10 §3).
 // The input file is never modified; producer truth stays on disk.
 
-let args = CommandLine.arguments
-guard args.count >= 3 else {
-    print("""
+func usage() {
+    let msg = """
     Usage: VRMAProcess <input.vrma> <output.vrma> [--idle|--walk]
       Measures stride speed, writes extras.arkavo (version 1), strips hips
       XZ (in-place clips), strips non-humanoid baked tracks, loop-trims by
       pose similarity. --idle/--walk force classification (default: auto,
       idle below \(LocomotionIngest.idleThreshold) m/s).
-    """)
+
+    """
+    FileHandle.standardError.write(Data(msg.utf8))
+}
+
+let args = CommandLine.arguments  // args[0] is the binary path
+guard args.count >= 3 else {
+    usage()
     exit(2)
 }
-let mode: LocomotionIngest.Mode = args.contains("--idle") ? .idle : (args.contains("--walk") ? .walk : .auto)
+
+let inputPath  = args[1]
+let outputPath = args[2]
+
+// Validate extra arguments: only --idle or --walk are allowed; not both.
+let extraArgs = args.dropFirst(3)
+let hasIdle = extraArgs.contains("--idle")
+let hasWalk = extraArgs.contains("--walk")
+let unknownArgs = extraArgs.filter { $0 != "--idle" && $0 != "--walk" }
+
+if hasIdle && hasWalk {
+    FileHandle.standardError.write(Data("VRMAProcess: ERROR --idle and --walk are mutually exclusive\n".utf8))
+    usage()
+    exit(2)
+}
+if !unknownArgs.isEmpty {
+    FileHandle.standardError.write(Data("VRMAProcess: ERROR unknown argument(s): \(unknownArgs.joined(separator: " "))\n".utf8))
+    usage()
+    exit(2)
+}
+
+// Guard: refuse to overwrite the input file.
+let resolvedInput  = URL(fileURLWithPath: inputPath).standardized
+let resolvedOutput = URL(fileURLWithPath: outputPath).standardized
+if resolvedInput == resolvedOutput {
+    FileHandle.standardError.write(Data("VRMAProcess: ERROR refusing to overwrite the input: \(resolvedInput.path)\n".utf8))
+    exit(2)
+}
+
+let mode: LocomotionIngest.Mode = hasIdle ? .idle : (hasWalk ? .walk : .auto)
+
 do {
-    let input = try Data(contentsOf: URL(fileURLWithPath: args[1]))
+    let input = try Data(contentsOf: resolvedInput)
     let output = try LocomotionIngest.process(glb: input, mode: mode)
-    try output.write(to: URL(fileURLWithPath: args[2]))
+    try output.write(to: resolvedOutput)
     if let meta = LocomotionExtras.read(from: try GLBContainer(data: output)) {
-        print("VRMAProcess: \(args[2]) strideSpeed=\(meta.strideSpeed) inPlace=\(meta.inPlace) sourceHipsHeight=\(meta.sourceHipsHeight)")
+        print("VRMAProcess: \(resolvedOutput.path) strideSpeed=\(meta.strideSpeed) inPlace=\(meta.inPlace) sourceHipsHeight=\(meta.sourceHipsHeight)")
     }
 } catch {
     FileHandle.standardError.write(Data("VRMAProcess: ERROR \(error)\n".utf8))

--- a/Sources/VRMAProcess/main.swift
+++ b/Sources/VRMAProcess/main.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2026 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 import VRMAProcessKit
 

--- a/Sources/VRMAProcessKit/GLBContainer.swift
+++ b/Sources/VRMAProcessKit/GLBContainer.swift
@@ -17,7 +17,9 @@ public struct GLBContainer {
 
     public init(json: [String: Any], bin: Data) {
         self.json = json
-        self.bin = bin
+        // Mirror the slice-safe pattern of init(data:): ensure startIndex == 0 so
+        // byte-offset arithmetic in read/write helpers is index-space correct.
+        self.bin = bin.startIndex == 0 ? bin : Data(bin)
     }
 
     public init(data input: Data) throws {

--- a/Sources/VRMAProcessKit/GLBContainer.swift
+++ b/Sources/VRMAProcessKit/GLBContainer.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2026 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 
 /// Minimal glb (binary glTF 2.0) container: one JSON chunk + optional BIN

--- a/Sources/VRMAProcessKit/GLBContainer.swift
+++ b/Sources/VRMAProcessKit/GLBContainer.swift
@@ -2,8 +2,13 @@ import Foundation
 
 /// Minimal glb (binary glTF 2.0) container: one JSON chunk + optional BIN
 /// chunk. Edits happen on the parsed `json` dictionary and raw `bin` data;
-/// `serialize()` re-emits with correct 4-byte alignment. Bytes we do not
-/// touch are preserved (producer truth).
+/// `serialize()` re-emits with correct 4-byte alignment.
+///
+/// Contract: BIN bytes are preserved except for trailing zero padding added
+/// when the length is not 4-byte aligned (re-parsing returns the padded
+/// bytes). The JSON chunk is value-preserving but NORMALIZED on every
+/// serialize (re-emitted via JSONSerialization with sorted keys), so JSON
+/// byte layout is deterministic, not producer-identical.
 public struct GLBContainer {
     public var json: [String: Any]
     public var bin: Data
@@ -15,7 +20,8 @@ public struct GLBContainer {
         self.bin = bin
     }
 
-    public init(data: Data) throws {
+    public init(data input: Data) throws {
+        let data = input.startIndex == 0 ? input : Data(input)
         guard data.count >= 12, data.prefix(4) == Data("glTF".utf8) else { throw GLBError.notGLB }
         var offset = 12
         var jsonDict: [String: Any]?
@@ -37,7 +43,7 @@ public struct GLBContainer {
         self.bin = binData
     }
 
-    public mutating func serialize() throws -> Data {
+    public func serialize() throws -> Data {
         var jsonData = try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
         while jsonData.count % 4 != 0 { jsonData.append(0x20) }  // pad with spaces
         var paddedBin = bin

--- a/Sources/VRMAProcessKit/GLBContainer.swift
+++ b/Sources/VRMAProcessKit/GLBContainer.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+/// Placeholder — implemented in Task 2.
+public enum VRMAProcessKitVersion { public static let current = 1 }

--- a/Sources/VRMAProcessKit/GLBContainer.swift
+++ b/Sources/VRMAProcessKit/GLBContainer.swift
@@ -1,4 +1,54 @@
 import Foundation
 
-/// Placeholder — implemented in Task 2.
-public enum VRMAProcessKitVersion { public static let current = 1 }
+/// Minimal glb (binary glTF 2.0) container: one JSON chunk + optional BIN
+/// chunk. Edits happen on the parsed `json` dictionary and raw `bin` data;
+/// `serialize()` re-emits with correct 4-byte alignment. Bytes we do not
+/// touch are preserved (producer truth).
+public struct GLBContainer {
+    public var json: [String: Any]
+    public var bin: Data
+
+    public enum GLBError: Error { case notGLB, truncated, noJSONChunk }
+
+    public init(json: [String: Any], bin: Data) {
+        self.json = json
+        self.bin = bin
+    }
+
+    public init(data: Data) throws {
+        guard data.count >= 12, data.prefix(4) == Data("glTF".utf8) else { throw GLBError.notGLB }
+        var offset = 12
+        var jsonDict: [String: Any]?
+        var binData = Data()
+        while offset + 8 <= data.count {
+            let len = Int(data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset, as: UInt32.self) })
+            let type = Int(data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset + 4, as: UInt32.self) })
+            guard offset + 8 + len <= data.count else { throw GLBError.truncated }
+            let chunk = data.subdata(in: (offset + 8)..<(offset + 8 + len))
+            if type == 0x4E4F534A {  // 'JSON'
+                jsonDict = try JSONSerialization.jsonObject(with: chunk) as? [String: Any]
+            } else if type == 0x004E4942 {  // 'BIN\0'
+                binData = chunk
+            }
+            offset += 8 + len
+        }
+        guard let j = jsonDict else { throw GLBError.noJSONChunk }
+        self.json = j
+        self.bin = binData
+    }
+
+    public mutating func serialize() throws -> Data {
+        var jsonData = try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
+        while jsonData.count % 4 != 0 { jsonData.append(0x20) }  // pad with spaces
+        var paddedBin = bin
+        while paddedBin.count % 4 != 0 { paddedBin.append(0x00) }
+        var out = Data()
+        func u32(_ v: UInt32) { withUnsafeBytes(of: v.littleEndian) { out.append(contentsOf: $0) } }
+        out.append(Data("glTF".utf8))
+        u32(2)
+        u32(UInt32(12 + 8 + jsonData.count + (paddedBin.isEmpty ? 0 : 8 + paddedBin.count)))
+        u32(UInt32(jsonData.count)); u32(0x4E4F534A); out.append(jsonData)
+        if !paddedBin.isEmpty { u32(UInt32(paddedBin.count)); u32(0x004E4942); out.append(paddedBin) }
+        return out
+    }
+}

--- a/Sources/VRMAProcessKit/LocomotionExtras.swift
+++ b/Sources/VRMAProcessKit/LocomotionExtras.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// The locomotion metadata contract — glTF `extras.arkavo` on animations[0].
+/// `strideSpeed: 0` is the explicit idle value; ABSENCE of the block means
+/// "not a locomotion clip". `version` hedges the one cross-repo contract.
+public struct LocomotionExtras: Equatable {
+    public var version: Int = 1
+    public var strideSpeed: Float
+    public var inPlace: Bool
+    public var sourceHipsHeight: Float
+
+    public init(strideSpeed: Float, inPlace: Bool, sourceHipsHeight: Float) {
+        self.strideSpeed = strideSpeed
+        self.inPlace = inPlace
+        self.sourceHipsHeight = sourceHipsHeight
+    }
+
+    public static func read(from container: GLBContainer) -> LocomotionExtras? {
+        guard let anims = container.json["animations"] as? [[String: Any]],
+              let extras = anims.first?["extras"] as? [String: Any],
+              let arkavo = extras["arkavo"] as? [String: Any],
+              let version = arkavo["version"] as? Int,
+              let stride = (arkavo["strideSpeed"] as? NSNumber)?.floatValue,
+              let inPlace = arkavo["inPlace"] as? Bool,
+              let hipsH = (arkavo["sourceHipsHeight"] as? NSNumber)?.floatValue
+        else { return nil }
+        var m = LocomotionExtras(strideSpeed: stride, inPlace: inPlace, sourceHipsHeight: hipsH)
+        m.version = version
+        return m
+    }
+
+    public func write(into container: inout GLBContainer) throws {
+        guard var anims = container.json["animations"] as? [[String: Any]], !anims.isEmpty else {
+            throw VRMAClipInspector.InspectError.noAnimation
+        }
+        var extras = anims[0]["extras"] as? [String: Any] ?? [:]
+        extras["arkavo"] = [
+            "version": version,
+            "strideSpeed": strideSpeed,
+            "inPlace": inPlace,
+            "sourceHipsHeight": sourceHipsHeight,
+        ] as [String: Any]
+        anims[0]["extras"] = extras
+        container.json["animations"] = anims
+    }
+}

--- a/Sources/VRMAProcessKit/LocomotionExtras.swift
+++ b/Sources/VRMAProcessKit/LocomotionExtras.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2026 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 
 /// The locomotion metadata contract — glTF `extras.arkavo` on animations[0].

--- a/Sources/VRMAProcessKit/LocomotionExtras.swift
+++ b/Sources/VRMAProcessKit/LocomotionExtras.swift
@@ -15,6 +15,8 @@ public struct LocomotionExtras: Equatable {
         self.sourceHipsHeight = sourceHipsHeight
     }
 
+    /// Reads locomotion metadata from `animations[0].extras.arkavo`.
+    /// Unknown versions read as nil — same semantics as absence.
     public static func read(from container: GLBContainer) -> LocomotionExtras? {
         guard let anims = container.json["animations"] as? [[String: Any]],
               let extras = anims.first?["extras"] as? [String: Any],
@@ -24,6 +26,8 @@ public struct LocomotionExtras: Equatable {
               let inPlace = arkavo["inPlace"] as? Bool,
               let hipsH = (arkavo["sourceHipsHeight"] as? NSNumber)?.floatValue
         else { return nil }
+        // I3 — unknown version = not a locomotion clip we understand
+        guard version == 1 else { return nil }
         var m = LocomotionExtras(strideSpeed: stride, inPlace: inPlace, sourceHipsHeight: hipsH)
         m.version = version
         return m

--- a/Sources/VRMAProcessKit/LocomotionExtras.swift
+++ b/Sources/VRMAProcessKit/LocomotionExtras.swift
@@ -4,6 +4,9 @@ import Foundation
 /// `strideSpeed: 0` is the explicit idle value; ABSENCE of the block means
 /// "not a locomotion clip". `version` hedges the one cross-repo contract.
 public struct LocomotionExtras: Equatable {
+    /// Error thrown by ``write(into:)``.
+    public enum WriteError: Error { case noAnimation }
+
     public var version: Int = 1
     public var strideSpeed: Float
     public var inPlace: Bool
@@ -26,7 +29,7 @@ public struct LocomotionExtras: Equatable {
               let inPlace = arkavo["inPlace"] as? Bool,
               let hipsH = (arkavo["sourceHipsHeight"] as? NSNumber)?.floatValue
         else { return nil }
-        // I3 — unknown version = not a locomotion clip we understand
+        // Only version 1 is understood; any other version reads as absent.
         guard version == 1 else { return nil }
         var m = LocomotionExtras(strideSpeed: stride, inPlace: inPlace, sourceHipsHeight: hipsH)
         m.version = version
@@ -35,7 +38,7 @@ public struct LocomotionExtras: Equatable {
 
     public func write(into container: inout GLBContainer) throws {
         guard var anims = container.json["animations"] as? [[String: Any]], !anims.isEmpty else {
-            throw VRMAClipInspector.InspectError.noAnimation
+            throw WriteError.noAnimation
         }
         var extras = anims[0]["extras"] as? [String: Any] ?? [:]
         extras["arkavo"] = [

--- a/Sources/VRMAProcessKit/LocomotionIngest.swift
+++ b/Sources/VRMAProcessKit/LocomotionIngest.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2026 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 
 /// The single-pass ingest pipeline from the locomotion spec §3:

--- a/Sources/VRMAProcessKit/LocomotionIngest.swift
+++ b/Sources/VRMAProcessKit/LocomotionIngest.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// The single-pass ingest pipeline from the locomotion spec §3:
+/// measure → write extras → strip hips XZ → strip non-humanoid → loop-trim.
+public enum LocomotionIngest {
+    public enum Mode { case auto, idle, walk }
+    /// Below this measured speed (m/s) a clip auto-classifies as idle.
+    public static let idleThreshold: Float = 0.1
+
+    public static func process(glb: Data, mode: Mode) throws -> Data {
+        var container = try GLBContainer(data: glb)
+        let inspector = try VRMAClipInspector(container: container)
+
+        // Measure FIRST — the strip below erases exactly what we measure.
+        let measured = try inspector.meanHipsXZSpeed()
+        let isIdle = mode == .idle || (mode == .auto && measured < idleThreshold)
+        let meta = LocomotionExtras(
+            strideSpeed: isIdle ? 0 : measured,
+            inPlace: true,
+            sourceHipsHeight: try inspector.hipsRestHeight()
+        )
+        try meta.write(into: &container)
+
+        var editor = VRMAClipEditor(container: container)
+        try editor.stripHipsXZ()
+        try editor.stripNonHumanoidChannels()
+        try editor.loopTrim()  // pose-similarity works for idle and walk alike
+        container = editor.container
+        return try container.serialize()
+    }
+}

--- a/Sources/VRMAProcessKit/LocomotionIngest.swift
+++ b/Sources/VRMAProcessKit/LocomotionIngest.swift
@@ -7,12 +7,25 @@ public enum LocomotionIngest {
     /// Below this measured speed (m/s) a clip auto-classifies as idle.
     public static let idleThreshold: Float = 0.1
 
+    public enum IngestError: Error, CustomStringConvertible {
+        case walkClipMeasuresStationary(measured: Float)
+        public var description: String {
+            switch self {
+            case .walkClipMeasuresStationary(let m):
+                return "walk clip measures \(m) m/s hips travel — below the idle threshold (\(LocomotionIngest.idleThreshold)). An already-in-place walk needs an authored stride speed; a --stride override is not implemented yet."
+            }
+        }
+    }
+
     public static func process(glb: Data, mode: Mode) throws -> Data {
         var container = try GLBContainer(data: glb)
         let inspector = try VRMAClipInspector(container: container)
 
         // Measure FIRST — the strip below erases exactly what we measure.
         let measured = try inspector.meanHipsXZSpeed()
+        if mode == .walk, measured < idleThreshold {
+            throw IngestError.walkClipMeasuresStationary(measured: measured)
+        }
         let isIdle = mode == .idle || (mode == .auto && measured < idleThreshold)
         let meta = LocomotionExtras(
             strideSpeed: isIdle ? 0 : measured,

--- a/Sources/VRMAProcessKit/VRMAClipEditor.swift
+++ b/Sources/VRMAProcessKit/VRMAClipEditor.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2026 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 
 /// All animation samplers must share one keyframe timeline; resample before trimming.

--- a/Sources/VRMAProcessKit/VRMAClipEditor.swift
+++ b/Sources/VRMAProcessKit/VRMAClipEditor.swift
@@ -54,11 +54,15 @@ public struct VRMAClipEditor {
         // accessor throws instead of being silently stomped.
         // base % 4 == 0: storeBytes(of:toByteOffset:as:) requires Float
         // alignment (glTF guarantees it for float accessors).
+        // Overflow-safe: base + count * 12 must not trap on hostile counts.
+        let (stride12, s12Overflow) = count.multipliedReportingOverflow(by: 12)
+        guard !s12Overflow else { throw VRMAClipInspector.InspectError.badAccessor }
+        let (endOff, endOverflow) = base.addingReportingOverflow(stride12)
         guard base >= 0, count >= 1,
               accessors[outputAcc]["componentType"] as? Int == 5126,
               accessors[outputAcc]["type"] as? String == "VEC3",
               base % 4 == 0,
-              base + count * 12 <= container.bin.count
+              !endOverflow, endOff <= container.bin.count
         else { throw VRMAClipInspector.InspectError.badAccessor }
         var bin = container.bin
         let x0 = bin.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: base, as: Float.self) }

--- a/Sources/VRMAProcessKit/VRMAClipEditor.swift
+++ b/Sources/VRMAProcessKit/VRMAClipEditor.swift
@@ -21,9 +21,12 @@ public struct VRMAClipEditor {
               bvIndex >= 0, bvIndex < bvs.count
         else { throw VRMAClipInspector.InspectError.badAccessor }
         let base = (bvs[bvIndex]["byteOffset"] as? Int ?? 0) + (accessors[outputAcc]["byteOffset"] as? Int ?? 0)
-        // Fix 1: count >= 1 so the unconditional first-frame reads at base/base+8 are in range.
-        // Fix 2: enforce float32 VEC3 (same constraints the read path already checks).
-        // Fix 3: base % 4 == 0 ensures storeBytes(of:toByteOffset:as:) alignment (glTF spec guarantees this).
+        // count >= 1: the first-frame reads at base/base+8 must be in range.
+        // float32 VEC3 required — the write path enforces the same accessor
+        // shape the read path (floats(accessor:)) does, so a malformed hips
+        // accessor throws instead of being silently stomped.
+        // base % 4 == 0: storeBytes(of:toByteOffset:as:) requires Float
+        // alignment (glTF guarantees it for float accessors).
         guard base >= 0, count >= 1,
               accessors[outputAcc]["componentType"] as? Int == 5126,
               accessors[outputAcc]["type"] as? String == "VEC3",

--- a/Sources/VRMAProcessKit/VRMAClipEditor.swift
+++ b/Sources/VRMAProcessKit/VRMAClipEditor.swift
@@ -87,7 +87,17 @@ public struct VRMAClipEditor {
               var samplers = anims[0]["samplers"] as? [[String: Any]]
         else { throw VRMAClipInspector.InspectError.noAnimation }
 
-        // N4 — guarded casts for accessors and bufferViews
+        // Every kept channel is sliced on the same [s...e] key window, so
+        // ALL of them — rotations and the hips translation alike — must
+        // share one keyframe timeline. Validate before any accessor math.
+        var channelInputs: [Int] = []
+        for ch in channels {
+            guard let si = ch["sampler"] as? Int, si >= 0, si < samplers.count,
+                  let input = samplers[si]["input"] as? Int else { continue }
+            channelInputs.append(input)
+        }
+        guard Set(channelInputs).count <= 1 else { throw EditError.unalignedKeyframes }
+
         guard let accessors0 = container.json["accessors"] as? [[String: Any]] else {
             throw VRMAClipInspector.InspectError.badAccessor
         }
@@ -95,8 +105,7 @@ public struct VRMAClipEditor {
             throw VRMAClipInspector.InspectError.badAccessor
         }
 
-        // FIX C1 — collect rotation channels, record their input accessors,
-        // then validate they all share a single timeline.
+        // Collect rotation outputs for the seam metric.
         var rotationOutputs: [[Float]] = []
         var rotationInputs: [Int] = []
         for ch in channels {
@@ -110,11 +119,8 @@ public struct VRMAClipEditor {
             rotationInputs.append(input)
         }
 
-        // FIX C1 — all rotation channels must share one input accessor
-        guard Set(rotationInputs).count <= 1 else { throw EditError.unalignedKeyframes }
-
-        // FIX C1 — derive keyCount from the shared input accessor's count field
-        // (not from output element count, which would be wrong if there's a bad accessor).
+        // keyCount comes from the shared input accessor — the one timeline
+        // every channel was just validated against.
         let keyCount: Int
         if let sharedInput = rotationInputs.first {
             guard sharedInput >= 0, sharedInput < accessors0.count,
@@ -127,12 +133,13 @@ public struct VRMAClipEditor {
 
         guard keyCount > 4 else { return }  // nothing meaningful to trim
 
-        // FIX C1 — guard each rotation output's count == keyCount * 4
+        // Each rotation output must be exactly one quat per key.
         for q in rotationOutputs {
             guard q.count == keyCount * 4 else { throw VRMAClipInspector.InspectError.badAccessor }
         }
 
-        // FIX I2 — collect hipsY for seam quality (every 3rd+1 float of hips translation output)
+        // Hips Y joins the seam metric: idle rotations are near-flat, so
+        // without the bob term the seam lands arbitrarily and pops vertically.
         var hipsY: [Float] = []
         if let (_, hipsOutputAcc) = try? inspector.hipsTranslationSampler() {
             let hipsVals = try inspector.floats(accessor: hipsOutputAcc)
@@ -144,7 +151,7 @@ public struct VRMAClipEditor {
                 throw VRMAClipInspector.InspectError.badAccessor
             }
         }
-        // FIX I2 — guard hipsY.count == keyCount when non-empty
+        // Bob samples must align with the shared timeline.
         if !hipsY.isEmpty {
             guard hipsY.count == keyCount else { throw VRMAClipInspector.InspectError.badAccessor }
         }
@@ -157,7 +164,7 @@ public struct VRMAClipEditor {
                 for k in 0..<4 { dot += q[a * 4 + k] * q[b * 4 + k] }
                 d += 1 - min(1, abs(dot))
             }
-            // FIX I2 — include hipsY bob in pose distance
+            // ~1 cm of bob mismatch weighs like a few degrees of joint error.
             if !hipsY.isEmpty {
                 d += wY * abs(hipsY[a] - hipsY[b])
             }
@@ -177,23 +184,18 @@ public struct VRMAClipEditor {
         var bufferViews = bufferViews0
         var bin = container.bin
 
-        // FIX I1(a) — build set of sampler indices referenced by current channels
         let usedSamplers = Set(channels.compactMap { $0["sampler"] as? Int })
 
-        // N2 — key `rewritten` by a composite string encoding index/comps/rebase
         var rewritten: [String: Int] = [:]
 
-        // FIX I1(b) — strict component map; no silent fallback
         let compsByType: [String: Int] = ["SCALAR": 1, "VEC3": 3, "VEC4": 4]
 
         func sliced(_ accessorIndex: Int, comps: Int, rebase: Bool) throws -> Int {
             // rebase only ever true for SCALAR inputs (comps==1)
             precondition(!rebase || comps == 1)
-            // N2 — composite key
             let key = "\(accessorIndex)/\(comps)/\(rebase)"
             if let existing = rewritten[key] { return existing }
             let vals = try inspector.floats(accessor: accessorIndex)
-            // FIX I1(b) — strict count guard (replaces the weaker >= guard)
             guard vals.count == keyCount * comps else { throw VRMAClipInspector.InspectError.badAccessor }
             let t0 = rebase ? vals[best.s] : 0
             var slice: [Float] = []
@@ -201,7 +203,6 @@ public struct VRMAClipEditor {
             for i in best.s...best.e {
                 for c in 0..<comps { slice.append(vals[i * comps + c] - (rebase && c == 0 ? t0 : 0)) }
             }
-            // N3 — 4-byte alignment before append
             while bin.count % 4 != 0 { bin.append(0) }
             let off = bin.count
             slice.withUnsafeBytes { bin.append(contentsOf: $0) }
@@ -218,11 +219,8 @@ public struct VRMAClipEditor {
         }
 
         for (i, s) in samplers.enumerated() {
-            // FIX I1(a) — skip orphaned samplers (not referenced by any channel)
             guard usedSamplers.contains(i) else { continue }
-            // N4 — guarded casts instead of as!
             guard let input = s["input"] as? Int, let output = s["output"] as? Int else { continue }
-            // FIX I1(b) — strict type-to-comps via the strict map
             guard output >= 0, output < accessors.count,
                   let typeStr = accessors[output]["type"] as? String,
                   let outComps = compsByType[typeStr]

--- a/Sources/VRMAProcessKit/VRMAClipEditor.swift
+++ b/Sources/VRMAProcessKit/VRMAClipEditor.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+/// All animation samplers must share one keyframe timeline; resample before trimming.
+public enum EditError: Error { case unalignedKeyframes }
+
 /// Write-side glb surgery for locomotion ingest. All edits are minimal and
 /// in-place: the bin chunk is only modified where values change.
 public struct VRMAClipEditor {
@@ -69,10 +72,14 @@ public struct VRMAClipEditor {
     /// Pose-similarity loop trim. Works for walk and idle alike (locomotion
     /// spec §3): finds the (start, end) key pair with minimal summed
     /// quaternion distance across all kept rotation channels, subject to
-    /// end-start >= 60% of the source key count, then rewrites every
-    /// sampler to the [start...end] window with times rebased to zero.
+    /// end-start >= 60% of the source key count, then rewrites only the
+    /// channel-referenced samplers to the [start...end] window with times
+    /// rebased to zero. Orphaned samplers are left untouched.
     /// Trimmed data is APPENDED as new bufferViews/accessors and samplers
     /// are repointed — existing bytes stay untouched.
+    ///
+    /// Throws `EditError.unalignedKeyframes` if rotation channels do not all
+    /// share a single input accessor. Resample before calling if needed.
     public mutating func loopTrim() throws {
         let inspector = try VRMAClipInspector(container: container)
         guard var anims = container.json["animations"] as? [[String: Any]], !anims.isEmpty,
@@ -80,26 +87,79 @@ public struct VRMAClipEditor {
               var samplers = anims[0]["samplers"] as? [[String: Any]]
         else { throw VRMAClipInspector.InspectError.noAnimation }
 
-        // Collect rotation outputs + the shared key count.
+        // N4 — guarded casts for accessors and bufferViews
+        guard let accessors0 = container.json["accessors"] as? [[String: Any]] else {
+            throw VRMAClipInspector.InspectError.badAccessor
+        }
+        guard let bufferViews0 = container.json["bufferViews"] as? [[String: Any]] else {
+            throw VRMAClipInspector.InspectError.badAccessor
+        }
+
+        // FIX C1 — collect rotation channels, record their input accessors,
+        // then validate they all share a single timeline.
         var rotationOutputs: [[Float]] = []
-        var keyCount = 0
+        var rotationInputs: [Int] = []
         for ch in channels {
             guard let target = ch["target"] as? [String: Any],
                   target["path"] as? String == "rotation",
                   let si = ch["sampler"] as? Int, si >= 0, si < samplers.count,
+                  let input = samplers[si]["input"] as? Int,
                   let out = samplers[si]["output"] as? Int else { continue }
             let q = try inspector.floats(accessor: out)
             rotationOutputs.append(q)
-            keyCount = q.count / 4
+            rotationInputs.append(input)
         }
+
+        // FIX C1 — all rotation channels must share one input accessor
+        guard Set(rotationInputs).count <= 1 else { throw EditError.unalignedKeyframes }
+
+        // FIX C1 — derive keyCount from the shared input accessor's count field
+        // (not from output element count, which would be wrong if there's a bad accessor).
+        let keyCount: Int
+        if let sharedInput = rotationInputs.first {
+            guard sharedInput >= 0, sharedInput < accessors0.count,
+                  let kc = accessors0[sharedInput]["count"] as? Int
+            else { throw VRMAClipInspector.InspectError.badAccessor }
+            keyCount = kc
+        } else {
+            return  // no rotation channels, nothing to trim
+        }
+
         guard keyCount > 4 else { return }  // nothing meaningful to trim
 
+        // FIX C1 — guard each rotation output's count == keyCount * 4
+        for q in rotationOutputs {
+            guard q.count == keyCount * 4 else { throw VRMAClipInspector.InspectError.badAccessor }
+        }
+
+        // FIX I2 — collect hipsY for seam quality (every 3rd+1 float of hips translation output)
+        var hipsY: [Float] = []
+        if let (_, hipsOutputAcc) = try? inspector.hipsTranslationSampler() {
+            let hipsVals = try inspector.floats(accessor: hipsOutputAcc)
+            // VEC3 interleaved: x, y, z — hipsY is index 1, 4, 7, ...
+            if hipsVals.count == keyCount * 3 {
+                hipsY = stride(from: 1, to: hipsVals.count, by: 3).map { hipsVals[$0] }
+            } else if !hipsVals.isEmpty {
+                // count mismatch — throw rather than use corrupt data
+                throw VRMAClipInspector.InspectError.badAccessor
+            }
+        }
+        // FIX I2 — guard hipsY.count == keyCount when non-empty
+        if !hipsY.isEmpty {
+            guard hipsY.count == keyCount else { throw VRMAClipInspector.InspectError.badAccessor }
+        }
+
+        let wY: Float = 1.5  // ~1 cm of bob ≈ a few degrees of joint mismatch on the 1-|dot| scale
         func poseDistance(_ a: Int, _ b: Int) -> Float {
             var d: Float = 0
             for q in rotationOutputs {
                 var dot: Float = 0
                 for k in 0..<4 { dot += q[a * 4 + k] * q[b * 4 + k] }
                 d += 1 - min(1, abs(dot))
+            }
+            // FIX I2 — include hipsY bob in pose distance
+            if !hipsY.isEmpty {
+                d += wY * abs(hipsY[a] - hipsY[b])
             }
             return d
         }
@@ -112,24 +172,37 @@ public struct VRMAClipEditor {
             }
         }
 
-        // Rewrite every sampler to [best.s ... best.e] via appended views.
-        var accessors = container.json["accessors"] as! [[String: Any]]
-        var bufferViews = container.json["bufferViews"] as! [[String: Any]]
+        // Rewrite only channel-referenced samplers to [best.s ... best.e] via appended views.
+        var accessors = accessors0
+        var bufferViews = bufferViews0
         var bin = container.bin
-        var rewritten: [Int: Int] = [:]  // old accessor -> new accessor
+
+        // FIX I1(a) — build set of sampler indices referenced by current channels
+        let usedSamplers = Set(channels.compactMap { $0["sampler"] as? Int })
+
+        // N2 — key `rewritten` by a composite string encoding index/comps/rebase
+        var rewritten: [String: Int] = [:]
+
+        // FIX I1(b) — strict component map; no silent fallback
+        let compsByType: [String: Int] = ["SCALAR": 1, "VEC3": 3, "VEC4": 4]
 
         func sliced(_ accessorIndex: Int, comps: Int, rebase: Bool) throws -> Int {
             // rebase only ever true for SCALAR inputs (comps==1)
             precondition(!rebase || comps == 1)
-            if let existing = rewritten[accessorIndex] { return existing }
+            // N2 — composite key
+            let key = "\(accessorIndex)/\(comps)/\(rebase)"
+            if let existing = rewritten[key] { return existing }
             let vals = try inspector.floats(accessor: accessorIndex)
-            guard vals.count >= (best.e + 1) * comps else { throw VRMAClipInspector.InspectError.badAccessor }
+            // FIX I1(b) — strict count guard (replaces the weaker >= guard)
+            guard vals.count == keyCount * comps else { throw VRMAClipInspector.InspectError.badAccessor }
             let t0 = rebase ? vals[best.s] : 0
             var slice: [Float] = []
             slice.reserveCapacity((best.e - best.s + 1) * comps)
             for i in best.s...best.e {
                 for c in 0..<comps { slice.append(vals[i * comps + c] - (rebase && c == 0 ? t0 : 0)) }
             }
+            // N3 — 4-byte alignment before append
+            while bin.count % 4 != 0 { bin.append(0) }
             let off = bin.count
             slice.withUnsafeBytes { bin.append(contentsOf: $0) }
             bufferViews.append(["buffer": 0, "byteOffset": off, "byteLength": slice.count * 4])
@@ -140,13 +213,20 @@ public struct VRMAClipEditor {
             ]
             if comps == 1 { acc["min"] = [0]; acc["max"] = [slice.last!] }
             accessors.append(acc)
-            rewritten[accessorIndex] = accessors.count - 1
+            rewritten[key] = accessors.count - 1
             return accessors.count - 1
         }
 
         for (i, s) in samplers.enumerated() {
+            // FIX I1(a) — skip orphaned samplers (not referenced by any channel)
+            guard usedSamplers.contains(i) else { continue }
+            // N4 — guarded casts instead of as!
             guard let input = s["input"] as? Int, let output = s["output"] as? Int else { continue }
-            let outComps = ((accessors[output]["type"] as? String) == "VEC3") ? 3 : 4
+            // FIX I1(b) — strict type-to-comps via the strict map
+            guard output >= 0, output < accessors.count,
+                  let typeStr = accessors[output]["type"] as? String,
+                  let outComps = compsByType[typeStr]
+            else { throw VRMAClipInspector.InspectError.badAccessor }
             samplers[i]["input"] = try sliced(input, comps: 1, rebase: true)
             samplers[i]["output"] = try sliced(output, comps: outComps, rebase: false)
         }

--- a/Sources/VRMAProcessKit/VRMAClipEditor.swift
+++ b/Sources/VRMAProcessKit/VRMAClipEditor.swift
@@ -65,4 +65,99 @@ public struct VRMAClipEditor {
         container.json["animations"] = anims
         return dropped
     }
+
+    /// Pose-similarity loop trim. Works for walk and idle alike (locomotion
+    /// spec §3): finds the (start, end) key pair with minimal summed
+    /// quaternion distance across all kept rotation channels, subject to
+    /// end-start >= 60% of the source key count, then rewrites every
+    /// sampler to the [start...end] window with times rebased to zero.
+    /// Trimmed data is APPENDED as new bufferViews/accessors and samplers
+    /// are repointed — existing bytes stay untouched.
+    public mutating func loopTrim() throws {
+        let inspector = try VRMAClipInspector(container: container)
+        guard var anims = container.json["animations"] as? [[String: Any]], !anims.isEmpty,
+              let channels = anims[0]["channels"] as? [[String: Any]],
+              var samplers = anims[0]["samplers"] as? [[String: Any]]
+        else { throw VRMAClipInspector.InspectError.noAnimation }
+
+        // Collect rotation outputs + the shared key count.
+        var rotationOutputs: [[Float]] = []
+        var keyCount = 0
+        for ch in channels {
+            guard let target = ch["target"] as? [String: Any],
+                  target["path"] as? String == "rotation",
+                  let si = ch["sampler"] as? Int, si >= 0, si < samplers.count,
+                  let out = samplers[si]["output"] as? Int else { continue }
+            let q = try inspector.floats(accessor: out)
+            rotationOutputs.append(q)
+            keyCount = q.count / 4
+        }
+        guard keyCount > 4 else { return }  // nothing meaningful to trim
+
+        func poseDistance(_ a: Int, _ b: Int) -> Float {
+            var d: Float = 0
+            for q in rotationOutputs {
+                var dot: Float = 0
+                for k in 0..<4 { dot += q[a * 4 + k] * q[b * 4 + k] }
+                d += 1 - min(1, abs(dot))
+            }
+            return d
+        }
+        let minSpan = Int(Float(keyCount) * 0.6)
+        var best = (s: 0, e: keyCount - 1, d: Float.greatestFiniteMagnitude)
+        for s in 0..<(keyCount - minSpan) {
+            for e in (s + minSpan)..<keyCount {
+                let d = poseDistance(s, e)
+                if d < best.d { best = (s, e, d) }
+            }
+        }
+
+        // Rewrite every sampler to [best.s ... best.e] via appended views.
+        var accessors = container.json["accessors"] as! [[String: Any]]
+        var bufferViews = container.json["bufferViews"] as! [[String: Any]]
+        var bin = container.bin
+        var rewritten: [Int: Int] = [:]  // old accessor -> new accessor
+
+        func sliced(_ accessorIndex: Int, comps: Int, rebase: Bool) throws -> Int {
+            // rebase only ever true for SCALAR inputs (comps==1)
+            precondition(!rebase || comps == 1)
+            if let existing = rewritten[accessorIndex] { return existing }
+            let vals = try inspector.floats(accessor: accessorIndex)
+            guard vals.count >= (best.e + 1) * comps else { throw VRMAClipInspector.InspectError.badAccessor }
+            let t0 = rebase ? vals[best.s] : 0
+            var slice: [Float] = []
+            slice.reserveCapacity((best.e - best.s + 1) * comps)
+            for i in best.s...best.e {
+                for c in 0..<comps { slice.append(vals[i * comps + c] - (rebase && c == 0 ? t0 : 0)) }
+            }
+            let off = bin.count
+            slice.withUnsafeBytes { bin.append(contentsOf: $0) }
+            bufferViews.append(["buffer": 0, "byteOffset": off, "byteLength": slice.count * 4])
+            var acc: [String: Any] = [
+                "bufferView": bufferViews.count - 1, "componentType": 5126,
+                "count": best.e - best.s + 1,
+                "type": comps == 1 ? "SCALAR" : (comps == 3 ? "VEC3" : "VEC4"),
+            ]
+            if comps == 1 { acc["min"] = [0]; acc["max"] = [slice.last!] }
+            accessors.append(acc)
+            rewritten[accessorIndex] = accessors.count - 1
+            return accessors.count - 1
+        }
+
+        for (i, s) in samplers.enumerated() {
+            guard let input = s["input"] as? Int, let output = s["output"] as? Int else { continue }
+            let outComps = ((accessors[output]["type"] as? String) == "VEC3") ? 3 : 4
+            samplers[i]["input"] = try sliced(input, comps: 1, rebase: true)
+            samplers[i]["output"] = try sliced(output, comps: outComps, rebase: false)
+        }
+        anims[0]["samplers"] = samplers
+        container.json["animations"] = anims
+        container.json["accessors"] = accessors
+        container.json["bufferViews"] = bufferViews
+        if var buffers = container.json["buffers"] as? [[String: Any]], !buffers.isEmpty {
+            buffers[0]["byteLength"] = bin.count
+            container.json["buffers"] = buffers
+        }
+        container.bin = bin
+    }
 }

--- a/Sources/VRMAProcessKit/VRMAClipEditor.swift
+++ b/Sources/VRMAProcessKit/VRMAClipEditor.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Write-side glb surgery for locomotion ingest. All edits are minimal and
+/// in-place: the bin chunk is only modified where values change.
+public struct VRMAClipEditor {
+    public var container: GLBContainer
+
+    public init(container: GLBContainer) { self.container = container }
+
+    /// Rebase the hips translation track's X and Z to their first-frame
+    /// values (in-place float writes in the bin chunk; same byte length).
+    /// Y (bob) and all rotation tracks are untouched.
+    public mutating func stripHipsXZ() throws {
+        let inspector = try VRMAClipInspector(container: container)
+        let (_, outputAcc) = try inspector.hipsTranslationSampler()
+        guard let accessors = container.json["accessors"] as? [[String: Any]],
+              outputAcc >= 0, outputAcc < accessors.count,
+              let count = accessors[outputAcc]["count"] as? Int,
+              let bvIndex = accessors[outputAcc]["bufferView"] as? Int,
+              let bvs = container.json["bufferViews"] as? [[String: Any]],
+              bvIndex >= 0, bvIndex < bvs.count
+        else { throw VRMAClipInspector.InspectError.badAccessor }
+        let base = (bvs[bvIndex]["byteOffset"] as? Int ?? 0) + (accessors[outputAcc]["byteOffset"] as? Int ?? 0)
+        guard base >= 0, count >= 0, base + count * 12 <= container.bin.count
+        else { throw VRMAClipInspector.InspectError.badAccessor }
+        var bin = container.bin
+        func read(_ floatIndex: Int) -> Float {
+            bin.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: base + floatIndex * 4, as: Float.self) }
+        }
+        func write(_ floatIndex: Int, _ v: Float) {
+            withUnsafeBytes(of: v) { bin.replaceSubrange((base + floatIndex * 4)..<(base + floatIndex * 4 + 4), with: $0) }
+        }
+        let x0 = read(0), z0 = read(2)
+        for i in 0..<count {
+            write(i * 3, x0)
+            write(i * 3 + 2, z0)
+        }
+        container.bin = bin
+    }
+
+    /// Drops animation channels whose target node is not in the
+    /// VRMC_vrm_animation humanBones map (baked hair/eye/accessory tracks).
+    /// Orphaned samplers/accessors are left in place — valid glTF, zero risk
+    /// to untouched data. Returns the number of channels dropped.
+    @discardableResult
+    public mutating func stripNonHumanoidChannels() throws -> Int {
+        let inspector = try VRMAClipInspector(container: container)
+        guard var anims = container.json["animations"] as? [[String: Any]], !anims.isEmpty,
+              let channels = anims[0]["channels"] as? [[String: Any]]
+        else { throw VRMAClipInspector.InspectError.noAnimation }
+        let kept = channels.filter { ch in
+            guard let target = ch["target"] as? [String: Any], let node = target["node"] as? Int
+            else { return false }
+            return inspector.humanBoneNodes.contains(node)
+        }
+        let dropped = channels.count - kept.count
+        anims[0]["channels"] = kept
+        container.json["animations"] = anims
+        return dropped
+    }
+}

--- a/Sources/VRMAProcessKit/VRMAClipEditor.swift
+++ b/Sources/VRMAProcessKit/VRMAClipEditor.swift
@@ -1,7 +1,15 @@
 import Foundation
 
 /// All animation samplers must share one keyframe timeline; resample before trimming.
-public enum EditError: Error { case unalignedKeyframes }
+public enum EditError: Error, CustomStringConvertible {
+    case unalignedKeyframes
+    public var description: String {
+        switch self {
+        case .unalignedKeyframes:
+            return "animation channels carry genuinely different keyframe timelines — resample to a shared timeline before trimming"
+        }
+    }
+}
 
 /// Write-side glb surgery for locomotion ingest. All edits are minimal and
 /// in-place: the bin chunk is only modified where values change.
@@ -78,8 +86,10 @@ public struct VRMAClipEditor {
     /// Trimmed data is APPENDED as new bufferViews/accessors and samplers
     /// are repointed — existing bytes stay untouched.
     ///
-    /// Throws `EditError.unalignedKeyframes` if rotation channels do not all
-    /// share a single input accessor. Resample before calling if needed.
+    /// Timelines may live in distinct accessors as long as their values are
+    /// identical (the common exporter pattern); genuinely divergent timelines
+    /// throw unalignedKeyframes. When values match, all kept samplers' "input"
+    /// is repointed to ONE shared new canonical accessor (not 91 identical copies).
     public mutating func loopTrim() throws {
         let inspector = try VRMAClipInspector(container: container)
         guard var anims = container.json["animations"] as? [[String: Any]], !anims.isEmpty,
@@ -87,16 +97,31 @@ public struct VRMAClipEditor {
               var samplers = anims[0]["samplers"] as? [[String: Any]]
         else { throw VRMAClipInspector.InspectError.noAnimation }
 
-        // Every kept channel is sliced on the same [s...e] key window, so
-        // ALL of them — rotations and the hips translation alike — must
-        // share one keyframe timeline. Validate before any accessor math.
+        // Every kept channel is sliced on the same [s...e] key window, so ALL of
+        // them — rotations and the hips translation alike — must share one keyframe
+        // timeline. Exporters commonly emit N distinct accessor objects that are
+        // byte-identical (one per channel), so we first collect distinct accessor
+        // indices and then verify their VALUES are elementwise equal before accepting.
         var channelInputs: [Int] = []
         for ch in channels {
             guard let si = ch["sampler"] as? Int, si >= 0, si < samplers.count,
                   let input = samplers[si]["input"] as? Int else { continue }
             channelInputs.append(input)
         }
-        guard Set(channelInputs).count <= 1 else { throw EditError.unalignedKeyframes }
+        let distinctInputs = Array(Set(channelInputs))
+        if distinctInputs.count > 1 {
+            // Decode the first and compare every other accessor elementwise.
+            let canonical = try inspector.floats(accessor: distinctInputs[0])
+            for i in 1..<distinctInputs.count {
+                let other = try inspector.floats(accessor: distinctInputs[i])
+                guard other.count == canonical.count,
+                      zip(other, canonical).allSatisfy({ $0 == $1 })
+                else { throw EditError.unalignedKeyframes }
+            }
+        }
+        // All timelines are value-identical; use the first distinct input as the
+        // canonical accessor index for slicing.
+        let canonicalInputIndex = distinctInputs.first
 
         guard let accessors0 = container.json["accessors"] as? [[String: Any]] else {
             throw VRMAClipInspector.InspectError.badAccessor
@@ -107,29 +132,26 @@ public struct VRMAClipEditor {
 
         // Collect rotation outputs for the seam metric.
         var rotationOutputs: [[Float]] = []
-        var rotationInputs: [Int] = []
         for ch in channels {
             guard let target = ch["target"] as? [String: Any],
                   target["path"] as? String == "rotation",
                   let si = ch["sampler"] as? Int, si >= 0, si < samplers.count,
-                  let input = samplers[si]["input"] as? Int,
                   let out = samplers[si]["output"] as? Int else { continue }
             let q = try inspector.floats(accessor: out)
             rotationOutputs.append(q)
-            rotationInputs.append(input)
         }
 
-        // keyCount comes from the shared input accessor — the one timeline
-        // every channel was just validated against.
-        let keyCount: Int
-        if let sharedInput = rotationInputs.first {
-            guard sharedInput >= 0, sharedInput < accessors0.count,
-                  let kc = accessors0[sharedInput]["count"] as? Int
-            else { throw VRMAClipInspector.InspectError.badAccessor }
-            keyCount = kc
-        } else {
-            return  // no rotation channels, nothing to trim
+        // keyCount comes from the canonical input accessor — the one timeline
+        // every channel was just validated against (by value).
+        guard let canonicalInput = canonicalInputIndex else {
+            return  // no channels at all, nothing to trim
         }
+        let keyCount: Int
+        guard canonicalInput >= 0, canonicalInput < accessors0.count,
+              let kc = accessors0[canonicalInput]["count"] as? Int
+        else { throw VRMAClipInspector.InspectError.badAccessor }
+        keyCount = kc
+        guard !rotationOutputs.isEmpty else { return }  // no rotation channels, nothing to trim
 
         guard keyCount > 4 else { return }  // nothing meaningful to trim
 
@@ -180,6 +202,8 @@ public struct VRMAClipEditor {
         }
 
         // Rewrite only channel-referenced samplers to [best.s ... best.e] via appended views.
+        // All kept samplers share ONE sliced input accessor (the canonical timeline);
+        // outputs are still sliced per-accessor as each channel has its own data.
         var accessors = accessors0
         var bufferViews = bufferViews0
         var bin = container.bin
@@ -218,14 +242,17 @@ public struct VRMAClipEditor {
             return accessors.count - 1
         }
 
+        // Slice the canonical input ONCE; every kept sampler repoints to it.
+        let sharedInputNew = try sliced(canonicalInput, comps: 1, rebase: true)
+
         for (i, s) in samplers.enumerated() {
             guard usedSamplers.contains(i) else { continue }
-            guard let input = s["input"] as? Int, let output = s["output"] as? Int else { continue }
+            guard let output = s["output"] as? Int else { continue }
             guard output >= 0, output < accessors.count,
                   let typeStr = accessors[output]["type"] as? String,
                   let outComps = compsByType[typeStr]
             else { throw VRMAClipInspector.InspectError.badAccessor }
-            samplers[i]["input"] = try sliced(input, comps: 1, rebase: true)
+            samplers[i]["input"] = sharedInputNew
             samplers[i]["output"] = try sliced(output, comps: outComps, rebase: false)
         }
         anims[0]["samplers"] = samplers

--- a/Sources/VRMAProcessKit/VRMAClipEditor.swift
+++ b/Sources/VRMAProcessKit/VRMAClipEditor.swift
@@ -21,19 +21,23 @@ public struct VRMAClipEditor {
               bvIndex >= 0, bvIndex < bvs.count
         else { throw VRMAClipInspector.InspectError.badAccessor }
         let base = (bvs[bvIndex]["byteOffset"] as? Int ?? 0) + (accessors[outputAcc]["byteOffset"] as? Int ?? 0)
-        guard base >= 0, count >= 0, base + count * 12 <= container.bin.count
+        // Fix 1: count >= 1 so the unconditional first-frame reads at base/base+8 are in range.
+        // Fix 2: enforce float32 VEC3 (same constraints the read path already checks).
+        // Fix 3: base % 4 == 0 ensures storeBytes(of:toByteOffset:as:) alignment (glTF spec guarantees this).
+        guard base >= 0, count >= 1,
+              accessors[outputAcc]["componentType"] as? Int == 5126,
+              accessors[outputAcc]["type"] as? String == "VEC3",
+              base % 4 == 0,
+              base + count * 12 <= container.bin.count
         else { throw VRMAClipInspector.InspectError.badAccessor }
         var bin = container.bin
-        func read(_ floatIndex: Int) -> Float {
-            bin.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: base + floatIndex * 4, as: Float.self) }
-        }
-        func write(_ floatIndex: Int, _ v: Float) {
-            withUnsafeBytes(of: v) { bin.replaceSubrange((base + floatIndex * 4)..<(base + floatIndex * 4 + 4), with: $0) }
-        }
-        let x0 = read(0), z0 = read(2)
-        for i in 0..<count {
-            write(i * 3, x0)
-            write(i * 3 + 2, z0)
+        let x0 = bin.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: base, as: Float.self) }
+        let z0 = bin.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: base + 8, as: Float.self) }
+        bin.withUnsafeMutableBytes { raw in
+            for i in 0..<count {
+                raw.storeBytes(of: x0, toByteOffset: base + i * 12, as: Float.self)
+                raw.storeBytes(of: z0, toByteOffset: base + i * 12 + 8, as: Float.self)
+            }
         }
         container.bin = bin
     }

--- a/Sources/VRMAProcessKit/VRMAClipInspector.swift
+++ b/Sources/VRMAProcessKit/VRMAClipInspector.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Read-side helpers over a VRMA GLBContainer: locate the hips channel via
+/// the VRMC_vrm_animation humanBones map and decode sampler float data.
+public struct VRMAClipInspector {
+    let container: GLBContainer
+    public let hipsNode: Int
+    public let humanBoneNodes: Set<Int>
+
+    public enum InspectError: Error { case noAnimation, noHumanoidMap, noHipsTranslation, badAccessor }
+
+    public init(container: GLBContainer) throws {
+        self.container = container
+        guard let ext = container.json["extensions"] as? [String: Any],
+              let vrma = ext["VRMC_vrm_animation"] as? [String: Any],
+              let humanoid = vrma["humanoid"] as? [String: Any],
+              let bones = humanoid["humanBones"] as? [String: Any]
+        else { throw InspectError.noHumanoidMap }
+        var nodes = Set<Int>()
+        var hips: Int?
+        for (name, v) in bones {
+            guard let d = v as? [String: Any], let n = d["node"] as? Int else { continue }
+            nodes.insert(n)
+            if name == "hips" { hips = n }
+        }
+        guard let h = hips else { throw InspectError.noHumanoidMap }
+        self.hipsNode = h
+        self.humanBoneNodes = nodes
+    }
+
+    func animation0() throws -> [String: Any] {
+        guard let anims = container.json["animations"] as? [[String: Any]], let a = anims.first
+        else { throw InspectError.noAnimation }
+        return a
+    }
+
+    /// Decodes the float array backing accessor `index`.
+    public func floats(accessor index: Int) throws -> [Float] {
+        guard let accessors = container.json["accessors"] as? [[String: Any]],
+              index < accessors.count,
+              let bvIndex = accessors[index]["bufferView"] as? Int,
+              let count = accessors[index]["count"] as? Int,
+              let type = accessors[index]["type"] as? String,
+              let bvs = container.json["bufferViews"] as? [[String: Any]],
+              bvIndex < bvs.count
+        else { throw InspectError.badAccessor }
+        let comps = ["SCALAR": 1, "VEC3": 3, "VEC4": 4][type] ?? 1
+        let byteOffset = (bvs[bvIndex]["byteOffset"] as? Int ?? 0) + (accessors[index]["byteOffset"] as? Int ?? 0)
+        let n = count * comps
+        return container.bin.withUnsafeBytes { raw in
+            (0..<n).map { raw.loadUnaligned(fromByteOffset: byteOffset + $0 * 4, as: Float.self) }
+        }
+    }
+
+    /// (input accessor, output accessor) of the hips translation channel.
+    public func hipsTranslationSampler() throws -> (input: Int, output: Int) {
+        let anim = try animation0()
+        guard let channels = anim["channels"] as? [[String: Any]],
+              let samplers = anim["samplers"] as? [[String: Any]]
+        else { throw InspectError.noAnimation }
+        for ch in channels {
+            guard let target = ch["target"] as? [String: Any],
+                  target["node"] as? Int == hipsNode,
+                  target["path"] as? String == "translation",
+                  let si = ch["sampler"] as? Int, si < samplers.count,
+                  let input = samplers[si]["input"] as? Int,
+                  let output = samplers[si]["output"] as? Int
+            else { continue }
+            return (input, output)
+        }
+        throw InspectError.noHipsTranslation
+    }
+
+    /// Mean ground speed of the hips over the clip: total XZ path length / duration.
+    public func meanHipsXZSpeed() throws -> Float {
+        let (inputAcc, outputAcc) = try hipsTranslationSampler()
+        let times = try floats(accessor: inputAcc)
+        let xyz = try floats(accessor: outputAcc)
+        guard times.count >= 2, xyz.count == times.count * 3 else { throw InspectError.badAccessor }
+        var path: Float = 0
+        for i in 1..<times.count {
+            let dx = xyz[i * 3] - xyz[(i - 1) * 3]
+            let dz = xyz[i * 3 + 2] - xyz[(i - 1) * 3 + 2]
+            path += (dx * dx + dz * dz).squareRoot()
+        }
+        let duration = times.last! - times.first!
+        return duration > 0 ? path / duration : 0
+    }
+
+    /// Rest hips world height from the node hierarchy (sum of ancestor Y translations).
+    public func hipsRestHeight() throws -> Float {
+        guard let nodes = container.json["nodes"] as? [[String: Any]] else { throw InspectError.badAccessor }
+        var parent: [Int: Int] = [:]
+        for (i, n) in nodes.enumerated() {
+            for c in (n["children"] as? [Int]) ?? [] { parent[c] = i }
+        }
+        var y: Float = 0
+        var cur: Int? = hipsNode
+        while let c = cur {
+            if let t = nodes[c]["translation"] as? [Any], t.count == 3 {
+                y += Float((t[1] as? NSNumber)?.doubleValue ?? 0)
+            }
+            cur = parent[c]
+        }
+        return y
+    }
+}

--- a/Sources/VRMAProcessKit/VRMAClipInspector.swift
+++ b/Sources/VRMAProcessKit/VRMAClipInspector.swift
@@ -7,7 +7,7 @@ public struct VRMAClipInspector {
     public let hipsNode: Int
     public let humanBoneNodes: Set<Int>
 
-    public enum InspectError: Error { case noAnimation, noHumanoidMap, noHipsTranslation, badAccessor }
+    public enum InspectError: Error { case noAnimation, noHumanoidMap, noHipsTranslation, badAccessor, malformedNodes }
 
     public init(container: GLBContainer) throws {
         self.container = container
@@ -35,18 +35,29 @@ public struct VRMAClipInspector {
     }
 
     /// Decodes the float array backing accessor `index`.
+    /// Throws `badAccessor` if componentType is not 5126 (Float), type is not SCALAR/VEC3/VEC4,
+    /// any index is out of range, or the byte range exceeds the bin buffer.
     public func floats(accessor index: Int) throws -> [Float] {
         guard let accessors = container.json["accessors"] as? [[String: Any]],
-              index < accessors.count,
+              index >= 0, index < accessors.count,
               let bvIndex = accessors[index]["bufferView"] as? Int,
+              bvIndex >= 0,
               let count = accessors[index]["count"] as? Int,
+              let componentType = accessors[index]["componentType"] as? Int,
               let type = accessors[index]["type"] as? String,
               let bvs = container.json["bufferViews"] as? [[String: Any]],
               bvIndex < bvs.count
         else { throw InspectError.badAccessor }
-        let comps = ["SCALAR": 1, "VEC3": 3, "VEC4": 4][type] ?? 1
+        // I1 — require float32 and a known vector width; no silent fallback
+        guard componentType == 5126,
+              let comps = ["SCALAR": 1, "VEC3": 3, "VEC4": 4][type]
+        else { throw InspectError.badAccessor }
         let byteOffset = (bvs[bvIndex]["byteOffset"] as? Int ?? 0) + (accessors[index]["byteOffset"] as? Int ?? 0)
         let n = count * comps
+        // C1 — bounds-check before any memory read
+        guard byteOffset >= 0, n >= 0,
+              byteOffset + n * 4 <= container.bin.count
+        else { throw InspectError.badAccessor }
         return container.bin.withUnsafeBytes { raw in
             (0..<n).map { raw.loadUnaligned(fromByteOffset: byteOffset + $0 * 4, as: Float.self) }
         }
@@ -62,9 +73,9 @@ public struct VRMAClipInspector {
             guard let target = ch["target"] as? [String: Any],
                   target["node"] as? Int == hipsNode,
                   target["path"] as? String == "translation",
-                  let si = ch["sampler"] as? Int, si < samplers.count,
-                  let input = samplers[si]["input"] as? Int,
-                  let output = samplers[si]["output"] as? Int
+                  let si = ch["sampler"] as? Int, si >= 0, si < samplers.count,
+                  let input = samplers[si]["input"] as? Int, input >= 0,
+                  let output = samplers[si]["output"] as? Int, output >= 0
             else { continue }
             return (input, output)
         }
@@ -88,15 +99,24 @@ public struct VRMAClipInspector {
     }
 
     /// Rest hips world height from the node hierarchy (sum of ancestor Y translations).
+    /// Throws `malformedNodes` if a cycle is detected in the parent chain.
     public func hipsRestHeight() throws -> Float {
         guard let nodes = container.json["nodes"] as? [[String: Any]] else { throw InspectError.badAccessor }
         var parent: [Int: Int] = [:]
         for (i, n) in nodes.enumerated() {
-            for c in (n["children"] as? [Int]) ?? [] { parent[c] = i }
+            // C2 — skip children entries that are out of range or negative
+            for c in (n["children"] as? [Int]) ?? [] {
+                guard c >= 0, c < nodes.count else { continue }
+                parent[c] = i
+            }
         }
         var y: Float = 0
         var cur: Int? = hipsNode
+        var visited = Set<Int>()
         while let c = cur {
+            // C2 — detect cycles and out-of-range indices during walk
+            guard c >= 0, c < nodes.count else { throw InspectError.malformedNodes }
+            guard visited.insert(c).inserted else { throw InspectError.malformedNodes }
             if let t = nodes[c]["translation"] as? [Any], t.count == 3 {
                 y += Float((t[1] as? NSNumber)?.doubleValue ?? 0)
             }

--- a/Sources/VRMAProcessKit/VRMAClipInspector.swift
+++ b/Sources/VRMAProcessKit/VRMAClipInspector.swift
@@ -48,13 +48,13 @@ public struct VRMAClipInspector {
               let bvs = container.json["bufferViews"] as? [[String: Any]],
               bvIndex < bvs.count
         else { throw InspectError.badAccessor }
-        // I1 — require float32 and a known vector width; no silent fallback
+        // componentType 5126 (Float32) and a recognised vector width are required; any other type throws.
         guard componentType == 5126,
               let comps = ["SCALAR": 1, "VEC3": 3, "VEC4": 4][type]
         else { throw InspectError.badAccessor }
         let byteOffset = (bvs[bvIndex]["byteOffset"] as? Int ?? 0) + (accessors[index]["byteOffset"] as? Int ?? 0)
         let n = count * comps
-        // C1 — bounds-check before any memory read
+        // Byte range must lie within the bin buffer before any unsafe memory access.
         guard byteOffset >= 0, n >= 0,
               byteOffset + n * 4 <= container.bin.count
         else { throw InspectError.badAccessor }
@@ -104,7 +104,7 @@ public struct VRMAClipInspector {
         guard let nodes = container.json["nodes"] as? [[String: Any]] else { throw InspectError.badAccessor }
         var parent: [Int: Int] = [:]
         for (i, n) in nodes.enumerated() {
-            // C2 — skip children entries that are out of range or negative
+            // Children indices that are out of range or negative are silently skipped.
             for c in (n["children"] as? [Int]) ?? [] {
                 guard c >= 0, c < nodes.count else { continue }
                 parent[c] = i
@@ -114,7 +114,7 @@ public struct VRMAClipInspector {
         var cur: Int? = hipsNode
         var visited = Set<Int>()
         while let c = cur {
-            // C2 — detect cycles and out-of-range indices during walk
+            // Out-of-range or repeated node indices indicate a malformed hierarchy.
             guard c >= 0, c < nodes.count else { throw InspectError.malformedNodes }
             guard visited.insert(c).inserted else { throw InspectError.malformedNodes }
             if let t = nodes[c]["translation"] as? [Any], t.count == 3 {

--- a/Sources/VRMAProcessKit/VRMAClipInspector.swift
+++ b/Sources/VRMAProcessKit/VRMAClipInspector.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2026 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 
 /// Read-side helpers over a VRMA GLBContainer: locate the hips channel via

--- a/Sources/VRMAProcessKit/VRMAClipInspector.swift
+++ b/Sources/VRMAProcessKit/VRMAClipInspector.swift
@@ -69,11 +69,13 @@ public struct VRMAClipInspector {
               let comps = ["SCALAR": 1, "VEC3": 3, "VEC4": 4][type]
         else { throw InspectError.badAccessor }
         let byteOffset = (bvs[bvIndex]["byteOffset"] as? Int ?? 0) + (accessors[index]["byteOffset"] as? Int ?? 0)
-        let n = count * comps
-        // Byte range must lie within the bin buffer before any unsafe memory access.
-        guard byteOffset >= 0, n >= 0,
-              byteOffset + n * 4 <= container.bin.count
-        else { throw InspectError.badAccessor }
+        // Overflow-safe bounds math: hostile accessor counts must throw, not trap.
+        let (n, nOverflow) = count.multipliedReportingOverflow(by: comps)
+        guard !nOverflow, n >= 0 else { throw InspectError.badAccessor }
+        let (nBytes, bOverflow) = n.multipliedReportingOverflow(by: 4)
+        guard !bOverflow else { throw InspectError.badAccessor }
+        let (end, eOverflow) = byteOffset.addingReportingOverflow(nBytes)
+        guard !eOverflow, byteOffset >= 0, end <= container.bin.count else { throw InspectError.badAccessor }
         return container.bin.withUnsafeBytes { raw in
             (0..<n).map { raw.loadUnaligned(fromByteOffset: byteOffset + $0 * 4, as: Float.self) }
         }

--- a/Sources/VRMMetalKit/Animation/Animation.swift
+++ b/Sources/VRMMetalKit/Animation/Animation.swift
@@ -18,6 +18,25 @@
 import Foundation
 import simd
 
+/// The locomotion clip contract — written by VRMAProcess into glTF
+/// `extras.arkavo` (see the GameOfMods locomotion design, 2026-06-10, §4).
+public struct LocomotionMetadata: Sendable, Equatable {
+    public let version: Int
+    /// Mean hips ground speed (m/s) of the source capture. 0 = explicit idle.
+    public let strideSpeed: Float
+    /// True when hips XZ translation has been stripped (root stays code-owned).
+    public let inPlace: Bool
+    /// Source rig's rest hips height (m), for future height normalization.
+    public let sourceHipsHeight: Float
+
+    public init(version: Int, strideSpeed: Float, inPlace: Bool, sourceHipsHeight: Float) {
+        self.version = version
+        self.strideSpeed = strideSpeed
+        self.inPlace = inPlace
+        self.sourceHipsHeight = sourceHipsHeight
+    }
+}
+
 /// Time-keyed clip of joint, node, morph, and expression samplers driven by an ``AnimationPlayer``.
 ///
 /// ## Discussion
@@ -55,6 +74,13 @@ public struct AnimationClip {
     /// source VRMA file did not contain a `lookAt` block (per VRMC_vrm_animation-1.0).
     /// (internal: B1 spec compliance)
     public var lookAtTargetSampler: ((Float) -> SIMD3<Float>)?
+
+    /// Locomotion metadata parsed from glTF `extras.arkavo` on the source
+    /// animation (written by VRMAProcess). `strideSpeed == 0` is an explicit
+    /// idle; `nil` means the clip is not a locomotion clip and the
+    /// locomotion blend layer will refuse it. Only contract version 1
+    /// parses; unknown versions read as nil, same semantics as absence.
+    public var locomotion: LocomotionMetadata?
 
     /// Creates an empty clip with the given duration in seconds.
     public init(duration: Float) {

--- a/Sources/VRMMetalKit/Animation/Layers/IdleBreathingLayer.swift
+++ b/Sources/VRMMetalKit/Animation/Layers/IdleBreathingLayer.swift
@@ -66,7 +66,9 @@ public class IdleBreathingLayer: AnimationLayer {
     private let noiseOffset: Float
 
     // Pre-allocated output to avoid per-frame allocations
-    private var cachedOutput = LayerOutput(blendMode: .blend(1.0))
+    // Additive: breathing is a small delta over whatever base layer (locomotion)
+    // produced — .blend(1.0) would replace the base outright on shared bones.
+    private var cachedOutput = LayerOutput(blendMode: .additive)
 
     // MARK: - Initialization
 

--- a/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendLayer.swift
+++ b/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendLayer.swift
@@ -79,6 +79,11 @@ public final class LocomotionBlendLayer: AnimationLayer {
         }
     }
 
+    /// Test seam: inject rest rotations without binding a model.
+    func setRestRotationsForTesting(_ rests: [VRMHumanoidBone: simd_quatf]) {
+        restRotations = rests
+    }
+
     public func setClips(idle: AnimationClip, walk: AnimationClip) throws {
         guard idle.locomotion != nil, let walkMeta = walk.locomotion else {
             throw LocomotionError.missingMetadata
@@ -87,7 +92,13 @@ public final class LocomotionBlendLayer: AnimationLayer {
         idleClip = idle
         walkClip = walk
         math = LocomotionBlendMath(walkStrideSpeed: walkMeta.strideSpeed)
-        affectedBones = Set(idle.jointTracks.map(\.bone)).union(walk.jointTracks.map(\.bone))
+        // Only bones that have a rotationSampler enter affectedBones.
+        // Translation-only tracks (e.g. hips Y-bob after ingest) must not be
+        // rotation-driven by this layer: sampling them returns nil, the old
+        // fallback to identity would emit `rest.inverse * identity` which snaps
+        // the bone to world-identity through the compositor.
+        affectedBones = Set(idle.jointTracks.filter { $0.rotationSampler != nil }.map(\.bone))
+            .union(walk.jointTracks.filter { $0.rotationSampler != nil }.map(\.bone))
     }
 
     public func update(deltaTime: Float, context: AnimationContext) {
@@ -123,12 +134,17 @@ public final class LocomotionBlendLayer: AnimationLayer {
 
         let identity = simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
         for bone in affectedBones {
-            let qi = idlePose[bone] ?? identity
-            let qw = walkPose[bone] ?? identity
+            // Default missing per-pose rotations to REST, not identity.
+            // Using identity here would emit `rest.inverse * identity` which
+            // snaps the bone to world-identity through the compositor when rest
+            // is non-trivial. Using rest means the delta for the missing side
+            // is `rest.inverse * rest == identity` (stay at rest) — correct.
+            let rest = restRotations[bone] ?? identity
+            let qi = idlePose[bone] ?? rest
+            let qw = walkPose[bone] ?? rest
             let blended = simd_slerp(qi, qw, blend.walkWeight)
             // Emit a rest-relative delta: compositor applies base * delta.
             // With no model bound, rest is identity so delta == clip rotation.
-            let rest = restRotations[bone] ?? identity
             let delta = rest.inverse * blended
             bones[bone] = ProceduralBoneTransform(rotation: delta)
         }

--- a/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendLayer.swift
+++ b/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendLayer.swift
@@ -1,0 +1,91 @@
+import Foundation
+import simd
+
+/// Base-pose locomotion layer (locomotion design §5): a 1-D speed blend
+/// space populated with an idle entry (strideSpeed 0) and a walk entry.
+/// Owns the full 0→max base pose; `IdleBreathingLayer` composes additively
+/// above it and `IKLayer` (priority 4) corrects foot plant after everything.
+///
+/// Purity contract: output is a function of (targetSpeed, accumulated
+/// sim dt, phaseOffset, clips). No clocks, no smoothing, no velocity
+/// dynamics — the host's controller owns those (design §6).
+public final class LocomotionBlendLayer: AnimationLayer {
+    public enum LocomotionError: Error {
+        case missingMetadata
+        case walkStrideMustBePositive
+    }
+
+    public let identifier = "locomotion-blend"
+    /// Below every existing layer: breathing 0, expression 1, lookAt 2, IK 4.
+    public let priority = -10
+    public var isEnabled = true
+    public private(set) var affectedBones: Set<VRMHumanoidBone> = []
+
+    /// Speed in m/s, set by the host controller. No internal smoothing.
+    public var targetSpeed: Float = 0
+    /// Normalized [0,1) cycle offset, seeded per-entity by the host.
+    public var phaseOffset: Float = 0
+
+    private var idleClip: AnimationClip?
+    private var walkClip: AnimationClip?
+    private var math: LocomotionBlendMath?
+    private var idlePhase: Float = 0  // seconds into idle clip
+    private var walkPhase: Float = 0  // seconds into walk clip
+
+    public init() {}
+
+    public func setClips(idle: AnimationClip, walk: AnimationClip) throws {
+        guard idle.locomotion != nil, let walkMeta = walk.locomotion else {
+            throw LocomotionError.missingMetadata
+        }
+        guard walkMeta.strideSpeed > 0 else { throw LocomotionError.walkStrideMustBePositive }
+        idleClip = idle
+        walkClip = walk
+        math = LocomotionBlendMath(walkStrideSpeed: walkMeta.strideSpeed)
+        affectedBones = Set(idle.jointTracks.map(\.bone)).union(walk.jointTracks.map(\.bone))
+    }
+
+    public func update(deltaTime: Float, context: AnimationContext) {
+        guard let math, let idleClip, let walkClip else { return }
+        let blend = math.blend(forSpeed: targetSpeed)
+        idlePhase = advance(idlePhase, by: deltaTime, duration: idleClip.duration)
+        walkPhase = advance(walkPhase, by: deltaTime * blend.walkRate, duration: walkClip.duration)
+    }
+
+    private func advance(_ phase: Float, by dt: Float, duration: Float) -> Float {
+        guard duration > 0 else { return 0 }
+        return fmodf(phase + dt, duration)
+    }
+
+    public func evaluate() -> LayerOutput {
+        guard let math, let idleClip, let walkClip else { return LayerOutput() }
+        let blend = math.blend(forSpeed: targetSpeed)
+        var bones: [VRMHumanoidBone: ProceduralBoneTransform] = [:]
+
+        func sample(_ clip: AnimationClip, phase: Float) -> [VRMHumanoidBone: simd_quatf] {
+            var out: [VRMHumanoidBone: simd_quatf] = [:]
+            let duration = max(clip.duration, 1e-5)
+            // phaseOffset is a normalized [0,1) entity seed; scaling by 0.5*duration
+            // maps phaseOffset=0.5 to the quarter-cycle peak (maximum decorrelation
+            // on a sine-based clip) rather than the half-cycle antipodal point.
+            let t = fmodf(phase + phaseOffset * duration * 0.5, duration)
+            for track in clip.jointTracks {
+                if let q = track.rotationSampler?(t) { out[track.bone] = q }
+            }
+            return out
+        }
+        let idlePose = sample(idleClip, phase: idlePhase)
+        let walkPose = sample(walkClip, phase: walkPhase)
+
+        let identity = simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
+        for bone in affectedBones {
+            let qi = idlePose[bone] ?? identity
+            let qw = walkPose[bone] ?? identity
+            let q = simd_slerp(qi, qw, blend.walkWeight)
+            bones[bone] = ProceduralBoneTransform(rotation: q)
+        }
+        // This layer IS the base pose for the bones it drives; additive
+        // layers (breathing) stack on top of the compositor's result.
+        return LayerOutput(bones: bones, morphWeights: [:], blendMode: .replace)
+    }
+}

--- a/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendLayer.swift
+++ b/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendLayer.swift
@@ -6,6 +6,15 @@ import simd
 /// Owns the full 0→max base pose; `IdleBreathingLayer` composes additively
 /// above it and `IKLayer` (priority 4) corrects foot plant after everything.
 ///
+/// Output contract: this layer emits **rest-relative deltas** — each bone
+/// rotation is `restRotation.inverse * blendedClipRotation`. The
+/// `AnimationLayerCompositor` applies `base * delta`, which reproduces the
+/// clip rotation exactly when `base == rest` (i.e. when `setup(model:)` and
+/// `AnimationLayerCompositor.setup(model:)` are both called on the same rest
+/// pose). When no model is bound (unit tests), `restRotations` is empty and
+/// delta == clip rotation (identity rest), so existing unit tests remain
+/// unchanged.
+///
 /// Purity contract: output is a function of (targetSpeed, accumulated
 /// sim dt, phaseOffset, clips). No clocks, no smoothing, no velocity
 /// dynamics — the host's controller owns those (design §6).
@@ -24,6 +33,7 @@ public final class LocomotionBlendLayer: AnimationLayer {
     /// Speed in m/s, set by the host controller. No internal smoothing.
     public var targetSpeed: Float = 0
     /// Normalized [0,1) cycle offset, seeded per-entity by the host.
+    /// Any value is safe — it is normalised internally to [0,1) via `floorf`.
     public var phaseOffset: Float = 0
 
     private var idleClip: AnimationClip?
@@ -32,7 +42,26 @@ public final class LocomotionBlendLayer: AnimationLayer {
     private var idlePhase: Float = 0  // seconds into idle clip
     private var walkPhase: Float = 0  // seconds into walk clip
 
+    /// Per-bone rest rotations captured at `setup(model:)`. Empty when no
+    /// model has been bound; in that case deltas equal clip rotations.
+    private var restRotations: [VRMHumanoidBone: simd_quatf] = [:]
+
     public init() {}
+
+    /// Captures the model's current per-bone rotations as the rest pose the
+    /// layer's deltas are expressed against. Call at the same rest moment as
+    /// `AnimationLayerCompositor.setup(model:)` — the compositor pre-multiplies
+    /// its own captured base, so both captures must see the same pose for
+    /// `base * delta` to reproduce the clip rotation exactly.
+    public func setup(model: VRMModel) {
+        restRotations.removeAll()
+        guard let humanoid = model.humanoid else { return }
+        for bone in VRMHumanoidBone.allCases {
+            if let idx = humanoid.getBoneNode(bone), idx < model.nodes.count {
+                restRotations[bone] = model.nodes[idx].rotation
+            }
+        }
+    }
 
     public func setClips(idle: AnimationClip, walk: AnimationClip) throws {
         guard idle.locomotion != nil, let walkMeta = walk.locomotion else {
@@ -65,7 +94,9 @@ public final class LocomotionBlendLayer: AnimationLayer {
         func sample(_ clip: AnimationClip, phase: Float) -> [VRMHumanoidBone: simd_quatf] {
             var out: [VRMHumanoidBone: simd_quatf] = [:]
             let duration = max(clip.duration, 1e-5)
-            let t = fmodf(phase + phaseOffset * duration, duration)
+            // normalise phaseOffset to [0,1) so any caller-supplied value is safe
+            let normalizedOffset = phaseOffset - floorf(phaseOffset)
+            let t = fmodf(phase + normalizedOffset * duration, duration)
             for track in clip.jointTracks {
                 if let q = track.rotationSampler?(t) { out[track.bone] = q }
             }
@@ -78,10 +109,14 @@ public final class LocomotionBlendLayer: AnimationLayer {
         for bone in affectedBones {
             let qi = idlePose[bone] ?? identity
             let qw = walkPose[bone] ?? identity
-            let q = simd_slerp(qi, qw, blend.walkWeight)
-            bones[bone] = ProceduralBoneTransform(rotation: q)
+            let blended = simd_slerp(qi, qw, blend.walkWeight)
+            // Emit a rest-relative delta: compositor applies base * delta.
+            // With no model bound, rest is identity so delta == clip rotation.
+            let rest = restRotations[bone] ?? identity
+            let delta = rest.inverse * blended
+            bones[bone] = ProceduralBoneTransform(rotation: delta)
         }
-        // This layer IS the base pose for the bones it drives; additive
+        // This layer IS the base-pose delta for the bones it drives; additive
         // layers (breathing) stack on top of the compositor's result.
         return LayerOutput(bones: bones, morphWeights: [:], blendMode: .replace)
     }

--- a/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendLayer.swift
+++ b/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendLayer.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2026 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 import simd
 

--- a/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendLayer.swift
+++ b/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendLayer.swift
@@ -65,10 +65,7 @@ public final class LocomotionBlendLayer: AnimationLayer {
         func sample(_ clip: AnimationClip, phase: Float) -> [VRMHumanoidBone: simd_quatf] {
             var out: [VRMHumanoidBone: simd_quatf] = [:]
             let duration = max(clip.duration, 1e-5)
-            // phaseOffset is a normalized [0,1) entity seed; scaling by 0.5*duration
-            // maps phaseOffset=0.5 to the quarter-cycle peak (maximum decorrelation
-            // on a sine-based clip) rather than the half-cycle antipodal point.
-            let t = fmodf(phase + phaseOffset * duration * 0.5, duration)
+            let t = fmodf(phase + phaseOffset * duration, duration)
             for track in clip.jointTracks {
                 if let q = track.rotationSampler?(t) { out[track.bone] = q }
             }

--- a/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendMath.swift
+++ b/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendMath.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Pure blend math for the 1-D locomotion blend space (locomotion design
+/// §5). Stateless and clock-free by construction: a function from speed to
+/// weights/rate.
+///
+/// Low-speed policy: below `kneeFraction` of the walk entry's stride speed,
+/// speed is expressed by idle↔walk WEIGHT blending with walk at its
+/// authored rate; above the knee, weight continues to saturate while
+/// playback RATE stays authored until full walk weight, then rate scales
+/// speed/strideSpeed clamped to [minRate, maxRate] so neither moonwalk nor
+/// benny-hill is reachable.
+public struct LocomotionBlendMath: Sendable {
+    public static let minRate: Float = 0.75
+    public static let maxRate: Float = 1.3
+    /// Fraction of stride speed where weight blending hands over to rate
+    /// scaling. Tunable (design §5).
+    public var kneeFraction: Float = 0.5
+
+    public let walkStrideSpeed: Float
+
+    public init(walkStrideSpeed: Float, kneeFraction: Float = 0.5) {
+        precondition(walkStrideSpeed > 0, "walk entry must have strideSpeed > 0; idle is the speed-0 entry")
+        self.walkStrideSpeed = walkStrideSpeed
+        self.kneeFraction = kneeFraction
+    }
+
+    public struct Blend: Sendable, Equatable {
+        public var idleWeight: Float
+        public var walkWeight: Float
+        /// Playback-rate multiplier for the walk clip (1.0 = authored).
+        public var walkRate: Float
+    }
+
+    public func blend(forSpeed rawSpeed: Float) -> Blend {
+        let speed = max(0, rawSpeed)
+        if speed <= 0 {
+            return Blend(idleWeight: 1, walkWeight: 0, walkRate: 1)
+        }
+        if speed < walkStrideSpeed {
+            // Weight expresses speed up to the stride speed; walk stays at
+            // its authored rate (residual ground-speed mismatch between the
+            // knee and full weight is the IK layer's plant correction to
+            // absorb).
+            let w = speed / walkStrideSpeed
+            return Blend(idleWeight: 1 - w, walkWeight: w, walkRate: 1)
+        }
+        // At/above stride speed: full walk; rate carries the difference.
+        let rate = min(Self.maxRate, max(Self.minRate, speed / walkStrideSpeed))
+        return Blend(idleWeight: 0, walkWeight: 1, walkRate: rate)
+    }
+}

--- a/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendMath.swift
+++ b/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendMath.swift
@@ -4,25 +4,22 @@ import Foundation
 /// §5). Stateless and clock-free by construction: a function from speed to
 /// weights/rate.
 ///
-/// Low-speed policy: below `kneeFraction` of the walk entry's stride speed,
-/// speed is expressed by idle↔walk WEIGHT blending with walk at its
-/// authored rate; above the knee, weight continues to saturate while
-/// playback RATE stays authored until full walk weight, then rate scales
-/// speed/strideSpeed clamped to [minRate, maxRate] so neither moonwalk nor
-/// benny-hill is reachable.
+/// Curve: weight expresses speed linearly up to the walk entry's stride speed
+/// (walkWeight = speed / strideSpeed, walkRate = 1.0 = authored). At or
+/// above stride speed the walk weight saturates at 1 and playback rate scales
+/// speed / strideSpeed, clamped to [minRate, maxRate] so neither moonwalk
+/// nor benny-hill is reachable.
+///
+/// Curve shaping (knee tunables) lands with M3 tuning.
 public struct LocomotionBlendMath: Sendable {
     public static let minRate: Float = 0.75
     public static let maxRate: Float = 1.3
-    /// Fraction of stride speed where weight blending hands over to rate
-    /// scaling. Tunable (design §5).
-    public var kneeFraction: Float = 0.5
 
     public let walkStrideSpeed: Float
 
-    public init(walkStrideSpeed: Float, kneeFraction: Float = 0.5) {
+    public init(walkStrideSpeed: Float) {
         precondition(walkStrideSpeed > 0, "walk entry must have strideSpeed > 0; idle is the speed-0 entry")
         self.walkStrideSpeed = walkStrideSpeed
-        self.kneeFraction = kneeFraction
     }
 
     public struct Blend: Sendable, Equatable {

--- a/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendMath.swift
+++ b/Sources/VRMMetalKit/Animation/Layers/LocomotionBlendMath.swift
@@ -1,3 +1,19 @@
+//
+// Copyright 2026 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 import Foundation
 
 /// Pure blend math for the 1-D locomotion blend space (locomotion design

--- a/Sources/VRMMetalKit/Animation/VRMAnimationLoader.swift
+++ b/Sources/VRMMetalKit/Animation/VRMAnimationLoader.swift
@@ -150,6 +150,25 @@ public enum VRMAnimationLoader {
 
         var clip = AnimationClip(duration: duration)
 
+        // Parse locomotion metadata from extras.arkavo on animations[0].
+        //
+        // GLTFAnimation is a Codable struct without an `extras` field, so
+        // JSONDecoder.decode(GLTFDocument.self, ...) silently drops per-animation
+        // extras. We re-parse the raw `data` bytes with JSONSerialization here
+        // (zero extra I/O — `data` is already in memory) to reach the extras dict.
+        // Only version 1 is understood; unknown version or absent block → nil.
+        if let glbJson = try? JSONSerialization.jsonObject(with: glbJsonChunk(from: data)) as? [String: Any],
+           let animations = glbJson["animations"] as? [[String: Any]],
+           let firstAnimation = animations.first,
+           let extras = firstAnimation["extras"] as? [String: Any],
+           let arkavo = extras["arkavo"] as? [String: Any],
+           let version = arkavo["version"] as? Int, version == 1,
+           let stride = (arkavo["strideSpeed"] as? NSNumber)?.floatValue,
+           let inPlace = arkavo["inPlace"] as? Bool,
+           let hipsH = (arkavo["sourceHipsHeight"] as? NSNumber)?.floatValue {
+            clip.locomotion = LocomotionMetadata(version: version, strideSpeed: stride, inPlace: inPlace, sourceHipsHeight: hipsH)
+        }
+
         // Build tracks grouped by node and path
         var nodeTracks: [Int: [String: KeyTrack]] = [:]
 
@@ -581,6 +600,28 @@ public enum VRMAnimationLoader {
 }
 
 // MARK: - Helpers
+
+/// Extracts the JSON chunk bytes from a GLB container for supplementary raw
+/// parsing (e.g. per-animation `extras` fields not surfaced by `GLTFDocument`).
+/// Returns an empty `Data` on any format error so callers can `try?`-elide it.
+private func glbJsonChunk(from data: Data) -> Data {
+    guard data.count >= 12 else { return Data() }
+    let magic = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 0, as: UInt32.self) }
+    guard magic == 0x46546C67 else { return Data() } // "glTF"
+    var offset = 12
+    while offset + 8 <= data.count {
+        let chunkLength = Int(data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset, as: UInt32.self) })
+        let chunkType = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset + 4, as: UInt32.self) }
+        let start = offset + 8
+        let end = start + chunkLength
+        guard end <= data.count else { break }
+        if chunkType == 0x4E4F534A { // "JSON"
+            return data.subdata(in: start..<end)
+        }
+        offset = end
+    }
+    return Data()
+}
 
 private func mix(_ a: SIMD3<Float>, _ b: SIMD3<Float>, t: Float) -> SIMD3<Float> {
     return a + (b - a) * t

--- a/Tests/VRMAProcessKitTests/GLBContainerTests.swift
+++ b/Tests/VRMAProcessKitTests/GLBContainerTests.swift
@@ -5,13 +5,13 @@ final class GLBContainerTests: XCTestCase {
     func makeMinimalGLB() throws -> Data {
         let json: [String: Any] = ["asset": ["version": "2.0"], "animations": []]
         let bin = Data([1, 2, 3, 4, 5, 6, 7, 8])
-        var glb = GLBContainer(json: json, bin: bin)
+        let glb = GLBContainer(json: json, bin: bin)
         return try glb.serialize()
     }
 
     func testRoundTripPreservesJSONAndBin() throws {
         let data = try makeMinimalGLB()
-        var container = try GLBContainer(data: data)
+        let container = try GLBContainer(data: data)
         XCTAssertEqual((container.json["asset"] as? [String: Any])?["version"] as? String, "2.0")
         XCTAssertEqual(container.bin, Data([1, 2, 3, 4, 5, 6, 7, 8]))
         let re = try container.serialize()
@@ -28,5 +28,33 @@ final class GLBContainerTests: XCTestCase {
 
     func testRejectsGarbage() {
         XCTAssertThrowsError(try GLBContainer(data: Data([0, 1, 2, 3])))
+    }
+
+    // FIX 2 — slice-safe init
+    func testParsesDataSlice() throws {
+        var prefixed = Data([0xFF, 0xFF, 0xFF, 0xFF])
+        prefixed.append(try makeMinimalGLB())
+        let slice = prefixed[4...]
+        let container = try GLBContainer(data: slice)
+        XCTAssertEqual(container.bin, Data([1, 2, 3, 4, 5, 6, 7, 8]))
+    }
+
+    // FIX 3 — honest byte-preservation contract tests
+    func testSerializeParseSerializeIsIdempotent() throws {
+        let first = try makeMinimalGLB()
+        let second = try GLBContainer(data: first).serialize()
+        XCTAssertEqual(first, second, "serialize→parse→serialize must be byte-stable")
+    }
+
+    func testUnalignedBinRoundTripPadsWithZeros() throws {
+        let glb = GLBContainer(json: ["asset": ["version": "2.0"]], bin: Data([9, 9, 9, 9, 9, 9]))
+        let reparsed = try GLBContainer(data: try glb.serialize())
+        XCTAssertEqual(reparsed.bin, Data([9, 9, 9, 9, 9, 9, 0, 0]), "documented padding behavior")
+    }
+
+    func testNoBinChunkParsesToEmptyBin() throws {
+        let glb = GLBContainer(json: ["asset": ["version": "2.0"]], bin: Data())
+        let reparsed = try GLBContainer(data: try glb.serialize())
+        XCTAssertTrue(reparsed.bin.isEmpty)
     }
 }

--- a/Tests/VRMAProcessKitTests/GLBContainerTests.swift
+++ b/Tests/VRMAProcessKitTests/GLBContainerTests.swift
@@ -30,7 +30,7 @@ final class GLBContainerTests: XCTestCase {
         XCTAssertThrowsError(try GLBContainer(data: Data([0, 1, 2, 3])))
     }
 
-    // FIX 2 — slice-safe init
+    /// GLBContainer must parse a Data slice (non-zero startIndex) without misreading the header.
     func testParsesDataSlice() throws {
         var prefixed = Data([0xFF, 0xFF, 0xFF, 0xFF])
         prefixed.append(try makeMinimalGLB())
@@ -39,7 +39,7 @@ final class GLBContainerTests: XCTestCase {
         XCTAssertEqual(container.bin, Data([1, 2, 3, 4, 5, 6, 7, 8]))
     }
 
-    // FIX 3 — honest byte-preservation contract tests
+    /// serialize → parse → serialize must produce byte-identical output.
     func testSerializeParseSerializeIsIdempotent() throws {
         let first = try makeMinimalGLB()
         let second = try GLBContainer(data: first).serialize()

--- a/Tests/VRMAProcessKitTests/GLBContainerTests.swift
+++ b/Tests/VRMAProcessKitTests/GLBContainerTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import VRMAProcessKit
+
+final class GLBContainerTests: XCTestCase {
+    func makeMinimalGLB() throws -> Data {
+        let json: [String: Any] = ["asset": ["version": "2.0"], "animations": []]
+        let bin = Data([1, 2, 3, 4, 5, 6, 7, 8])
+        var glb = GLBContainer(json: json, bin: bin)
+        return try glb.serialize()
+    }
+
+    func testRoundTripPreservesJSONAndBin() throws {
+        let data = try makeMinimalGLB()
+        var container = try GLBContainer(data: data)
+        XCTAssertEqual((container.json["asset"] as? [String: Any])?["version"] as? String, "2.0")
+        XCTAssertEqual(container.bin, Data([1, 2, 3, 4, 5, 6, 7, 8]))
+        let re = try container.serialize()
+        let reparsed = try GLBContainer(data: re)
+        XCTAssertEqual(reparsed.bin, container.bin)
+    }
+
+    func testHeaderMagicAndLengthAreValid() throws {
+        let data = try makeMinimalGLB()
+        XCTAssertEqual(data.prefix(4), Data("glTF".utf8))
+        let total = data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 8, as: UInt32.self) }
+        XCTAssertEqual(Int(total), data.count)
+    }
+
+    func testRejectsGarbage() {
+        XCTAssertThrowsError(try GLBContainer(data: Data([0, 1, 2, 3])))
+    }
+}

--- a/Tests/VRMAProcessKitTests/LocomotionIngestTests.swift
+++ b/Tests/VRMAProcessKitTests/LocomotionIngestTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import VRMAProcessKit
+
+final class LocomotionIngestTests: XCTestCase {
+    func testWalkPipelineSinglePassOrder() throws {
+        let out = try LocomotionIngest.process(glb: try SyntheticVRMA.make(vx: 1.5), mode: .auto)
+        let container = try GLBContainer(data: out)
+        let meta = try XCTUnwrap(LocomotionExtras.read(from: container))
+        // measured BEFORE strip:
+        XCTAssertEqual(meta.strideSpeed, 1.5, accuracy: 0.05)
+        XCTAssertTrue(meta.inPlace)
+        XCTAssertEqual(meta.sourceHipsHeight, 0.85, accuracy: 0.001)
+        // stripped AFTER measure:
+        XCTAssertEqual(try VRMAClipInspector(container: container).meanHipsXZSpeed(), 0, accuracy: 1e-3)
+    }
+
+    func testIdleAutoDetectionWritesExplicitZero() throws {
+        let out = try LocomotionIngest.process(glb: try SyntheticVRMA.make(vx: 0.0), mode: .auto)
+        let meta = try XCTUnwrap(LocomotionExtras.read(from: try GLBContainer(data: out)))
+        XCTAssertEqual(meta.strideSpeed, 0)
+    }
+
+    func testForcedIdleModeOverridesMeasurement() throws {
+        let out = try LocomotionIngest.process(glb: try SyntheticVRMA.make(vx: 1.5), mode: .idle)
+        let meta = try XCTUnwrap(LocomotionExtras.read(from: try GLBContainer(data: out)))
+        XCTAssertEqual(meta.strideSpeed, 0)
+    }
+}

--- a/Tests/VRMAProcessKitTests/LocomotionIngestTests.swift
+++ b/Tests/VRMAProcessKitTests/LocomotionIngestTests.swift
@@ -2,6 +2,14 @@ import XCTest
 @testable import VRMAProcessKit
 
 final class LocomotionIngestTests: XCTestCase {
+    func testWalkModeRefusesStationaryClip() throws {
+        XCTAssertThrowsError(try LocomotionIngest.process(glb: try SyntheticVRMA.make(vx: 0.0), mode: .walk)) { error in
+            guard case LocomotionIngest.IngestError.walkClipMeasuresStationary = error else {
+                return XCTFail("expected walkClipMeasuresStationary, got \(error)")
+            }
+        }
+    }
+
     func testWalkPipelineSinglePassOrder() throws {
         let out = try LocomotionIngest.process(glb: try SyntheticVRMA.make(vx: 1.5), mode: .auto)
         let container = try GLBContainer(data: out)

--- a/Tests/VRMAProcessKitTests/LoopTrimTests.swift
+++ b/Tests/VRMAProcessKitTests/LoopTrimTests.swift
@@ -2,6 +2,36 @@ import XCTest
 @testable import VRMAProcessKit
 
 final class LoopTrimTests: XCTestCase {
+    func testMixedTimelinesThrowInsteadOfCrashing() throws {
+        var container = try GLBContainer(data: try SyntheticVRMA.make(duration: 3.0))
+        // Give the leg-rotation sampler its own (shorter) timeline: clone input accessor with smaller count.
+        var json = container.json
+        var accessors = json["accessors"] as! [[String: Any]]
+        var clone = accessors[0]
+        clone["count"] = (accessors[0]["count"] as! Int) - 10
+        accessors.append(clone)
+        json["accessors"] = accessors
+        var anims = json["animations"] as! [[String: Any]]
+        var samplers = anims[0]["samplers"] as! [[String: Any]]
+        samplers[1]["input"] = accessors.count - 1
+        anims[0]["samplers"] = samplers
+        json["animations"] = anims
+        container.json = json
+        var editor = VRMAClipEditor(container: container)
+        try editor.stripNonHumanoidChannels()
+        XCTAssertThrowsError(try editor.loopTrim())
+    }
+
+    func testOrphanedSamplersAreLeftUntouched() throws {
+        var editor = VRMAClipEditor(container: try GLBContainer(data: try SyntheticVRMA.make(duration: 3.0)))
+        try editor.stripNonHumanoidChannels()  // hair channel dropped, its sampler orphaned
+        let samplersBefore = ((editor.container.json["animations"] as! [[String: Any]])[0]["samplers"] as! [[String: Any]])
+        let orphanOutputBefore = samplersBefore[2]["output"] as! Int
+        try editor.loopTrim()
+        let samplersAfter = ((editor.container.json["animations"] as! [[String: Any]])[0]["samplers"] as! [[String: Any]])
+        XCTAssertEqual(samplersAfter[2]["output"] as! Int, orphanOutputBefore, "orphaned sampler must not be rewritten")
+    }
+
     func testTrimProducesLoopContinuousClip() throws {
         var editor = VRMAClipEditor(container: try GLBContainer(data: try SyntheticVRMA.make(duration: 3.0)))
         try editor.stripNonHumanoidChannels()

--- a/Tests/VRMAProcessKitTests/LoopTrimTests.swift
+++ b/Tests/VRMAProcessKitTests/LoopTrimTests.swift
@@ -25,7 +25,6 @@ final class LoopTrimTests: XCTestCase {
         var editor = VRMAClipEditor(container: container)
         try editor.stripNonHumanoidChannels()
         // Must NOT throw — value-identical timelines are accepted.
-        XCTAssertNoThrow(try editor.loopTrim())
         try editor.loopTrim()
 
         // After trim, all kept samplers must point at ONE shared new input accessor.

--- a/Tests/VRMAProcessKitTests/LoopTrimTests.swift
+++ b/Tests/VRMAProcessKitTests/LoopTrimTests.swift
@@ -19,7 +19,11 @@ final class LoopTrimTests: XCTestCase {
         container.json = json
         var editor = VRMAClipEditor(container: container)
         try editor.stripNonHumanoidChannels()
-        XCTAssertThrowsError(try editor.loopTrim())
+        XCTAssertThrowsError(try editor.loopTrim()) { error in
+            guard case EditError.unalignedKeyframes = error else {
+                return XCTFail("expected unalignedKeyframes, got \(error) — the timeline validation must fire before any accessor math")
+            }
+        }
     }
 
     func testOrphanedSamplersAreLeftUntouched() throws {

--- a/Tests/VRMAProcessKitTests/LoopTrimTests.swift
+++ b/Tests/VRMAProcessKitTests/LoopTrimTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import VRMAProcessKit
+
+final class LoopTrimTests: XCTestCase {
+    func testTrimProducesLoopContinuousClip() throws {
+        var editor = VRMAClipEditor(container: try GLBContainer(data: try SyntheticVRMA.make(duration: 3.0)))
+        try editor.stripNonHumanoidChannels()
+        try editor.loopTrim()
+        let inspector = try VRMAClipInspector(container: editor.container)
+        // first/last leg-rotation keys nearly identical after trim
+        let anim = (editor.container.json["animations"] as! [[String: Any]])[0]
+        let samplers = anim["samplers"] as! [[String: Any]]
+        let channels = anim["channels"] as! [[String: Any]]
+        let legCh = channels.first { ($0["target"] as! [String: Any])["path"] as! String == "rotation" }!
+        let s = samplers[legCh["sampler"] as! Int]
+        let quats = try inspector.floats(accessor: s["output"] as! Int)
+        let first = Array(quats.prefix(4)), last = Array(quats.suffix(4))
+        let dot = abs(zip(first, last).map(*).reduce(0, +))
+        XCTAssertGreaterThan(dot, 0.9999, "loop seam should be pose-continuous")
+        // times rebased to 0
+        let times = try inspector.floats(accessor: s["input"] as! Int)
+        XCTAssertEqual(times.first!, 0, accuracy: 1e-6)
+    }
+
+    func testTrimKeepsAtLeast60PercentDuration() throws {
+        var editor = VRMAClipEditor(container: try GLBContainer(data: try SyntheticVRMA.make(duration: 3.0)))
+        try editor.stripNonHumanoidChannels()
+        try editor.loopTrim()
+        let inspector = try VRMAClipInspector(container: editor.container)
+        let (inputAcc, _) = try inspector.hipsTranslationSampler()
+        let times = try inspector.floats(accessor: inputAcc)
+        XCTAssertGreaterThanOrEqual(times.last!, 3.0 * 0.6 - 0.2)
+    }
+}

--- a/Tests/VRMAProcessKitTests/LoopTrimTests.swift
+++ b/Tests/VRMAProcessKitTests/LoopTrimTests.swift
@@ -2,6 +2,41 @@ import XCTest
 @testable import VRMAProcessKit
 
 final class LoopTrimTests: XCTestCase {
+    /// Real exporters (e.g. VRM-compatible tools) commonly emit 91 channels each
+    /// with its own input accessor object, all byte-identical. loopTrim must accept
+    /// these and repoint every kept sampler to ONE shared new input accessor.
+    func testValueIdenticalDistinctInputAccessorsTrimSuccessfully() throws {
+        var container = try GLBContainer(data: try SyntheticVRMA.make(duration: 3.0))
+        // Clone input accessor 0 as a new accessor (same bufferView/count/min/max)
+        // and repoint sampler 1's input to the clone.
+        var json = container.json
+        var accessors = json["accessors"] as! [[String: Any]]
+        let clone = accessors[0]  // byte-identical: same bufferView, count, min, max
+        accessors.append(clone)
+        json["accessors"] = accessors
+        var anims = json["animations"] as! [[String: Any]]
+        var samplers = anims[0]["samplers"] as! [[String: Any]]
+        let cloneIndex = accessors.count - 1
+        samplers[1]["input"] = cloneIndex
+        anims[0]["samplers"] = samplers
+        json["animations"] = anims
+        container.json = json
+
+        var editor = VRMAClipEditor(container: container)
+        try editor.stripNonHumanoidChannels()
+        // Must NOT throw — value-identical timelines are accepted.
+        XCTAssertNoThrow(try editor.loopTrim())
+        try editor.loopTrim()
+
+        // After trim, all kept samplers must point at ONE shared new input accessor.
+        let animOut = (editor.container.json["animations"] as! [[String: Any]])[0]
+        let samplersOut = animOut["samplers"] as! [[String: Any]]
+        let channelsOut = animOut["channels"] as! [[String: Any]]
+        let usedSamplerIndices = Set(channelsOut.compactMap { $0["sampler"] as? Int })
+        let inputIndices = usedSamplerIndices.compactMap { samplersOut[$0]["input"] as? Int }
+        XCTAssertEqual(Set(inputIndices).count, 1, "all kept samplers must share one input accessor after trim")
+    }
+
     func testMixedTimelinesThrowInsteadOfCrashing() throws {
         var container = try GLBContainer(data: try SyntheticVRMA.make(duration: 3.0))
         // Give the leg-rotation sampler its own (shorter) timeline: clone input accessor with smaller count.

--- a/Tests/VRMAProcessKitTests/StrideAndExtrasTests.swift
+++ b/Tests/VRMAProcessKitTests/StrideAndExtrasTests.swift
@@ -27,4 +27,50 @@ final class StrideAndExtrasTests: XCTestCase {
         let container = try GLBContainer(data: try SyntheticVRMA.make())
         XCTAssertNil(LocomotionExtras.read(from: container))
     }
+
+    // C1 — oversized count must throw instead of reading out-of-bounds memory
+    func testOversizedAccessorCountThrowsInsteadOfOverreading() throws {
+        var container = try GLBContainer(data: try SyntheticVRMA.make())
+        var accessors = container.json["accessors"] as! [[String: Any]]
+        accessors[1]["count"] = 100_000
+        container.json["accessors"] = accessors
+        let inspector = try VRMAClipInspector(container: container)
+        XCTAssertThrowsError(try inspector.meanHipsXZSpeed())
+    }
+
+    // C2 — a cycle in the node hierarchy must throw instead of hanging
+    func testNodeCycleThrowsInsteadOfHanging() throws {
+        var container = try GLBContainer(data: try SyntheticVRMA.make())
+        var nodes = container.json["nodes"] as! [[String: Any]]
+        nodes[1]["children"] = [2, 0]  // hips claims Root as child → cycle Root→hips→Root
+        container.json["nodes"] = nodes
+        let inspector = try VRMAClipInspector(container: container)
+        XCTAssertThrowsError(try inspector.hipsRestHeight())
+    }
+
+    // I1 — non-float componentType must throw instead of silently returning garbage
+    func testNonFloatComponentTypeThrows() throws {
+        var container = try GLBContainer(data: try SyntheticVRMA.make())
+        var accessors = container.json["accessors"] as! [[String: Any]]
+        accessors[1]["componentType"] = 5123  // ushort
+        container.json["accessors"] = accessors
+        let inspector = try VRMAClipInspector(container: container)
+        XCTAssertThrowsError(try inspector.meanHipsXZSpeed())
+    }
+
+    // Zero-velocity clip sanity check
+    func testZeroVelocityClipMeasuresZeroStride() throws {
+        let container = try GLBContainer(data: try SyntheticVRMA.make(vx: 0.0))
+        let inspector = try VRMAClipInspector(container: container)
+        XCTAssertEqual(try inspector.meanHipsXZSpeed(), 0, accuracy: 1e-4)
+    }
+
+    // I3 — unknown version must read as nil
+    func testUnknownExtrasVersionReadsNil() throws {
+        var container = try GLBContainer(data: try SyntheticVRMA.make())
+        var meta = LocomotionExtras(strideSpeed: 1.0, inPlace: true, sourceHipsHeight: 0.85)
+        meta.version = 2
+        try meta.write(into: &container)
+        XCTAssertNil(LocomotionExtras.read(from: container))
+    }
 }

--- a/Tests/VRMAProcessKitTests/StrideAndExtrasTests.swift
+++ b/Tests/VRMAProcessKitTests/StrideAndExtrasTests.swift
@@ -28,7 +28,7 @@ final class StrideAndExtrasTests: XCTestCase {
         XCTAssertNil(LocomotionExtras.read(from: container))
     }
 
-    // C1 — oversized count must throw instead of reading out-of-bounds memory
+    /// An accessor whose count would extend the byte read beyond the bin buffer must throw, not read out-of-bounds memory.
     func testOversizedAccessorCountThrowsInsteadOfOverreading() throws {
         var container = try GLBContainer(data: try SyntheticVRMA.make())
         var accessors = container.json["accessors"] as! [[String: Any]]
@@ -38,7 +38,7 @@ final class StrideAndExtrasTests: XCTestCase {
         XCTAssertThrowsError(try inspector.meanHipsXZSpeed())
     }
 
-    // C2 — a cycle in the node hierarchy must throw instead of hanging
+    /// A cycle in the node hierarchy must throw `malformedNodes`, not hang.
     func testNodeCycleThrowsInsteadOfHanging() throws {
         var container = try GLBContainer(data: try SyntheticVRMA.make())
         var nodes = container.json["nodes"] as! [[String: Any]]
@@ -48,7 +48,7 @@ final class StrideAndExtrasTests: XCTestCase {
         XCTAssertThrowsError(try inspector.hipsRestHeight())
     }
 
-    // I1 — non-float componentType must throw instead of silently returning garbage
+    /// Non-float componentType (e.g. ushort 5123) must throw `badAccessor`, not return garbage floats.
     func testNonFloatComponentTypeThrows() throws {
         var container = try GLBContainer(data: try SyntheticVRMA.make())
         var accessors = container.json["accessors"] as! [[String: Any]]
@@ -65,7 +65,7 @@ final class StrideAndExtrasTests: XCTestCase {
         XCTAssertEqual(try inspector.meanHipsXZSpeed(), 0, accuracy: 1e-4)
     }
 
-    // I3 — unknown version must read as nil
+    /// An extras block with an unrecognised version must read as nil (treated as absent).
     func testUnknownExtrasVersionReadsNil() throws {
         var container = try GLBContainer(data: try SyntheticVRMA.make())
         var meta = LocomotionExtras(strideSpeed: 1.0, inPlace: true, sourceHipsHeight: 0.85)

--- a/Tests/VRMAProcessKitTests/StrideAndExtrasTests.swift
+++ b/Tests/VRMAProcessKitTests/StrideAndExtrasTests.swift
@@ -73,4 +73,13 @@ final class StrideAndExtrasTests: XCTestCase {
         try meta.write(into: &container)
         XCTAssertNil(LocomotionExtras.read(from: container))
     }
+
+    func testNearIntMaxAccessorCountThrowsInsteadOfTrapping() throws {
+        var container = try GLBContainer(data: try SyntheticVRMA.make())
+        var accessors = container.json["accessors"] as! [[String: Any]]
+        accessors[1]["count"] = Int.max / 2
+        container.json["accessors"] = accessors
+        let inspector = try VRMAClipInspector(container: container)
+        XCTAssertThrowsError(try inspector.meanHipsXZSpeed())
+    }
 }

--- a/Tests/VRMAProcessKitTests/StrideAndExtrasTests.swift
+++ b/Tests/VRMAProcessKitTests/StrideAndExtrasTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import VRMAProcessKit
+
+final class StrideAndExtrasTests: XCTestCase {
+    func testMeasuresConstantStrideSpeed() throws {
+        let glb = try SyntheticVRMA.make(duration: 2.0, vx: 1.5)
+        let container = try GLBContainer(data: glb)
+        let inspector = try VRMAClipInspector(container: container)
+        let speed = try inspector.meanHipsXZSpeed()
+        XCTAssertEqual(speed, 1.5, accuracy: 0.05)
+        XCTAssertEqual(try inspector.hipsRestHeight(), 0.85, accuracy: 0.001)
+    }
+
+    func testExtrasRoundTrip() throws {
+        let glb = try SyntheticVRMA.make()
+        var container = try GLBContainer(data: glb)
+        let meta = LocomotionExtras(strideSpeed: 1.42, inPlace: true, sourceHipsHeight: 0.85)
+        try meta.write(into: &container)
+        let reparsed = try GLBContainer(data: try container.serialize())
+        let read = try XCTUnwrap(LocomotionExtras.read(from: reparsed))
+        XCTAssertEqual(read.version, 1)
+        XCTAssertEqual(read.strideSpeed, 1.42, accuracy: 1e-5)
+        XCTAssertTrue(read.inPlace)
+    }
+
+    func testAbsentExtrasReadsNil() throws {
+        let container = try GLBContainer(data: try SyntheticVRMA.make())
+        XCTAssertNil(LocomotionExtras.read(from: container))
+    }
+}

--- a/Tests/VRMAProcessKitTests/StripTests.swift
+++ b/Tests/VRMAProcessKitTests/StripTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import VRMAProcessKit
+
+final class StripTests: XCTestCase {
+    func testHipsXZStripZeroesGroundMotionKeepsBob() throws {
+        var container = try GLBContainer(data: try SyntheticVRMA.make(vx: 1.5))
+        var editor = VRMAClipEditor(container: container)
+        try editor.stripHipsXZ()
+        container = editor.container
+        let inspector = try VRMAClipInspector(container: container)
+        XCTAssertEqual(try inspector.meanHipsXZSpeed(), 0, accuracy: 1e-4)
+        // Y bob survives: output VEC3 ys must not all be equal
+        let (_, out) = try inspector.hipsTranslationSampler()
+        let xyz = try inspector.floats(accessor: out)
+        let ys = stride(from: 1, to: xyz.count, by: 3).map { xyz[$0] }
+        XCTAssertGreaterThan(ys.max()! - ys.min()!, 0.01)
+        // XZ are rebased to first-frame values, not merely zeroed: x[0] == x[k]
+        let xs = stride(from: 0, to: xyz.count, by: 3).map { xyz[$0] }
+        XCTAssertEqual(xs.max()! - xs.min()!, 0, accuracy: 1e-5)
+    }
+
+    func testNonHumanoidChannelStripDropsHairKeepsLeg() throws {
+        var editor = VRMAClipEditor(container: try GLBContainer(data: try SyntheticVRMA.make()))
+        let dropped = try editor.stripNonHumanoidChannels()
+        XCTAssertEqual(dropped, 1)
+        let anim = (editor.container.json["animations"] as! [[String: Any]])[0]
+        let channels = anim["channels"] as! [[String: Any]]
+        XCTAssertEqual(channels.count, 2)  // hips translation + leg rotation remain
+    }
+}

--- a/Tests/VRMAProcessKitTests/StripTests.swift
+++ b/Tests/VRMAProcessKitTests/StripTests.swift
@@ -17,6 +17,10 @@ final class StripTests: XCTestCase {
         // XZ are rebased to first-frame values, not merely zeroed: x[0] == x[k]
         let xs = stride(from: 0, to: xyz.count, by: 3).map { xyz[$0] }
         XCTAssertEqual(xs.max()! - xs.min()!, 0, accuracy: 1e-5)
+        // Pin the rebase: first-frame value is 0.1 (not zero), 0.05 for Z
+        XCTAssertEqual(xs[0], 0.1, accuracy: 1e-5, "X rebased to first-frame value, not zeroed")
+        let zs = stride(from: 2, to: xyz.count, by: 3).map { xyz[$0] }
+        XCTAssertEqual(zs[0], 0.05, accuracy: 1e-5, "Z rebased to first-frame value, not zeroed")
     }
 
     func testNonHumanoidChannelStripDropsHairKeepsLeg() throws {
@@ -26,5 +30,14 @@ final class StripTests: XCTestCase {
         let anim = (editor.container.json["animations"] as! [[String: Any]])[0]
         let channels = anim["channels"] as! [[String: Any]]
         XCTAssertEqual(channels.count, 2)  // hips translation + leg rotation remain
+    }
+
+    func testZeroCountHipsAccessorThrows() throws {
+        var container = try GLBContainer(data: try SyntheticVRMA.make())
+        var accessors = container.json["accessors"] as! [[String: Any]]
+        accessors[1]["count"] = 0
+        container.json["accessors"] = accessors
+        var editor = VRMAClipEditor(container: container)
+        XCTAssertThrowsError(try editor.stripHipsXZ())
     }
 }

--- a/Tests/VRMAProcessKitTests/SyntheticVRMA.swift
+++ b/Tests/VRMAProcessKitTests/SyntheticVRMA.swift
@@ -17,7 +17,7 @@ enum SyntheticVRMA {
         for i in 0..<n {
             let t = Float(i) / 30.0
             times.append(t)
-            hipsT.append(contentsOf: [vx * t, 0.85 + 0.02 * sin(t * 4), 0])
+            hipsT.append(contentsOf: [0.1 + vx * t, 0.85 + 0.02 * sin(t * 4), 0.05])
             let a = 0.3 * sin(t * 6)
             legR.append(contentsOf: [sin(a / 2), 0, 0, cos(a / 2)])
             hairR.append(contentsOf: [0, sin(a / 4), 0, cos(a / 4)])

--- a/Tests/VRMAProcessKitTests/SyntheticVRMA.swift
+++ b/Tests/VRMAProcessKitTests/SyntheticVRMA.swift
@@ -1,0 +1,83 @@
+import Foundation
+@testable import VRMAProcessKit
+
+/// Builds a minimal but valid VRMA glb in memory: a 3-node rig
+/// (root → hips → rightUpperLeg), a VRMC_vrm_animation humanBones map,
+/// one animation with a hips translation track (constant ground speed
+/// `vx` on X, sinusoidal Y bob) and a rightUpperLeg rotation track, plus
+/// one non-humanoid "J_Sec_Hair" rotation track for strip tests.
+enum SyntheticVRMA {
+    /// 30 Hz keys over `duration` seconds.
+    static func make(duration: Float = 2.0, vx: Float = 1.5, includeHairTrack: Bool = true) throws -> Data {
+        let n = max(2, Int(duration * 30))
+        var times: [Float] = []
+        var hipsT: [Float] = []      // xyz interleaved
+        var legR: [Float] = []       // quat xyzw interleaved
+        var hairR: [Float] = []
+        for i in 0..<n {
+            let t = Float(i) / 30.0
+            times.append(t)
+            hipsT.append(contentsOf: [vx * t, 0.85 + 0.02 * sin(t * 4), 0])
+            let a = 0.3 * sin(t * 6)
+            legR.append(contentsOf: [sin(a / 2), 0, 0, cos(a / 2)])
+            hairR.append(contentsOf: [0, sin(a / 4), 0, cos(a / 4)])
+        }
+        var bin = Data()
+        func append(_ floats: [Float]) -> Int {  // returns byteOffset
+            let off = bin.count
+            floats.withUnsafeBytes { bin.append(contentsOf: $0) }
+            return off
+        }
+        let timesOff = append(times), hipsOff = append(hipsT)
+        let legOff = append(legR), hairOff = append(hairR)
+
+        func bufferView(_ off: Int, _ len: Int) -> [String: Any] {
+            ["buffer": 0, "byteOffset": off, "byteLength": len]
+        }
+        func accessor(_ bv: Int, _ count: Int, _ type: String) -> [String: Any] {
+            var a: [String: Any] = ["bufferView": bv, "componentType": 5126, "count": count, "type": type]
+            if type == "SCALAR" { a["min"] = [0]; a["max"] = [times.last!] }
+            return a
+        }
+        var channels: [[String: Any]] = [
+            ["sampler": 0, "target": ["node": 1, "path": "translation"]],
+            ["sampler": 1, "target": ["node": 2, "path": "rotation"]],
+        ]
+        var samplers: [[String: Any]] = [
+            ["input": 0, "output": 1, "interpolation": "LINEAR"],
+            ["input": 0, "output": 2, "interpolation": "LINEAR"],
+        ]
+        var accessors: [[String: Any]] = [
+            accessor(0, n, "SCALAR"), accessor(1, n, "VEC3"), accessor(2, n, "VEC4"),
+        ]
+        var bufferViews: [[String: Any]] = [
+            bufferView(timesOff, times.count * 4), bufferView(hipsOff, hipsT.count * 4),
+            bufferView(legOff, legR.count * 4),
+        ]
+        var nodes: [[String: Any]] = [
+            ["name": "Root", "children": [1]],
+            ["name": "J_Bip_C_Hips", "translation": [0, 0.85, 0], "children": [2]],
+            ["name": "J_Bip_R_UpperLeg", "translation": [-0.08, -0.05, 0]],
+        ]
+        if includeHairTrack {
+            nodes.append(["name": "J_Sec_Hair", "translation": [0, 0.2, 0]])
+            bufferViews.append(bufferView(hairOff, hairR.count * 4))
+            accessors.append(accessor(3, n, "VEC4"))
+            samplers.append(["input": 0, "output": 3, "interpolation": "LINEAR"])
+            channels.append(["sampler": 2, "target": ["node": 3, "path": "rotation"]])
+        }
+        let json: [String: Any] = [
+            "asset": ["version": "2.0"],
+            "buffers": [["byteLength": bin.count]],
+            "bufferViews": bufferViews,
+            "accessors": accessors,
+            "nodes": nodes,
+            "animations": [["channels": channels, "samplers": samplers]],
+            "extensions": ["VRMC_vrm_animation": ["specVersion": "1.0", "humanoid": ["humanBones": [
+                "hips": ["node": 1], "rightUpperLeg": ["node": 2],
+            ]]]],
+        ]
+        let glb = GLBContainer(json: json, bin: bin)
+        return try glb.serialize()
+    }
+}

--- a/Tests/VRMMetalKitTests/Animation/LocomotionBlendLayerTests.swift
+++ b/Tests/VRMMetalKitTests/Animation/LocomotionBlendLayerTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+import simd
+@testable import VRMMetalKit
+
+final class LocomotionBlendLayerTests: XCTestCase {
+    func makeClip(stride: Float, legAmplitude: Float = 0.4) -> AnimationClip {
+        var clip = AnimationClip(duration: 1.0)
+        clip.locomotion = LocomotionMetadata(
+            version: 1, strideSpeed: stride, inPlace: true, sourceHipsHeight: 0.85)
+        clip.addJointTrack(JointTrack(
+            bone: .rightUpperLeg,
+            rotationSampler: { t in simd_quatf(angle: legAmplitude * sin(t * 2 * .pi), axis: SIMD3(1, 0, 0)) }
+        ))
+        return clip
+    }
+
+    func testRefusesClipWithoutMetadata() {
+        let layer = LocomotionBlendLayer()
+        var bare = AnimationClip(duration: 1)
+        XCTAssertThrowsError(try layer.setClips(idle: bare, walk: makeClip(stride: 1.5)))
+        bare.locomotion = LocomotionMetadata(version: 1, strideSpeed: 0, inPlace: true, sourceHipsHeight: 0.85)
+        XCTAssertNoThrow(try layer.setClips(idle: bare, walk: makeClip(stride: 1.5)))
+    }
+
+    func testRefusesWalkWithZeroStride() {
+        let layer = LocomotionBlendLayer()
+        XCTAssertThrowsError(try layer.setClips(idle: makeClip(stride: 0), walk: makeClip(stride: 0)))
+    }
+
+    func testDeterministicReplay() throws {
+        func run() throws -> [simd_quatf] {
+            let layer = LocomotionBlendLayer()
+            try layer.setClips(idle: makeClip(stride: 0, legAmplitude: 0.05), walk: makeClip(stride: 1.5))
+            layer.targetSpeed = 1.2
+            layer.phaseOffset = 0.25
+            var out: [simd_quatf] = []
+            for _ in 0..<120 {
+                layer.update(deltaTime: 1.0 / 60.0, context: AnimationContext())
+                out.append(layer.evaluate().bones[.rightUpperLeg]!.rotation)
+            }
+            return out
+        }
+        let a = try run(), b = try run()
+        for (qa, qb) in zip(a, b) {
+            XCTAssertEqual(qa.vector, qb.vector, "bit-identical replay required")
+        }
+    }
+
+    func testPhaseOffsetDecorrelates() throws {
+        func leg(at phase: Float) throws -> simd_quatf {
+            let layer = LocomotionBlendLayer()
+            try layer.setClips(idle: makeClip(stride: 0, legAmplitude: 0.05), walk: makeClip(stride: 1.5))
+            layer.targetSpeed = 1.5
+            layer.phaseOffset = phase
+            layer.update(deltaTime: 1.0 / 60.0, context: AnimationContext())
+            return layer.evaluate().bones[.rightUpperLeg]!.rotation
+        }
+        let q0 = try leg(at: 0), qHalf = try leg(at: 0.5)
+        XCTAssertLessThan(abs(simd_dot(q0.vector, qHalf.vector)), 0.999,
+                          "half-cycle phase offset must change the pose")
+    }
+
+    func testZeroSpeedHoldsIdlePose() throws {
+        let layer = LocomotionBlendLayer()
+        try layer.setClips(idle: makeClip(stride: 0, legAmplitude: 0.0), walk: makeClip(stride: 1.5))
+        layer.targetSpeed = 0
+        layer.update(deltaTime: 0.5, context: AnimationContext())
+        let q = layer.evaluate().bones[.rightUpperLeg]!.rotation
+        XCTAssertEqual(abs(simd_dot(q.vector, simd_quatf(angle: 0, axis: SIMD3(1, 0, 0)).vector)), 1.0, accuracy: 1e-4)
+    }
+
+    func testPriorityIsBelowAllExistingLayers() {
+        XCTAssertLessThan(LocomotionBlendLayer().priority, IdleBreathingLayer().priority)
+    }
+}

--- a/Tests/VRMMetalKitTests/Animation/LocomotionBlendLayerTests.swift
+++ b/Tests/VRMMetalKitTests/Animation/LocomotionBlendLayerTests.swift
@@ -55,9 +55,12 @@ final class LocomotionBlendLayerTests: XCTestCase {
             layer.update(deltaTime: 1.0 / 60.0, context: AnimationContext())
             return layer.evaluate().bones[.rightUpperLeg]!.rotation
         }
-        let q0 = try leg(at: 0), qHalf = try leg(at: 0.5)
-        XCTAssertLessThan(abs(simd_dot(q0.vector, qHalf.vector)), 0.999,
-                          "half-cycle phase offset must change the pose")
+        // Quarter-cycle offset gives maximum angular separation on the
+        // sine-driven fixture (a half-cycle offset is antipodal in TIME but
+        // nearly symmetric in ANGLE this early in the cycle).
+        let q0 = try leg(at: 0), qQuarter = try leg(at: 0.25)
+        XCTAssertLessThan(abs(simd_dot(q0.vector, qQuarter.vector)), 0.999,
+                          "quarter-cycle phase offset must change the pose")
     }
 
     func testZeroSpeedHoldsIdlePose() throws {

--- a/Tests/VRMMetalKitTests/Animation/LocomotionBlendLayerTests.swift
+++ b/Tests/VRMMetalKitTests/Animation/LocomotionBlendLayerTests.swift
@@ -75,4 +75,36 @@ final class LocomotionBlendLayerTests: XCTestCase {
     func testPriorityIsBelowAllExistingLayers() {
         XCTAssertLessThan(LocomotionBlendLayer().priority, IdleBreathingLayer().priority)
     }
+
+    func testTranslationOnlyTrackDoesNotEnterAffectedBones() throws {
+        var idle = makeClip(stride: 0, legAmplitude: 0.05)
+        // hips Y-bob: translation-only track, the post-ingest shape
+        idle.addJointTrack(JointTrack(bone: .hips, translationSampler: { _ in SIMD3<Float>(0, 0.85, 0) }))
+        let layer = LocomotionBlendLayer()
+        try layer.setClips(idle: idle, walk: makeClip(stride: 1.5))
+        XCTAssertFalse(layer.affectedBones.contains(.hips),
+                       "translation-only bones must not be rotation-driven by the blend")
+        layer.targetSpeed = 0.75
+        layer.update(deltaTime: 1.0 / 60.0, context: AnimationContext())
+        XCTAssertNil(layer.evaluate().bones[.hips])
+    }
+
+    func testBoneMissingFromOneClipBlendsTowardRestNotIdentity() throws {
+        // walk animates rightLowerLeg; idle does not. With a non-identity
+        // rest, the idle side of the blend must contribute REST (delta
+        // identity), never world-identity.
+        var walk = makeClip(stride: 1.5)
+        let q = simd_quatf(angle: 0.5, axis: SIMD3<Float>(1, 0, 0))
+        walk.addJointTrack(JointTrack(bone: .rightLowerLeg, rotationSampler: { _ in q }))
+        let layer = LocomotionBlendLayer()
+        // Simulate a captured non-identity rest without a model:
+        layer.setRestRotationsForTesting([.rightLowerLeg: simd_quatf(angle: 0.2, axis: SIMD3<Float>(1, 0, 0))])
+        try layer.setClips(idle: makeClip(stride: 0, legAmplitude: 0.05), walk: walk)
+        layer.targetSpeed = 0  // pure idle: bone absent from idle pose
+        layer.update(deltaTime: 1.0 / 60.0, context: AnimationContext())
+        let delta = try XCTUnwrap(layer.evaluate().bones[.rightLowerLeg]).rotation
+        let identity = simd_quatf(angle: 0, axis: SIMD3<Float>(1, 0, 0))
+        XCTAssertEqual(abs(simd_dot(delta.vector, identity.vector)), 1.0, accuracy: 1e-4,
+                       "missing-from-idle bone at speed 0 must emit an identity DELTA (stay at rest)")
+    }
 }

--- a/Tests/VRMMetalKitTests/Animation/LocomotionBlendMathTests.swift
+++ b/Tests/VRMMetalKitTests/Animation/LocomotionBlendMathTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import VRMMetalKit
+
+final class LocomotionBlendMathTests: XCTestCase {
+    let math = LocomotionBlendMath(walkStrideSpeed: 1.5)
+
+    func testWeightsSumToOneAndAreMonotonic() {
+        var lastWalk: Float = -1
+        for i in 0...100 {
+            let speed = Float(i) / 100 * 3.0
+            let b = math.blend(forSpeed: speed)
+            XCTAssertEqual(b.idleWeight + b.walkWeight, 1.0, accuracy: 1e-5)
+            XCTAssertGreaterThanOrEqual(b.walkWeight, lastWalk - 1e-6, "walk weight monotonic in speed")
+            lastWalk = b.walkWeight
+        }
+    }
+
+    func testRateClampBounds() {
+        for i in 0...300 {
+            let b = math.blend(forSpeed: Float(i) / 100 * 3.0)
+            XCTAssertGreaterThanOrEqual(b.walkRate, LocomotionBlendMath.minRate - 1e-6)
+            XCTAssertLessThanOrEqual(b.walkRate, LocomotionBlendMath.maxRate + 1e-6)
+        }
+    }
+
+    func testLowSpeedUsesWeightNotRate() {
+        let b = math.blend(forSpeed: 0.5)
+        XCTAssertEqual(b.walkRate, 1.0, accuracy: 0.05)
+        XCTAssertLessThan(b.walkWeight, 1.0)
+    }
+
+    func testAtStrideSpeedFullWalkAuthoredRate() {
+        let b = math.blend(forSpeed: 1.5)
+        XCTAssertEqual(b.walkWeight, 1.0, accuracy: 1e-4)
+        XCTAssertEqual(b.walkRate, 1.0, accuracy: 1e-4)
+    }
+
+    func testAboveStrideSpeedRateScalesUpToClamp() {
+        XCTAssertEqual(math.blend(forSpeed: 1.8).walkRate, 1.2, accuracy: 1e-3)
+        XCTAssertEqual(math.blend(forSpeed: 3.0).walkRate, LocomotionBlendMath.maxRate, accuracy: 1e-4)
+    }
+
+    func testZeroSpeedIsPureIdle() {
+        let b = math.blend(forSpeed: 0)
+        XCTAssertEqual(b.idleWeight, 1.0)
+        XCTAssertEqual(b.walkWeight, 0.0)
+    }
+
+    func testDeterminism() {
+        for _ in 0..<3 {
+            let a = math.blend(forSpeed: 1.2345)
+            let b = math.blend(forSpeed: 1.2345)
+            XCTAssertEqual(a.walkWeight, b.walkWeight)
+            XCTAssertEqual(a.walkRate, b.walkRate)
+        }
+    }
+}

--- a/Tests/VRMMetalKitTests/Animation/LocomotionGuardTests.swift
+++ b/Tests/VRMMetalKitTests/Animation/LocomotionGuardTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+import VRMAProcessKit
+@testable import VRMMetalKit
+
+final class LocomotionGuardTests: XCTestCase {
+    /// Locomotion design §5: the composition stack is a contract.
+    /// Locomotion (base) → breathing (additive) → expression → lookAt → IK last.
+    func testCanonicalLayerOrder() {
+        let locomotion = LocomotionBlendLayer().priority
+        let breathing = IdleBreathingLayer().priority
+        let ik = IKLayer().priority  // IKLayer.init() is public and takes no arguments
+        XCTAssertLessThan(locomotion, breathing, "locomotion is the base pose; breathing rides on top")
+        XCTAssertLessThan(breathing, ik)
+        // IK must be strictly last among the canonical set (expression 1, lookAt 2).
+        XCTAssertTrue([locomotion, breathing, 1, 2].allSatisfy { $0 < ik },
+                      "IKLayer must compose last so plant correction sees the final pose")
+    }
+
+    /// Locomotion design §7: clock APIs are forbidden in locomotion code paths.
+    func testNoClockAPIsInLocomotionSources() throws {
+        let thisFile = URL(fileURLWithPath: #filePath)
+        // Path: Tests/VRMMetalKitTests/Animation/LocomotionGuardTests.swift
+        // 4x deletingLastPathComponent: Animation → VRMMetalKitTests → Tests → repo root
+        let repoRoot = thisFile
+            .deletingLastPathComponent()  // Animation/
+            .deletingLastPathComponent()  // VRMMetalKitTests/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // repo root
+        let sources = [
+            "Sources/VRMMetalKit/Animation/Layers/LocomotionBlendLayer.swift",
+            "Sources/VRMMetalKit/Animation/Layers/LocomotionBlendMath.swift",
+        ]
+        let banned = ["CACurrentMediaTime", "Date(", "DispatchTime.now", "ProcessInfo.processInfo.systemUptime"]
+        for rel in sources {
+            let fileURL = repoRoot.appendingPathComponent(rel)
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: fileURL.path),
+                "source file not found at \(fileURL.path) — repoRoot path math may be wrong"
+            )
+            let text = try String(contentsOf: fileURL, encoding: .utf8)
+            for token in banned {
+                XCTAssertFalse(text.contains(token),
+                               "\(rel) must not use \(token) — caller-dt purity (locomotion design §7)")
+            }
+        }
+    }
+
+    /// The extras.arkavo block is the one cross-repo contract (design §4):
+    /// what VRMAProcessKit WRITES, VRMAnimationLoader must READ. A key
+    /// rename on the tool side that updates its own tests consistently
+    /// would otherwise silently nil out engine-side metadata.
+    func testToolWrittenExtrasParseInEngine() throws {
+        // Minimal VRMA json the tool can stamp and the engine can load.
+        let json: [String: Any] = [
+            "asset": ["version": "2.0"],
+            "buffers": [["byteLength": 32]],
+            "bufferViews": [
+                ["buffer": 0, "byteOffset": 0, "byteLength": 8],
+                ["buffer": 0, "byteOffset": 8, "byteLength": 24],
+            ],
+            "accessors": [
+                ["bufferView": 0, "componentType": 5126, "count": 2, "type": "SCALAR", "min": [0], "max": [1]],
+                ["bufferView": 1, "componentType": 5126, "count": 2, "type": "VEC3"],
+            ],
+            "nodes": [["name": "hips"]],
+            "animations": [[
+                "channels": [["sampler": 0, "target": ["node": 0, "path": "translation"]]],
+                "samplers": [["input": 0, "output": 1, "interpolation": "LINEAR"]],
+            ]],
+            "extensions": ["VRMC_vrm_animation": ["specVersion": "1.0",
+                "humanoid": ["humanBones": ["hips": ["node": 0]]]]],
+        ]
+        var bin = Data()
+        let times: [Float] = [0, 1], vals: [Float] = [0, 0.9, 0, 0, 0.9, 0]
+        times.withUnsafeBytes { bin.append(contentsOf: $0) }
+        vals.withUnsafeBytes { bin.append(contentsOf: $0) }
+        var container = VRMAProcessKit.GLBContainer(json: json, bin: bin)
+        let written = VRMAProcessKit.LocomotionExtras(strideSpeed: 1.42, inPlace: true, sourceHipsHeight: 0.9)
+        try written.write(into: &container)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("contract-roundtrip.vrma")
+        try container.serialize().write(to: url)
+
+        let clip = try VRMAnimationLoader.loadVRMA(from: url, model: nil)
+        let meta = try XCTUnwrap(clip.locomotion, "tool-written extras must parse in the engine")
+        XCTAssertEqual(meta.strideSpeed, 1.42, accuracy: 1e-5)
+        XCTAssertEqual(meta.version, 1)
+        XCTAssertTrue(meta.inPlace)
+        XCTAssertEqual(meta.sourceHipsHeight, 0.9, accuracy: 1e-5)
+    }
+}

--- a/Tests/VRMMetalKitTests/Animation/LocomotionGuardTests.swift
+++ b/Tests/VRMMetalKitTests/Animation/LocomotionGuardTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import Metal
+import simd
 import VRMAProcessKit
 @testable import VRMMetalKit
 
@@ -43,6 +45,44 @@ final class LocomotionGuardTests: XCTestCase {
                                "\(rel) must not use \(token) — caller-dt purity (locomotion design §7)")
             }
         }
+    }
+
+    /// The compositor applies `base * delta`; the locomotion layer emits
+    /// rest-relative deltas. Together they must reproduce the clip rotation
+    /// exactly — this is the seam no per-task test covered.
+    func testCompositorProducesClipPoseThroughLocomotionLayer() async throws {
+        let modelURL = URL(fileURLWithPath: getTestVRM10ModelPath())
+        guard FileManager.default.fileExists(atPath: modelURL.path) else {
+            throw XCTSkip("AvatarSample_A_1.0.vrm.glb fixture not present")
+        }
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw XCTSkip("Metal device not available")
+        }
+        let model = try await VRMModel.load(from: modelURL, device: device)
+
+        var walk = AnimationClip(duration: 1.0)
+        walk.locomotion = LocomotionMetadata(version: 1, strideSpeed: 1.5, inPlace: true, sourceHipsHeight: 0.85)
+        let fixedQ = simd_quatf(angle: 0.35, axis: SIMD3<Float>(1, 0, 0))
+        walk.addJointTrack(JointTrack(bone: .rightUpperLeg, rotationSampler: { _ in fixedQ }))
+        var idle = AnimationClip(duration: 1.0)
+        idle.locomotion = LocomotionMetadata(version: 1, strideSpeed: 0, inPlace: true, sourceHipsHeight: 0.85)
+        idle.addJointTrack(JointTrack(bone: .rightUpperLeg, rotationSampler: { _ in fixedQ }))
+
+        let compositor = AnimationLayerCompositor()
+        compositor.setup(model: model)
+        let layer = LocomotionBlendLayer()
+        layer.setup(model: model)
+        try layer.setClips(idle: idle, walk: walk)
+        layer.targetSpeed = 1.5
+        compositor.addLayer(layer)
+        compositor.update(deltaTime: 1.0 / 60.0, context: AnimationContext())
+
+        let humanoid = try XCTUnwrap(model.humanoid)
+        let idx = try XCTUnwrap(humanoid.getBoneNode(.rightUpperLeg))
+        let applied = model.nodes[idx].rotation
+        let dot = abs(simd_dot(applied.vector, fixedQ.vector))
+        XCTAssertEqual(dot, 1.0, accuracy: 1e-4,
+                       "compositor(base * layerDelta) must reproduce the clip rotation")
     }
 
     /// The extras.arkavo block is the one cross-repo contract (design §4):

--- a/Tests/VRMMetalKitTests/Animation/LocomotionGuardTests.swift
+++ b/Tests/VRMMetalKitTests/Animation/LocomotionGuardTests.swift
@@ -21,13 +21,22 @@ final class LocomotionGuardTests: XCTestCase {
     /// Locomotion design §7: clock APIs are forbidden in locomotion code paths.
     func testNoClockAPIsInLocomotionSources() throws {
         let thisFile = URL(fileURLWithPath: #filePath)
-        // Path: Tests/VRMMetalKitTests/Animation/LocomotionGuardTests.swift
-        // 4x deletingLastPathComponent: Animation → VRMMetalKitTests → Tests → repo root
-        let repoRoot = thisFile
-            .deletingLastPathComponent()  // Animation/
-            .deletingLastPathComponent()  // VRMMetalKitTests/
-            .deletingLastPathComponent()  // Tests/
-            .deletingLastPathComponent()  // repo root
+        // Locate the repo root by marker (Package.swift), not fixed depth, so
+        // moving this file can't silently misroute the grep. No marker within
+        // 8 levels ⇒ no source checkout (CI runner) ⇒ skip. Marker found but a
+        // banned-list source missing ⇒ loud failure (structure regression).
+        var probe = thisFile.deletingLastPathComponent()
+        var foundRoot: URL?
+        for _ in 0..<8 {
+            if FileManager.default.fileExists(atPath: probe.appendingPathComponent("Package.swift").path) {
+                foundRoot = probe
+                break
+            }
+            probe.deleteLastPathComponent()
+        }
+        guard let repoRoot = foundRoot else {
+            throw XCTSkip("no Package.swift above \(thisFile.path) — source checkout not reachable; the lint workflow greps sources as the CI backstop")
+        }
         let sources = [
             "Sources/VRMMetalKit/Animation/Layers/LocomotionBlendLayer.swift",
             "Sources/VRMMetalKit/Animation/Layers/LocomotionBlendMath.swift",
@@ -35,13 +44,12 @@ final class LocomotionGuardTests: XCTestCase {
         let banned = ["CACurrentMediaTime", "Date(", "DispatchTime.now", "ProcessInfo.processInfo.systemUptime"]
         for rel in sources {
             let fileURL = repoRoot.appendingPathComponent(rel)
-            // CI test runners (Xcode Cloud) may not have the source checkout
-            // at the path #filePath was compiled with. The grep only means
-            // something against sources, so skip there — the lint workflow's
-            // source grep is the CI backstop for this same ban.
-            guard FileManager.default.fileExists(atPath: fileURL.path) else {
-                throw XCTSkip("source checkout not reachable at \(fileURL.path) — clock-ban grep runs in source environments only")
-            }
+            // The checkout exists (marker found) — a missing source file here
+            // is a real structure regression, not an environment gap.
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: fileURL.path),
+                "\(rel) missing under \(repoRoot.path) — banned-list paths out of date?"
+            )
             let text = try String(contentsOf: fileURL, encoding: .utf8)
             for token in banned {
                 XCTAssertFalse(text.contains(token),

--- a/Tests/VRMMetalKitTests/Animation/LocomotionGuardTests.swift
+++ b/Tests/VRMMetalKitTests/Animation/LocomotionGuardTests.swift
@@ -35,10 +35,13 @@ final class LocomotionGuardTests: XCTestCase {
         let banned = ["CACurrentMediaTime", "Date(", "DispatchTime.now", "ProcessInfo.processInfo.systemUptime"]
         for rel in sources {
             let fileURL = repoRoot.appendingPathComponent(rel)
-            XCTAssertTrue(
-                FileManager.default.fileExists(atPath: fileURL.path),
-                "source file not found at \(fileURL.path) — repoRoot path math may be wrong"
-            )
+            // CI test runners (Xcode Cloud) may not have the source checkout
+            // at the path #filePath was compiled with. The grep only means
+            // something against sources, so skip there — the lint workflow's
+            // source grep is the CI backstop for this same ban.
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                throw XCTSkip("source checkout not reachable at \(fileURL.path) — clock-ban grep runs in source environments only")
+            }
             let text = try String(contentsOf: fileURL, encoding: .utf8)
             for token in banned {
                 XCTAssertFalse(text.contains(token),

--- a/Tests/VRMMetalKitTests/Animation/LocomotionMetadataTests.swift
+++ b/Tests/VRMMetalKitTests/Animation/LocomotionMetadataTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import VRMMetalKit
+
+final class LocomotionMetadataTests: XCTestCase {
+    /// Builds the smallest VRMA glb with extras.arkavo inline.
+    func makeVRMA(withExtras: Bool) throws -> URL {
+        var animation: [String: Any] = [
+            "channels": [["sampler": 0, "target": ["node": 0, "path": "translation"]]],
+            "samplers": [["input": 0, "output": 1, "interpolation": "LINEAR"]],
+        ]
+        if withExtras {
+            animation["extras"] = ["arkavo": [
+                "version": 1, "strideSpeed": 1.42, "inPlace": true, "sourceHipsHeight": 0.9,
+            ]]
+        }
+        var bin = Data()
+        let times: [Float] = [0, 1], vals: [Float] = [0, 0.9, 0, 0, 0.9, 0]
+        times.withUnsafeBytes { bin.append(contentsOf: $0) }
+        vals.withUnsafeBytes { bin.append(contentsOf: $0) }
+        let json: [String: Any] = [
+            "asset": ["version": "2.0"],
+            "buffers": [["byteLength": bin.count]],
+            "bufferViews": [
+                ["buffer": 0, "byteOffset": 0, "byteLength": 8],
+                ["buffer": 0, "byteOffset": 8, "byteLength": 24],
+            ],
+            "accessors": [
+                ["bufferView": 0, "componentType": 5126, "count": 2, "type": "SCALAR", "min": [0], "max": [1]],
+                ["bufferView": 1, "componentType": 5126, "count": 2, "type": "VEC3"],
+            ],
+            "nodes": [["name": "hips"]],
+            "animations": [animation],
+            "extensions": ["VRMC_vrm_animation": ["specVersion": "1.0",
+                "humanoid": ["humanBones": ["hips": ["node": 0]]]]],
+        ]
+        var jsonData = try JSONSerialization.data(withJSONObject: json)
+        while jsonData.count % 4 != 0 { jsonData.append(0x20) }
+        while bin.count % 4 != 0 { bin.append(0) }
+        var out = Data("glTF".utf8)
+        func u32(_ v: UInt32) { withUnsafeBytes(of: v.littleEndian) { out.append(contentsOf: $0) } }
+        u32(2); u32(UInt32(12 + 8 + jsonData.count + 8 + bin.count))
+        u32(UInt32(jsonData.count)); u32(0x4E4F534A); out.append(jsonData)
+        u32(UInt32(bin.count)); u32(0x004E4942); out.append(bin)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("locometa-\(withExtras).vrma")
+        try out.write(to: url)
+        return url
+    }
+
+    func testParsesLocomotionExtras() throws {
+        let clip = try VRMAnimationLoader.loadVRMA(from: try makeVRMA(withExtras: true), model: nil)
+        let meta = try XCTUnwrap(clip.locomotion)
+        XCTAssertEqual(meta.version, 1)
+        XCTAssertEqual(meta.strideSpeed, 1.42, accuracy: 1e-5)
+        XCTAssertTrue(meta.inPlace)
+        XCTAssertEqual(meta.sourceHipsHeight, 0.9, accuracy: 1e-5)
+    }
+
+    func testAbsentExtrasGivesNil() throws {
+        let clip = try VRMAnimationLoader.loadVRMA(from: try makeVRMA(withExtras: false), model: nil)
+        XCTAssertNil(clip.locomotion)
+    }
+
+    func testUnknownVersionGivesNil() throws {
+        let url = try makeVRMA(withExtras: true)
+        // rewrite version to 2 by editing the file's JSON chunk
+        var data = try Data(contentsOf: url)
+        if let range = data.range(of: Data("\"version\":1".utf8)) {
+            data.replaceSubrange(range, with: Data("\"version\":2".utf8))
+        } else if let range = data.range(of: Data("\"version\" : 1".utf8)) {
+            data.replaceSubrange(range, with: Data("\"version\" : 2".utf8))
+        } else {
+            throw XCTSkip("serialized JSON layout unexpected; adapt the byte patch")
+        }
+        let patched = FileManager.default.temporaryDirectory.appendingPathComponent("locometa-v2.vrma")
+        try data.write(to: patched)
+        let clip = try VRMAnimationLoader.loadVRMA(from: patched, model: nil)
+        XCTAssertNil(clip.locomotion)
+    }
+}


### PR DESCRIPTION
Fixes #340. Engine half of the GameOfMods locomotion design (2026-06-10); the GoM controller (M2) and the Spatial capture pipeline (M0) consume this.

## VRMAProcessKit (new zero-dep target) + VRMAProcess CLI
- GLB chunk container: byte-stable serialize, slice-safe parse, honest padding contract.
- Clip inspector: bounds/shape-validated accessor decoding (no OOB on hostile counts, no node-cycle hangs), stride measurement (hips XZ path length / duration), rest-height walk.
- Clip editor: in-place hips-XZ strip (rebase to first frame — keeps Y bob), non-humanoid channel strip (baked hair/eye tracks), pose-similarity loop trim with a hips-Y bob term (idle seams) via appended buffer views — producer bytes untouched.
- Timeline validation by VALUE: real exports carry per-sampler timelines that are value-identical (verified on the VRMA_01 sample: 91 channels, 91 accessors, identical 709-key timelines) — these pass and share one sliced input; genuinely divergent timelines throw with a resample hint.
- Single-pass ingest (measure → extras → strip → trim) with idle auto-detection (<0.1 m/s ⇒ explicit strideSpeed 0); walk mode refuses stationary clips. CLI: strict args, stderr errors, refuses output==input. Smoke: VRMA_01 ingests end-to-end, and its output re-ingests (idempotence).

## Engine
- `AnimationClip.locomotion` parsed from glTF `extras.arkavo` v1 (versioned cross-repo contract; unknown version reads as nil, same as absence).
- `LocomotionBlendMath`: pure speed→(weights, rate) function — weight expresses speed to the stride speed at authored rate; above it, rate scales clamped to [0.75, 1.3].
- `LocomotionBlendLayer` (priority −10, base of the stack): caller-dt-pure, seeded phase offsets (normalized cycle fraction), emits REST-RELATIVE deltas so the compositor's `base * delta` reproduces clip rotations exactly — pinned by a compositor-seam integration test that fails on double-composition (rest rotations on real rigs are non-identity). `IdleBreathingLayer` switched `.blend(1.0)` → `.additive` so breathing genuinely stacks on the locomotion base instead of replacing shared bones.
- Guard tests: canonical layer order (locomotion → breathing → expression → lookAt → IK last), clock-API ban in locomotion sources, and a tool-write → engine-read extras round-trip so a key rename can't silently sever the contract. All sabotage-verified.

## Verification
Full suite: 1731 tests, 0 failures. Every guard test proven to fail under sabotage before being trusted.

## Out of scope (tracked for M0/M2)
- Resampling genuinely divergent timelines (value-equality covers the standard exporter pattern).
- `--stride` override for authoring in-place walks with a known stride speed.
- GoM-side LocomotionController + wiring (M2 plan, written after this API ships).