### PR TITLE
fix(culling): skinned cull volume follows the skeleton — walking avatars no longer vanish

### DIFF
--- a/Sources/VRMMetalKit/Renderer/Systems/FrustumCuller.swift
+++ b/Sources/VRMMetalKit/Renderer/Systems/FrustumCuller.swift
@@ -87,6 +87,37 @@ public struct Frustum {
     }
 }
 
+/// Culling support for skinned primitives, whose vertices are posed by the
+/// joint palette rather than the mesh node's `worldMatrix`.
+public enum SkinnedCullBounds {
+    /// Model matrix that positions a model's rest-pose bounds for a skinned
+    /// frustum test: a pure translation by the hips joint's displacement from
+    /// its rest-pose world position.
+    ///
+    /// Skinned vertices follow the joint palette, so the mesh node's
+    /// `worldMatrix` says nothing about where the body is. Testing the
+    /// rest-pose bounds untranslated (the pre-#301 behavior) pins the cull
+    /// volume at the model's load position — a character that walks away is
+    /// culled while visibly on screen. Pose variance (raised arms, crouches)
+    /// is absorbed by the caller's bounds inflation; this matrix only needs
+    /// to track gross displacement, for which the hips joint is the anchor.
+    ///
+    /// Returns identity when either position is unavailable (non-humanoid
+    /// glTF) — the rest-pose box at the load position is the best available
+    /// estimate there.
+    public static func cullModelMatrix(
+        hipsWorldPosition: SIMD3<Float>?,
+        restHipsWorldPosition: SIMD3<Float>?
+    ) -> matrix_float4x4 {
+        guard let now = hipsWorldPosition, let rest = restHipsWorldPosition else {
+            return matrix_identity_float4x4
+        }
+        var m = matrix_identity_float4x4
+        m.columns.3 = SIMD4<Float>(now.x - rest.x, now.y - rest.y, now.z - rest.z, 1)
+        return m
+    }
+}
+
 /// Helpers for transforming axis-aligned bounding boxes between coordinate spaces.
 public enum AABBTransform {
     /// Transforms a local-space AABB by a model matrix into a (conservative) world-space AABB.

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -942,7 +942,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
         // (#301): each frame the inflated rest bounds are translated by the
         // hips' displacement from this position, so a character that moves
         // away from its load position keeps a valid cull volume.
-        if let hipsIndex = model.humanoid?.getBoneNode(.hips), hipsIndex < model.nodes.count {
+        if let hipsIndex = model.humanoid?.getBoneNode(.hips), hipsIndex >= 0, hipsIndex < model.nodes.count {
             restHipsWorldPosition = model.nodes[hipsIndex].worldPosition
         } else {
             restHipsWorldPosition = nil
@@ -1675,7 +1675,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
         // translation tracks the hips joint; pose variance is absorbed by
         // the inflation above.
         let skinnedCullMatrix: matrix_float4x4
-        if let hipsIndex = model.humanoid?.getBoneNode(.hips), hipsIndex < model.nodes.count {
+        if let hipsIndex = model.humanoid?.getBoneNode(.hips), hipsIndex >= 0, hipsIndex < model.nodes.count {
             skinnedCullMatrix = SkinnedCullBounds.cullModelMatrix(
                 hipsWorldPosition: model.nodes[hipsIndex].worldPosition,
                 restHipsWorldPosition: restHipsWorldPosition)

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -741,6 +741,10 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
     private var cachedRenderItems: [RenderItem]?
     private var cacheNeedsRebuild = true
 
+    /// Hips world position captured at `loadModel` (rest pose). Anchors the
+    /// skinned-primitive cull volume — see `SkinnedCullBounds.cullModelMatrix`.
+    private var restHipsWorldPosition: SIMD3<Float>?
+
     // Scratch dictionary reused by the transparency-sort pass to avoid a
     // per-frame dictionary allocation. Keys are primitiveIndex.
     private var viewZByIndex: [Int: Float] = [:]
@@ -933,6 +937,16 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
         // PERFORMANCE: Invalidate cached render items when model changes
         cacheNeedsRebuild = true
         cachedRenderItems = nil
+
+        // Rest-pose hips anchor for the skinned-primitive frustum cull
+        // (#301): each frame the inflated rest bounds are translated by the
+        // hips' displacement from this position, so a character that moves
+        // away from its load position keeps a valid cull volume.
+        if let hipsIndex = model.humanoid?.getBoneNode(.hips), hipsIndex < model.nodes.count {
+            restHipsWorldPosition = model.nodes[hipsIndex].worldPosition
+        } else {
+            restHipsWorldPosition = nil
+        }
 
         // Initialize skinning system with all skins for proper offset allocation
         if !model.skins.isEmpty {
@@ -1654,6 +1668,20 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
         let inflatedHalfExtent = (modelLocalBounds.max - modelLocalBounds.min) * 0.25
         let inflatedModelMin = modelLocalBounds.min - inflatedHalfExtent
         let inflatedModelMax = modelLocalBounds.max + inflatedHalfExtent
+        // Skinned vertices are posed by the joint palette, not the mesh
+        // node's worldMatrix, so the rest-pose bounds must follow the
+        // skeleton — a character that walks away from its load position
+        // would otherwise be culled while visibly on screen (#301). The
+        // translation tracks the hips joint; pose variance is absorbed by
+        // the inflation above.
+        let skinnedCullMatrix: matrix_float4x4
+        if let hipsIndex = model.humanoid?.getBoneNode(.hips), hipsIndex < model.nodes.count {
+            skinnedCullMatrix = SkinnedCullBounds.cullModelMatrix(
+                hipsWorldPosition: model.nodes[hipsIndex].worldPosition,
+                restHipsWorldPosition: restHipsWorldPosition)
+        } else {
+            skinnedCullMatrix = matrix_identity_float4x4
+        }
         var culledThisFrame = 0
 
         // Use stored light directions directly (world-space lighting)
@@ -2392,7 +2420,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
             let cullLocalMax: SIMD3<Float>
             let isSkinnedForCull = (item.node.skin != nil || (item.primitive.hasJoints && item.primitive.hasWeights)) && hasSkinning
             if isSkinnedForCull {
-                cullModelMatrix = matrix_identity_float4x4
+                cullModelMatrix = skinnedCullMatrix
                 cullLocalMin = inflatedModelMin
                 cullLocalMax = inflatedModelMax
             } else {
@@ -3740,7 +3768,8 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
             model: model,
             frustum: frameFrustum,
             inflatedModelMin: inflatedModelMin,
-            inflatedModelMax: inflatedModelMax
+            inflatedModelMax: inflatedModelMax,
+            skinnedCullMatrix: skinnedCullMatrix
         )
 
         encoder.endEncoding()
@@ -3793,7 +3822,8 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
         model: VRMModel,
         frustum: Frustum,
         inflatedModelMin: SIMD3<Float>,
-        inflatedModelMax: SIMD3<Float>
+        inflatedModelMax: SIMD3<Float>,
+        skinnedCullMatrix: matrix_float4x4
     ) {
         // Only render outlines if we have a pipeline and global outline width is non-zero
         guard mtoonOutlinePipelineState != nil || mtoonSkinnedOutlinePipelineState != nil else {
@@ -3856,7 +3886,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
             let outlineCullMin: SIMD3<Float>
             let outlineCullMax: SIMD3<Float>
             if isSkinned {
-                outlineCullModel = matrix_identity_float4x4
+                outlineCullModel = skinnedCullMatrix
                 outlineCullMin = inflatedModelMin
                 outlineCullMax = inflatedModelMax
             } else {

--- a/Tests/VRMMetalKitTests/FrustumCullingTests.swift
+++ b/Tests/VRMMetalKitTests/FrustumCullingTests.swift
@@ -132,3 +132,101 @@ final class FrustumCullingTests: XCTestCase {
         XCTAssertEqual(world.max.z, sqrtf(2), accuracy: 1e-4)
     }
 }
+
+// MARK: - #301: avatars rejected at distance
+
+extension FrustumCullingTests {
+
+    /// The unit repro #301 asks for: camera looking on-axis at an avatar-sized
+    /// AABB ~25 m ahead, well inside the FOV and far plane. The pure plane
+    /// math must accept it — if this fails, `Frustum`/`cullsAABB` itself is
+    /// broken for distant boxes.
+    func testOnAxisDistantAvatarIsNotCulled() {
+        let projection = metalPerspective(fovy: .pi / 3, aspect: 16.0 / 9.0, near: 0.1, far: 100)
+        // Over-the-shoulder-ish camera at the #301 geometry: avatar ~25 m away.
+        let view = lookAt(
+            eye: SIMD3<Float>(7.2, 1.7, -4.0),
+            center: SIMD3<Float>(7.4, 0.9, 20.8),
+            up: SIMD3<Float>(0, 1, 0))
+        let frustum = Frustum(viewProjection: simd_mul(projection, view))
+        // Avatar-sized box (1 × 2 × 1 m) centered at the logged reject position.
+        let lo = SIMD3<Float>(6.9, -0.1, 20.3)
+        let hi = SIMD3<Float>(7.9,  1.9, 21.3)
+        XCTAssertFalse(frustum.cullsAABB(min: lo, max: hi),
+                       "on-screen avatar 25 m ahead must not be culled")
+    }
+
+    /// The live #301 mechanism in the renderer: skinned primitives were culled
+    /// against the inflated rest-pose bounds with an IDENTITY model matrix, so
+    /// the cull volume stayed at the model's load position forever. A
+    /// character that walks 20 m away — camera following — left the stale box
+    /// behind and vanished. `SkinnedCullBounds.cullModelMatrix` translates the
+    /// box by the hips' displacement so it follows the skeleton.
+    func testSkinnedCullVolumeFollowsSkeleton() {
+        let projection = metalPerspective(fovy: .pi / 3, aspect: 16.0 / 9.0, near: 0.1, far: 100)
+        // Camera 6 m behind the walked-to position, looking at the character.
+        let view = lookAt(
+            eye: SIMD3<Float>(20, 1.6, 6),
+            center: SIMD3<Float>(20, 1.0, 0),
+            up: SIMD3<Float>(0, 1, 0))
+        let frustum = Frustum(viewProjection: simd_mul(projection, view))
+
+        // Inflated rest-pose bounds of a ~1.7 m humanoid loaded at the origin.
+        let inflatedMin = SIMD3<Float>(-0.6, -0.2, -0.5)
+        let inflatedMax = SIMD3<Float>( 0.6,  2.0,  0.5)
+        let restHips = SIMD3<Float>(0, 0.8, 0)
+        let walkedHips = SIMD3<Float>(20, 0.8, 0)  // walked 20 m down +X
+
+        // Old behavior (identity): the stale box at the origin is out of view
+        // even though the character is dead-center on screen.
+        let staleAABB = AABBTransform.worldAABB(
+            localMin: inflatedMin, localMax: inflatedMax,
+            modelMatrix: matrix_identity_float4x4)
+        XCTAssertTrue(frustum.cullsAABB(min: staleAABB.min, max: staleAABB.max),
+                      "precondition: the stale rest box at origin is off-screen for this camera")
+
+        // Fixed behavior: the box follows the hips and is accepted.
+        let followMatrix = SkinnedCullBounds.cullModelMatrix(
+            hipsWorldPosition: walkedHips,
+            restHipsWorldPosition: restHips)
+        let followedAABB = AABBTransform.worldAABB(
+            localMin: inflatedMin, localMax: inflatedMax,
+            modelMatrix: followMatrix)
+        XCTAssertFalse(frustum.cullsAABB(min: followedAABB.min, max: followedAABB.max),
+                       "cull volume must follow the walked character")
+    }
+
+    /// Camera still at the spawn point looking where the character USED to
+    /// be: once the character walks away, the followed volume should cull
+    /// (the character is genuinely off-screen) — guards against the fix
+    /// accidentally making skinned primitives never-culled.
+    func testWalkedAwayCharacterStillCullsWhenOffScreen() {
+        let projection = metalPerspective(fovy: .pi / 3, aspect: 16.0 / 9.0, near: 0.1, far: 100)
+        // Camera looking down -Z at the spawn point; character walked +X out of frame.
+        let view = lookAt(
+            eye: SIMD3<Float>(0, 1.6, 6),
+            center: SIMD3<Float>(0, 1.0, 0),
+            up: SIMD3<Float>(0, 1, 0))
+        let frustum = Frustum(viewProjection: simd_mul(projection, view))
+
+        let inflatedMin = SIMD3<Float>(-0.6, -0.2, -0.5)
+        let inflatedMax = SIMD3<Float>( 0.6,  2.0,  0.5)
+        let followMatrix = SkinnedCullBounds.cullModelMatrix(
+            hipsWorldPosition: SIMD3<Float>(40, 0.8, 0),
+            restHipsWorldPosition: SIMD3<Float>(0, 0.8, 0))
+        let followedAABB = AABBTransform.worldAABB(
+            localMin: inflatedMin, localMax: inflatedMax,
+            modelMatrix: followMatrix)
+        XCTAssertTrue(frustum.cullsAABB(min: followedAABB.min, max: followedAABB.max))
+    }
+
+    /// Non-humanoid models have no hips anchor — the matrix degrades to
+    /// identity (rest box at load position), the pre-fix behavior.
+    func testCullMatrixIdentityWithoutHips() {
+        let m = SkinnedCullBounds.cullModelMatrix(hipsWorldPosition: nil, restHipsWorldPosition: nil)
+        XCTAssertEqual(m, matrix_identity_float4x4)
+        let m2 = SkinnedCullBounds.cullModelMatrix(
+            hipsWorldPosition: SIMD3<Float>(1, 2, 3), restHipsWorldPosition: nil)
+        XCTAssertEqual(m2, matrix_identity_float4x4)
+    }
+}


### PR DESCRIPTION
Fixes #301.

## Root cause

Skinned primitives were frustum-tested against the inflated rest-pose model bounds with an **identity model matrix** (`VRMRenderer.draw` + the MToon outline pass), pinning the cull volume at the model's load position forever. Skinned vertices are posed by the joint palette, so the rendered body walks away while the cull box stays at spawn — once the camera follows the character far enough that the spawn point leaves the frustum, every skinned primitive is rejected and the avatar vanishes while visibly on screen.

The consuming app in #301 could only disable its own model-level cull (`VRMModel.isOutsideFrustum`); this internal per-primitive cull was unreachable, which is why avatars still popped out at ~25 m. The pure plane math is **exonerated** by the new on-axis unit repro the issue asked for: `Frustum`/`cullsAABB` accepts a distant on-screen AABB when given correct inputs (`testOnAxisDistantAvatarIsNotCulled`).

## Fix

`SkinnedCullBounds.cullModelMatrix` translates the inflated rest bounds by the hips joint's displacement from its rest-pose world position (captured at `loadModel`). Gross displacement is what the stale box got wrong; pose variance stays absorbed by the existing 25% inflation. Non-humanoid models (no hips) degrade to the previous identity behavior. Applied to both the main draw cull and the MToon outline cull.

## Tests

- `testOnAxisDistantAvatarIsNotCulled` — the #301 unit repro; pins that the plane math accepts distant on-screen boxes.
- `testSkinnedCullVolumeFollowsSkeleton` — stale identity box is rejected for a walked-away character (precondition), followed box is accepted.
- `testWalkedAwayCharacterStillCullsWhenOffScreen` — the fix doesn't make skinned primitives never-culled.
- `testCullMatrixIdentityWithoutHips` — non-humanoid fallback.

Full suite: 1742 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)