### PR TITLE
Fix crashes and wrong animation speed in async loaders and LookAt

### DIFF
--- a/Sources/GLTFCore/Loader/GLTFParallelMeshLoader.swift
+++ b/Sources/GLTFCore/Loader/GLTFParallelMeshLoader.swift
@@ -71,8 +71,9 @@ public final class GLTFParallelMeshLoader<Mesh: Sendable>: @unchecked Sendable {
 
         await withTaskGroup(of: (Int, Mesh?).self) { group in
             for meshIndex in indices {
-                group.addTask { [unowned self] in
-                    guard let gltfMesh = self.document.meshes?[safe: meshIndex] else {
+                group.addTask { [weak self] in
+                    guard let self,
+                          let gltfMesh = self.document.meshes?[safe: meshIndex] else {
                         return (meshIndex, nil)
                     }
                     do {

--- a/Sources/GLTFCore/Loader/ParallelTextureLoader.swift
+++ b/Sources/GLTFCore/Loader/ParallelTextureLoader.swift
@@ -125,7 +125,8 @@ public final class ParallelTextureLoader: @unchecked Sendable {
 
         await withTaskGroup(of: (Int, MTLTexture?).self) { group in
             for textureIndex in indices {
-                group.addTask { [unowned self] in
+                group.addTask { [weak self] in
+                    guard let self else { return (textureIndex, nil) }
                     let isLinear = linearTextureIndices.contains(textureIndex)
                     let texture = try? await self.loadTexture(at: textureIndex, sRGB: !isLinear)
                     return (textureIndex, texture)

--- a/Sources/VRMMetalKit/Loader/ParallelMaterialLoader.swift
+++ b/Sources/VRMMetalKit/Loader/ParallelMaterialLoader.swift
@@ -81,8 +81,9 @@ public final class ParallelMaterialLoader: @unchecked Sendable {
 
         await withTaskGroup(of: (Int, VRMMaterial?).self) { group in
             for materialIndex in indices {
-                group.addTask { [unowned self] in
-                    guard let gltfMaterial = self.document.materials?[safe: materialIndex] else {
+                group.addTask { [weak self] in
+                    guard let self,
+                          let gltfMaterial = self.document.materials?[safe: materialIndex] else {
                         return (materialIndex, nil)
                     }
                     let vrm0Prop = materialIndex < self.vrm0MaterialProperties.count

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -926,7 +926,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
         vrmLog("[VRMRenderer] Finished setup sprite pipeline")
 
         if pipelineArchiveEnabled {
-            try? VRMPipelineCache.shared.flushPersistentArchive()
+            _ = try? VRMPipelineCache.shared.flushPersistentArchive()
             // Don't leave the process-wide cache pinned to this renderer's
             // device + archive: later renderers (other GPUs, or flag off) must
             // not record into it, and concurrent inits must not race on it.
@@ -1544,42 +1544,42 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
             hasLoggedSpringBone = true
         }
 
+        // Calculate actual deltaTime. `simulationDeltaTime` is the
+        // explicit offline-rendering escape: when set, use it directly
+        // so tests / video extractors / conformance harnesses get a
+        // deterministic physics timestep independent of wall-clock.
+        //
+        // `config.synchronousSpringBone` is the documented offline-render
+        // mode (see RendererConfig.synchronousSpringBone). Offline rendering
+        // and wall-clock pacing are incompatible: the XPBD substep
+        // accumulator picks up a different substep count each frame as
+        // wall-clock pacing varies, and long chains diverge run-to-run
+        // on the same input (#283 conformance reproducer). When sync
+        // mode is on but no explicit `simulationDeltaTime` was supplied,
+        // fall back to a 60Hz fixed step so callers that opt into the
+        // offline mode get reproducibility without also having to know
+        // about `simulationDeltaTime`.
+        let clampedDeltaTime: Float
+        if let override = simulationDeltaTime {
+            clampedDeltaTime = Float(override)
+            lastUpdateTime = CACurrentMediaTime()
+        } else if config.synchronousSpringBone {
+            clampedDeltaTime = 1.0 / 60.0
+            lastUpdateTime = CACurrentMediaTime()
+        } else {
+            let currentTime = CACurrentMediaTime()
+            let deltaTime = lastUpdateTime > 0 ? Float(currentTime - lastUpdateTime) : 1.0 / 60.0
+            lastUpdateTime = currentTime
+            // Clamp deltaTime to reasonable values (prevent huge jumps)
+            clampedDeltaTime = min(deltaTime, 1.0 / 30.0)  // Max 30ms per frame
+        }
+
         // Update SpringBone GPU physics BEFORE the render encoder is created.
         // Spring-bone now shares the renderer's command buffer (audit's #2 bottleneck
         // fix), so its compute encoder must be opened+closed before any other encoder
         // (compute or render) is active on the same buffer — Metal forbids overlap.
         if enableSpringBone, model.springBone != nil {
             performanceTracker?.beginPhase(.springBone)
-
-            // Calculate actual deltaTime. `simulationDeltaTime` is the
-            // explicit offline-rendering escape: when set, use it directly
-            // so tests / video extractors / conformance harnesses get a
-            // deterministic physics timestep independent of wall-clock.
-            //
-            // `config.synchronousSpringBone` is the documented offline-render
-            // mode (see RendererConfig.synchronousSpringBone). Offline rendering
-            // and wall-clock pacing are incompatible: the XPBD substep
-            // accumulator picks up a different substep count each frame as
-            // wall-clock pacing varies, and long chains diverge run-to-run
-            // on the same input (#283 conformance reproducer). When sync
-            // mode is on but no explicit `simulationDeltaTime` was supplied,
-            // fall back to a 60Hz fixed step so callers that opt into the
-            // offline mode get reproducibility without also having to know
-            // about `simulationDeltaTime`.
-            let clampedDeltaTime: Float
-            if let override = simulationDeltaTime {
-                clampedDeltaTime = Float(override)
-                lastUpdateTime = CACurrentMediaTime()
-            } else if config.synchronousSpringBone {
-                clampedDeltaTime = 1.0 / 60.0
-                lastUpdateTime = CACurrentMediaTime()
-            } else {
-                let currentTime = CACurrentMediaTime()
-                let deltaTime = lastUpdateTime > 0 ? Float(currentTime - lastUpdateTime) : 1.0 / 60.0
-                lastUpdateTime = currentTime
-                // Clamp deltaTime to reasonable values (prevent huge jumps)
-                clampedDeltaTime = min(deltaTime, 1.0 / 30.0)  // Max 30ms per frame
-            }
 
             // Update temporary forces if any
             updateSpringBoneForces(deltaTime: clampedDeltaTime)
@@ -1658,11 +1658,8 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
                 viewMatrixInv[3][2]
             )
 
-            // DEBUG: Log camera position occasionally
-            // TODO: Add proper frame counting later
-
             lookAtController.cameraPosition = cameraPos
-            lookAtController.update(deltaTime: 1.0 / 60.0) // Assume 60 FPS for now
+            lookAtController.update(deltaTime: clampedDeltaTime)
 
             // Apply LookAt to animation state if in bone mode
             if let animationState = animationState,

--- a/Tests/VRMMetalKitTests/LookAtDeltaTimeRegressionTests.swift
+++ b/Tests/VRMMetalKitTests/LookAtDeltaTimeRegressionTests.swift
@@ -1,0 +1,187 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+
+import XCTest
+import simd
+@testable import VRMMetalKit
+
+/// Regression tests for the frame-rate independence of ``VRMLookAtController`` smoothing.
+///
+/// The smoothing formula `smoothFactor = 1.0 - pow(smoothing, deltaTime * 60.0)` is
+/// designed to be frame-rate independent: after T seconds of updates, the eye should
+/// converge the same amount regardless of the display refresh rate (60 Hz, 120 Hz, etc.).
+///
+/// **Bug:** `VRMRenderer.drawCore` hardcoded `lookAtController.update(deltaTime: 1.0 / 60.0)`
+/// regardless of the actual frame delta. On a 120 Hz ProMotion display the actual delta is
+/// ~1/120 s, but the controller was told 1/60 s — so `pow(smoothing, (1/60)*60)` was evaluated
+/// every frame, making the eyes converge **twice as fast** as intended. This manifests as
+/// unnaturally snappy eye-tracking on high-refresh-rate screens.
+///
+/// These tests exercise the controller directly (no GPU required) to prove:
+/// 1. The controller IS frame-rate independent when given the correct `deltaTime`.
+/// 2. Always passing `1/60` regardless of actual frame rate breaks frame-rate independence.
+final class LookAtDeltaTimeRegressionTests: XCTestCase {
+
+    // MARK: - Rig helpers (adapted from VRMALookAtIntegrationTests)
+
+    private func makeGLTFNode(name: String) throws -> GLTFNode {
+        let json: [String: Any] = ["name": name]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(GLTFNode.self, from: data)
+    }
+
+    private func makeMinimalGLTF() throws -> GLTFDocument {
+        let json: [String: Any] = ["asset": ["version": "2.0", "generator": "Test"]]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(GLTFDocument.self, from: data)
+    }
+
+    /// Builds a minimal LookAt rig with `smoothing > 0` so the frame-rate-dependent
+    /// lerp is exercised. Saccades are disabled for determinism.
+    private func makeRig(smoothing: Float) throws -> (model: VRMModel, controller: VRMLookAtController, leftEye: VRMNode, rightEye: VRMNode) {
+        let head     = try VRMNode(index: 0, gltfNode: makeGLTFNode(name: "head"))
+        let leftEye  = try VRMNode(index: 1, gltfNode: makeGLTFNode(name: "leftEye"))
+        let rightEye = try VRMNode(index: 2, gltfNode: makeGLTFNode(name: "rightEye"))
+
+        head.worldMatrix = matrix_identity_float4x4
+        head.localMatrix = matrix_identity_float4x4
+
+        let humanoid = VRMHumanoid()
+        humanoid.humanBones[.head]     = VRMHumanoid.VRMHumanBone(node: 0)
+        humanoid.humanBones[.leftEye]  = VRMHumanoid.VRMHumanBone(node: 1)
+        humanoid.humanBones[.rightEye] = VRMHumanoid.VRMHumanBone(node: 2)
+
+        let model = VRMModel(
+            specVersion: .v1_0,
+            meta: VRMMeta(licenseUrl: ""),
+            humanoid: humanoid,
+            gltf: try makeMinimalGLTF()
+        )
+        model.nodes = [head, leftEye, rightEye]
+        model.lookAt = VRMLookAt()
+        model.lookAt?.type = .bone
+
+        let controller = VRMLookAtController()
+        controller.smoothing = smoothing
+        controller.saccadeEnabled = false
+        controller.setup(model: model)
+        controller.mode = .bone
+
+        return (model, controller, leftEye, rightEye)
+    }
+
+    // MARK: - Tests
+
+    /// After the same wall-clock time, a 60 Hz render loop and a 120 Hz render loop
+    /// must converge the eye rotation to the same point — but only if each loop passes
+    /// its *actual* per-frame delta time.
+    ///
+    /// 60 Hz: 3 updates × dt=1/60  → `pow(s, 1.0)^3  = pow(s, 3)`
+    /// 120 Hz: 6 updates × dt=1/120 → `pow(s, 0.5)^6 = pow(s, 3)`
+    ///
+    /// These are mathematically identical, proving the controller's formula is correct.
+    func testFrameRateIndependenceWhenCorrectDeltaTime() throws {
+        let smoothing: Float = 0.5
+        let target = SIMD3<Float>(0.3, 1.6, 2.0)
+
+        // 60 Hz: 3 ticks (50 ms of wall-clock time)
+        let rig60 = try makeRig(smoothing: smoothing)
+        rig60.controller.target = .point(target)
+        for _ in 0..<3 {
+            rig60.controller.update(deltaTime: 1.0 / 60.0)
+        }
+
+        // 120 Hz: 6 ticks (same 50 ms of wall-clock time)
+        let rig120 = try makeRig(smoothing: smoothing)
+        rig120.controller.target = .point(target)
+        for _ in 0..<6 {
+            rig120.controller.update(deltaTime: 1.0 / 120.0)
+        }
+
+        // Both should converge to nearly the same eye rotation after 50 ms.
+        let tol: Float = 1e-4
+        XCTAssertEqual(rig60.leftEye.rotation.imag.y,  rig120.leftEye.rotation.imag.y,
+                       accuracy: tol,
+                       "60 Hz (3 ticks) and 120 Hz (6 ticks) must converge equally after 50 ms when given correct deltaTime")
+        XCTAssertEqual(rig60.leftEye.rotation.real,   rig120.leftEye.rotation.real,
+                       accuracy: tol,
+                       "60 Hz (3 ticks) and 120 Hz (6 ticks) must converge equally after 50 ms when given correct deltaTime")
+    }
+
+    /// **This test demonstrates the bug.** If the renderer always passes `1/60` regardless
+    /// of actual frame rate, a 120 Hz loop will call `update` with `deltaTime = 1/60` for
+    /// every frame, making the eyes converge **twice as fast** as intended.
+    ///
+    /// After 3 ticks (25 ms of wall-clock time at 120 Hz):
+    /// - **Correct 120 Hz** (dt=1/120 × 3): remaining error = `pow(0.5, 1.5)` ≈ 0.354
+    /// - **Buggy 120 Hz**   (dt=1/60  × 3): remaining error = `pow(0.5, 3.0)` ≈ 0.125
+    ///
+    /// The buggy path converges ~2.8x further than it should in the same wall-clock time.
+    func testHardcodedSixtyFPSBreaksFrameRateIndependence() throws {
+        let smoothing: Float = 0.5
+        let target = SIMD3<Float>(0.3, 1.6, 2.0)
+        let tickCount = 3
+
+        // Correct 120 Hz: 3 ticks × dt=1/120 (25 ms of wall-clock time)
+        let rigCorrect = try makeRig(smoothing: smoothing)
+        rigCorrect.controller.target = .point(target)
+        for _ in 0..<tickCount {
+            rigCorrect.controller.update(deltaTime: 1.0 / 120.0)
+        }
+
+        // Buggy renderer: 3 ticks × dt=1/60 (same 25 ms, but renderer hardcodes 1/60)
+        let rigBuggy = try makeRig(smoothing: smoothing)
+        rigBuggy.controller.target = .point(target)
+        for _ in 0..<tickCount {
+            rigBuggy.controller.update(deltaTime: 1.0 / 60.0)
+        }
+
+        // The buggy path has converged further than the correct path.
+        // Eye rotation angle magnitude must be materially different.
+        let correctMag = abs(rigCorrect.leftEye.rotation.angle)
+        let buggyMag   = abs(rigBuggy.leftEye.rotation.angle)
+
+        XCTAssertGreaterThan(buggyMag, correctMag,
+                             "The buggy (always-1/60) path must converge FURTHER than the correct path (1/120)")
+    }
+
+    /// Directly exercises the smoothing formula to document the mathematical relationship.
+    /// With `smoothing = 0.5`:
+    /// - dt=1/60  → smoothFactor = 1 - pow(0.5, 1.0) = 0.5
+    /// - dt=1/120 → smoothFactor = 1 - pow(0.5, 0.5) ≈ 0.293
+    ///
+    /// Over 1 second, both converge identically (60×0.5 = 120×0.293 in exponent space).
+    /// But over the SAME NUMBER of ticks, 1/60 converges twice as fast — which is the bug.
+    func testSmoothFactorFormulaProducesDifferentPerTickConvergence() {
+        let smoothing: Float = 0.5
+
+        let smoothFactor60  = 1.0 - pow(smoothing, (1.0 / 60.0) * 60.0)   // 0.5
+        let smoothFactor120 = 1.0 - pow(smoothing, (1.0 / 120.0) * 60.0)  // ≈0.293
+
+        XCTAssertEqual(smoothFactor60, 0.5, accuracy: 1e-6,
+                       "At 60 Hz, smoothFactor should be 0.5")
+        XCTAssertEqual(smoothFactor120, 1.0 - pow(0.5, 0.5), accuracy: 1e-6,
+                       "At 120 Hz, smoothFactor should be ~0.293")
+
+        // Per-tick convergence is different — that's correct and expected.
+        // The bug is passing 1/60 when the actual frame time is 1/120.
+        XCTAssertGreaterThan(smoothFactor60, smoothFactor120,
+                             "Per-tick convergence at 60 Hz must be greater than at 120 Hz")
+
+        // After 1 second of wall-clock time, cumulative convergence is equal:
+        // 60 Hz: (1 - 0.5)^60  = 0.5^60
+        // 120 Hz: (1 - 0.293)^120 = (0.5^0.5)^120 = 0.5^60
+        let remaining60  = pow(smoothing, 60.0)    // 60 ticks at dt=1/60
+        let remaining120 = pow(smoothing, 60.0)    // 120 ticks at dt=1/120 → same exponent
+
+        XCTAssertEqual(remaining60, remaining120, accuracy: 1e-10,
+                       "After 1 second, both frame rates must have the same remaining error")
+    }
+}

--- a/Tests/VRMMetalKitTests/TaskGroupCaptureSemanticsTests.swift
+++ b/Tests/VRMMetalKitTests/TaskGroupCaptureSemanticsTests.swift
@@ -1,0 +1,131 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+
+import XCTest
+@testable import VRMMetalKit
+
+/// Regression tests for `[unowned self]` capture semantics in async task groups.
+///
+/// The parallel loaders (`ParallelMaterialLoader`, `ParallelTextureLoader`,
+/// `GLTFParallelMeshLoader`) used `[unowned self]` inside `withTaskGroup` child tasks.
+/// If the loader is deallocated while async work is in flight — e.g. the load is
+/// cancelled, or the owning object sets its loader property to nil from another task —
+/// the unowned reference becomes a dangling pointer and crashes the process.
+///
+/// These tests reproduce the capture pattern in isolation to demonstrate that:
+/// 1. `[unowned self]` crashes when the owner is deallocated before the task completes.
+/// 2. `[weak self]` handles deallocation gracefully (returns nil / skips work).
+final class TaskGroupCaptureSemanticsTests: XCTestCase {
+
+    /// A minimal stand-in for the loader classes: stores some data that child tasks read.
+    private final class WorkItem: @unchecked Sendable {
+        let payload: [Int]
+        init(_ payload: [Int]) { self.payload = payload }
+    }
+
+    /// **Demonstrates the bug:** `[unowned]` capture in a task group crashes when the
+    /// referenced object is deallocated before the child task runs.
+    ///
+    /// We cannot actually let the test crash the process, so instead we verify the
+    /// *fix* pattern: `[weak self]` returns nil gracefully when the owner is gone.
+    /// This test guards against regression back to `[unowned self]`.
+    func testWeakSelfInTaskGroupSurvivesDeallocation() async {
+        var item: WorkItem? = WorkItem(Array(0..<100))
+        weak let weakItem = item
+
+        let results = await withTaskGroup(of: Int?.self) { group -> [Int] in
+            // Child task captures [weak item] — the fix pattern
+            group.addTask { [weak item] in
+                // Yield to let the parent run first and drop the reference
+                await Task.yield()
+                await Task.yield()
+                guard let item else { return nil }
+                return item.payload.count
+            }
+
+            // Drop the only strong reference — item is deallocated.
+            // With [unowned self], the child task would crash here.
+            // With [weak self], the child task returns nil.
+            item = nil
+            XCTAssertNil(weakItem, "WorkItem should be deallocated after strong ref dropped")
+
+            var collected: [Int] = []
+            for await result in group {
+                collected.append(result ?? -1)
+            }
+            return collected
+        }
+
+        // With [weak self], the task returned nil (→ -1) instead of crashing.
+        XCTAssertEqual(results, [-1],
+                       "Weak capture must return nil gracefully when owner is deallocated, not crash")
+    }
+
+    /// Complementary test: when the owner is NOT deallocated, `[weak self]` works
+    /// identically to `[unowned self]` — the child task runs to completion.
+    func testWeakSelfInTaskGroupCompletesNormallyWhenRetained() async {
+        let item = WorkItem(Array(0..<100))
+
+        let results = await withTaskGroup(of: Int.self) { group -> [Int] in
+            group.addTask { [weak item] in
+                await Task.yield()
+                guard let item else { return -1 }
+                return item.payload.count
+            }
+
+            // Keep `item` alive (it's a `let` so it can't be nilled)
+            var collected: [Int] = []
+            for await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+
+        XCTAssertEqual(results, [100],
+                       "Weak capture must return correct result when owner is retained")
+    }
+
+    /// Stress test: run many iterations of the weak-capture deallocation pattern to
+    /// ensure no intermittent crashes. This is the closest we can get to reproducing
+    /// the race condition that `[unowned self]` would trigger in the real loaders.
+    func testWeakCaptureDeallocationUnderStress() async {
+        let iterations = 200
+
+        await withTaskGroup(of: Bool.self) { outerGroup in
+            for _ in 0..<iterations {
+                outerGroup.addTask {
+                    var item: WorkItem? = WorkItem(Array(repeating: 42, count: 1000))
+
+                    let result = await withTaskGroup(of: Int?.self) { group -> Int? in
+                        group.addTask { [weak item] in
+                            // Simulate async I/O (texture/mesh loading)
+                            try? await Task.sleep(nanoseconds: 1_000)
+                            return item?.payload.count
+                        }
+
+                        item = nil  // deallocate during async work
+
+                        return await group.next() ?? nil
+                    }
+
+                    // Either nil (deallocated before task ran) or 1000 (task ran first).
+                    // Either way, no crash.
+                    return result == nil || result == 1000
+                }
+            }
+
+            var allPassed = true
+            for await passed in outerGroup {
+                if !passed { allPassed = false }
+            }
+            XCTAssertTrue(allPassed, "All iterations must complete without crash")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Replace `[unowned self]` with `[weak self]`** in three parallel loader task groups (`ParallelMaterialLoader`, `ParallelTextureLoader`, `GLTFParallelMeshLoader`) to prevent dangling-pointer crashes when a model load is cancelled or the loader is deallocated mid-flight.
- **Fix LookAt eye-tracking deltaTime** to use the actual frame delta (`clampedDeltaTime`) instead of a hardcoded `1.0 / 60.0`. The real delta time was already computed for SpringBone physics but scoped too narrowly — it's now hoisted so LookAt picks it up too, giving correct animation speed on 120Hz ProMotion displays and during frame drops.
- **Suppress unused `try?` warning** in `VRMRenderer` pipeline archive flush.

## TDD honesty

These fixes were **not** driven by failing tests. Here's what the tests actually prove:

| Fix | Failing test? | Why not? |
|-----|--------------|----------|
| LookAt hardcoded deltaTime | **No** | The controller is correct — the bug is in `VRMRenderer.drawCore`, which requires a Metal device to exercise. Tests on the controller prove the mathematical impact (frame-rate independence) but can't fail against the old renderer code. |
| `[unowned self]` → `[weak self]` | **No** | The crash is non-deterministic (race condition during async I/O). The tests verify the `[weak self]` pattern is correct but can't reproduce the crash against the actual loader classes. |
| `try?` warning | **No** | Compiler warning, not a behavioral bug. |

The tests serve as **behavioral regression guards** documenting the expected properties:
- `LookAtDeltaTimeRegressionTests`: proves frame-rate independence works when given correct deltaTime, and that always passing 1/60 at 120 Hz converges ~2.8x faster than intended.
- `TaskGroupCaptureSemanticsTests`: verifies `[weak self]` in task groups returns nil gracefully on deallocation instead of crashing.

## Files changed

**Source:**
- `Sources/VRMMetalKit/Loader/ParallelMaterialLoader.swift`
- `Sources/GLTFCore/Loader/ParallelTextureLoader.swift`
- `Sources/GLTFCore/Loader/GLTFParallelMeshLoader.swift`
- `Sources/VRMMetalKit/Renderer/VRMRenderer.swift`

**Tests:**
- `Tests/VRMMetalKitTests/LookAtDeltaTimeRegressionTests.swift` (new)
- `Tests/VRMMetalKitTests/TaskGroupCaptureSemanticsTests.swift` (new)

## Test plan

- `swift build` passes
- New tests pass (6/6)
- Full test suite: 1751 tests pass (2 pre-existing flakes in `SpringBoneRendererDeterminismTests` / `SpriteCacheSystemTests` — issue #283 GPU timing, pass in isolation)


💘 Generated with Crush