### PR TITLE
feat(vrmaprocess): --stride override for already-in-place walk clips

### DIFF
--- a/Sources/VRMAProcess/main.swift
+++ b/Sources/VRMAProcess/main.swift
@@ -48,8 +48,8 @@ let hasIdle = extraArgs.contains("--idle")
 let hasWalk = extraArgs.contains("--walk")
 var strideOverride: Float?
 if let i = extraArgs.firstIndex(of: "--stride") {
-    guard i + 1 < extraArgs.count, let v = Float(extraArgs[i + 1]) else {
-        FileHandle.standardError.write(Data("VRMAProcess: ERROR --stride requires a numeric m/s value\n".utf8))
+    guard i + 1 < extraArgs.count, let v = Float(extraArgs[i + 1]), v.isFinite else {
+        FileHandle.standardError.write(Data("VRMAProcess: ERROR --stride requires a finite numeric m/s value\n".utf8))
         usage()
         exit(2)
     }

--- a/Sources/VRMAProcess/main.swift
+++ b/Sources/VRMAProcess/main.swift
@@ -22,11 +22,12 @@ import VRMAProcessKit
 
 func usage() {
     let msg = """
-    Usage: VRMAProcess <input.vrma> <output.vrma> [--idle|--walk]
+    Usage: VRMAProcess <input.vrma> <output.vrma> [--idle|--walk] [--stride <m/s>]
       Measures stride speed, writes extras.arkavo (version 1), strips hips
       XZ (in-place clips), strips non-humanoid baked tracks, loop-trims by
       pose similarity. --idle/--walk force classification (default: auto,
-      idle below \(LocomotionIngest.idleThreshold) m/s).
+      idle below \(LocomotionIngest.idleThreshold) m/s). --stride supplies
+      an authored stride speed for already-in-place walks (licensed packs).
 
     """
     FileHandle.standardError.write(Data(msg.utf8))
@@ -41,10 +42,20 @@ guard args.count >= 3 else {
 let inputPath  = args[1]
 let outputPath = args[2]
 
-// Validate extra arguments: only --idle or --walk are allowed; not both.
-let extraArgs = args.dropFirst(3)
+// Validate extra arguments: --idle or --walk (not both), optional --stride <m/s>.
+var extraArgs = Array(args.dropFirst(3))
 let hasIdle = extraArgs.contains("--idle")
 let hasWalk = extraArgs.contains("--walk")
+var strideOverride: Float?
+if let i = extraArgs.firstIndex(of: "--stride") {
+    guard i + 1 < extraArgs.count, let v = Float(extraArgs[i + 1]) else {
+        FileHandle.standardError.write(Data("VRMAProcess: ERROR --stride requires a numeric m/s value\n".utf8))
+        usage()
+        exit(2)
+    }
+    strideOverride = v
+    extraArgs.removeSubrange(i...(i + 1))
+}
 let unknownArgs = extraArgs.filter { $0 != "--idle" && $0 != "--walk" }
 
 if hasIdle && hasWalk {
@@ -70,7 +81,7 @@ let mode: LocomotionIngest.Mode = hasIdle ? .idle : (hasWalk ? .walk : .auto)
 
 do {
     let input = try Data(contentsOf: resolvedInput)
-    let output = try LocomotionIngest.process(glb: input, mode: mode)
+    let output = try LocomotionIngest.process(glb: input, mode: mode, strideOverride: strideOverride)
     try output.write(to: resolvedOutput)
     if let meta = LocomotionExtras.read(from: try GLBContainer(data: output)) {
         print("VRMAProcess: \(resolvedOutput.path) strideSpeed=\(meta.strideSpeed) inPlace=\(meta.inPlace) sourceHipsHeight=\(meta.sourceHipsHeight)")

--- a/Sources/VRMAProcess/main.swift
+++ b/Sources/VRMAProcess/main.swift
@@ -58,6 +58,11 @@ if let i = extraArgs.firstIndex(of: "--stride") {
 }
 let unknownArgs = extraArgs.filter { $0 != "--idle" && $0 != "--walk" }
 
+if hasIdle, strideOverride != nil {
+    FileHandle.standardError.write(Data("VRMAProcess: ERROR --stride is meaningless with --idle (idle is the explicit strideSpeed-0 entry)\n".utf8))
+    usage()
+    exit(2)
+}
 if hasIdle && hasWalk {
     FileHandle.standardError.write(Data("VRMAProcess: ERROR --idle and --walk are mutually exclusive\n".utf8))
     usage()

--- a/Sources/VRMAProcessKit/LocomotionIngest.swift
+++ b/Sources/VRMAProcessKit/LocomotionIngest.swift
@@ -50,7 +50,7 @@ public enum LocomotionIngest {
         // Measure FIRST — the strip below erases exactly what we measure.
         let measured = try inspector.meanHipsXZSpeed()
         if let override = strideOverride {
-            guard override > 0 else { throw IngestError.strideOverrideMustBePositive(supplied: override) }
+            guard override > 0, override.isFinite else { throw IngestError.strideOverrideMustBePositive(supplied: override) }
             guard mode != .idle else { throw IngestError.strideOverrideConflictsWithIdle }
         }
         if mode == .walk, strideOverride == nil, measured < idleThreshold {

--- a/Sources/VRMAProcessKit/LocomotionIngest.swift
+++ b/Sources/VRMAProcessKit/LocomotionIngest.swift
@@ -25,26 +25,36 @@ public enum LocomotionIngest {
 
     public enum IngestError: Error, CustomStringConvertible {
         case walkClipMeasuresStationary(measured: Float)
+        case strideOverrideMustBePositive(supplied: Float)
         public var description: String {
             switch self {
-            case .walkClipMeasuresStationary(let m):
+            case .strideOverrideMustBePositive(let v):
+            return "stride override must be positive, got \(v)"
+        case .walkClipMeasuresStationary(let m):
                 return "walk clip measures \(m) m/s hips travel — below the idle threshold (\(LocomotionIngest.idleThreshold)). An already-in-place walk needs an authored stride speed; a --stride override is not implemented yet."
             }
         }
     }
 
-    public static func process(glb: Data, mode: Mode) throws -> Data {
+    /// `strideOverride` supplies an authored stride speed (m/s) for clips
+    /// whose hips travel was already stripped at the source — the common
+    /// shape for licensed in-place packs. Only meaningful with `.walk`;
+    /// must be positive. Without it, `.walk` refuses near-stationary input.
+    public static func process(glb: Data, mode: Mode, strideOverride: Float? = nil) throws -> Data {
         var container = try GLBContainer(data: glb)
         let inspector = try VRMAClipInspector(container: container)
 
         // Measure FIRST — the strip below erases exactly what we measure.
         let measured = try inspector.meanHipsXZSpeed()
-        if mode == .walk, measured < idleThreshold {
+        if let override = strideOverride {
+            guard override > 0 else { throw IngestError.strideOverrideMustBePositive(supplied: override) }
+        }
+        if mode == .walk, strideOverride == nil, measured < idleThreshold {
             throw IngestError.walkClipMeasuresStationary(measured: measured)
         }
-        let isIdle = mode == .idle || (mode == .auto && measured < idleThreshold)
+        let isIdle = mode == .idle || (mode == .auto && strideOverride == nil && measured < idleThreshold)
         let meta = LocomotionExtras(
-            strideSpeed: isIdle ? 0 : measured,
+            strideSpeed: isIdle ? 0 : (strideOverride ?? measured),
             inPlace: true,
             sourceHipsHeight: try inspector.hipsRestHeight()
         )

--- a/Sources/VRMAProcessKit/LocomotionIngest.swift
+++ b/Sources/VRMAProcessKit/LocomotionIngest.swift
@@ -26,12 +26,15 @@ public enum LocomotionIngest {
     public enum IngestError: Error, CustomStringConvertible {
         case walkClipMeasuresStationary(measured: Float)
         case strideOverrideMustBePositive(supplied: Float)
+        case strideOverrideConflictsWithIdle
         public var description: String {
             switch self {
             case .strideOverrideMustBePositive(let v):
             return "stride override must be positive, got \(v)"
+        case .strideOverrideConflictsWithIdle:
+            return "a stride override is meaningless for an idle (idle is the explicit strideSpeed-0 entry) — drop --stride or use --walk"
         case .walkClipMeasuresStationary(let m):
-                return "walk clip measures \(m) m/s hips travel — below the idle threshold (\(LocomotionIngest.idleThreshold)). An already-in-place walk needs an authored stride speed; a --stride override is not implemented yet."
+                return "walk clip measures \(m) m/s hips travel — below the idle threshold (\(LocomotionIngest.idleThreshold)). An already-in-place walk needs an authored stride speed; re-run with --stride <m/s>."
             }
         }
     }
@@ -48,6 +51,7 @@ public enum LocomotionIngest {
         let measured = try inspector.meanHipsXZSpeed()
         if let override = strideOverride {
             guard override > 0 else { throw IngestError.strideOverrideMustBePositive(supplied: override) }
+            guard mode != .idle else { throw IngestError.strideOverrideConflictsWithIdle }
         }
         if mode == .walk, strideOverride == nil, measured < idleThreshold {
             throw IngestError.walkClipMeasuresStationary(measured: measured)

--- a/Tests/VRMAProcessKitTests/LocomotionIngestTests.swift
+++ b/Tests/VRMAProcessKitTests/LocomotionIngestTests.swift
@@ -37,6 +37,11 @@ final class LocomotionIngestTests: XCTestCase {
         XCTAssertTrue(meta.inPlace)
     }
 
+    func testNonFiniteStrideOverrideThrows() {
+        XCTAssertThrowsError(try LocomotionIngest.process(glb: try! SyntheticVRMA.make(vx: 0.0), mode: .walk, strideOverride: .infinity))
+        XCTAssertThrowsError(try LocomotionIngest.process(glb: try! SyntheticVRMA.make(vx: 0.0), mode: .walk, strideOverride: .nan))
+    }
+
     func testStrideOverrideWithIdleModeThrows() {
         XCTAssertThrowsError(try LocomotionIngest.process(glb: try! SyntheticVRMA.make(vx: 0.0), mode: .idle, strideOverride: 1.4))
     }

--- a/Tests/VRMAProcessKitTests/LocomotionIngestTests.swift
+++ b/Tests/VRMAProcessKitTests/LocomotionIngestTests.swift
@@ -37,6 +37,10 @@ final class LocomotionIngestTests: XCTestCase {
         XCTAssertTrue(meta.inPlace)
     }
 
+    func testStrideOverrideWithIdleModeThrows() {
+        XCTAssertThrowsError(try LocomotionIngest.process(glb: try! SyntheticVRMA.make(vx: 0.0), mode: .idle, strideOverride: 1.4))
+    }
+
     func testStrideOverrideMustBePositive() {
         XCTAssertThrowsError(try LocomotionIngest.process(glb: try! SyntheticVRMA.make(vx: 0.0), mode: .walk, strideOverride: 0))
     }

--- a/Tests/VRMAProcessKitTests/LocomotionIngestTests.swift
+++ b/Tests/VRMAProcessKitTests/LocomotionIngestTests.swift
@@ -28,6 +28,19 @@ final class LocomotionIngestTests: XCTestCase {
         XCTAssertEqual(meta.strideSpeed, 0)
     }
 
+    func testStrideOverrideStampsAuthoredValueOnInPlaceWalk() throws {
+        // The common case for licensed packs: an already-in-place walk
+        // (hips travel ~0) with a known authored stride speed.
+        let out = try LocomotionIngest.process(glb: try SyntheticVRMA.make(vx: 0.0), mode: .walk, strideOverride: 1.4)
+        let meta = try XCTUnwrap(LocomotionExtras.read(from: try GLBContainer(data: out)))
+        XCTAssertEqual(meta.strideSpeed, 1.4, accuracy: 1e-5)
+        XCTAssertTrue(meta.inPlace)
+    }
+
+    func testStrideOverrideMustBePositive() {
+        XCTAssertThrowsError(try LocomotionIngest.process(glb: try! SyntheticVRMA.make(vx: 0.0), mode: .walk, strideOverride: 0))
+    }
+
     func testForcedIdleModeOverridesMeasurement() throws {
         let out = try LocomotionIngest.process(glb: try SyntheticVRMA.make(vx: 1.5), mode: .idle)
         let meta = try XCTUnwrap(LocomotionExtras.read(from: try GLBContainer(data: out)))


### PR DESCRIPTION
Follow-up to #341 (locomotion M1), driven by real content: licensed locomotion packs ship walks with hips travel pre-stripped (the VRMA_Locomotion_Pack's Walk.vrma measures 0.012 m/s) — exactly the case the stationary-walk refusal added in M1 correctly rejects, with an error message that already promised this flag.

- `LocomotionIngest.process(glb:mode:strideOverride:)` — optional authored stride speed (m/s); must be positive (`IngestError.strideOverrideMustBePositive`), bypasses the stationary refusal, stamps the supplied value into `extras.arkavo`. Auto mode with an override also classifies as walk.
- CLI: `--stride <m/s>`, validated (numeric required, plays nice with the strict-args handling).
- Tests: override stamps the authored value on a stationary clip; non-positive override throws. 30/30 kit tests green.

Already proven in anger: GameOfMods' locomotion M2 ships `Walk.loco.vrma` produced by this flag (`--walk --stride 1.4`) from the pack's in-place walk.