### PR TITLE
perf(outline): dedupe redundant outline pipeline binds (#192)

### DIFF
--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -4007,7 +4007,12 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
                 continue
             }
 
-            encoder.setRenderPipelineState(pipeline)
+            // Dedupe the pipeline bind: consecutive outline draws almost always
+            // share the same (skinned) pipeline, so route through the encoder state
+            // cache to skip redundant identical binds. The main draw loop also binds
+            // through this cache, so its tracked state is consistent here. Output is
+            // bit-identical — this only removes no-op state calls.
+            encoderStateCache.setRenderPipelineState(encoder, pipeline)
 
             // Set vertex buffer
             encoder.setVertexBuffer(vertexBuffer, offset: 0, index: 0)


### PR DESCRIPTION
Stacked on #346 (PR-C of the perf roadmap).

**Honest finding on #192:** the issue asks to merge color+outline+silhouette into one tile-memory pass — but the outline pass is **already in the single render encoder**, so that tile-memory benefit is already realized. Interleaving color+outline per-primitive would *add* depth-state and cull-mode thrash on every primitive, not remove it. The only safe, output-preserving win is deduping the redundant per-draw pipeline bind.

**Change:** route the outline pipeline bind through `encoderStateCache` (the main loop already binds through the same cache, so tracked state is consistent). Consecutive outline draws almost always share the skinned pipeline → redundant identical binds skipped. **Output is bit-identical.**

**Verification:** render/MToon/outline tests green; `make bench-gate` PASS (median flat, slight p95 tail improvement — mostly noise).

Recommend closing #192 after this: the architectural goal is already met by the single-encoder design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)