### PR TITLE
docs(readme): add "Used by" showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ make docs        # local preview server
 make docs-static # static site under .build/docs
 ```
 
+## Used by
+
+VRMMetalKit renders the avatars in [Arkavo](https://arkavo.com)'s apps — real products putting the loader, MToon shading, expressions, and SpringBone physics through their paces:
+
+- **[Avatar Muse](https://apps.apple.com/us/app/avatar-muse/id6755342276)** — *out now on iOS.* An AI companion whose avatar reacts to the conversation with real-time facial expressions and lookAt gaze, then drops into your physical space — VRMMetalKit renders and animates the character while ARKit world tracking anchors it in the room around you.
+- **[Arkavo Creator](https://apps.apple.com/us/app/arkavo-creator/id6738845556?mt=12)** — *coming soon on macOS.* A streaming and content-creation studio that puts a live, expressive avatar on camera — virtual-presenter performance for your broadcasts and screen recordings, rendered in real time by VRMMetalKit.
+- **[Game of Mods](https://store.steampowered.com/app/4029870/Game_of_Mods/)** — *coming soon on Steam.* A contemplative mod-creation platform with AI dialogue running **locally**. Its crowded, many-character scenes lean on VRMMetalKit's full performance stack to render many avatars at once while leaving CPU headroom free for on-device inference.
+
+Building something with VRMMetalKit? Open a PR adding it here.
+
 ## Contributing
 
 Contributions are welcome! Please read our [Contributing Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Adds a `## Used by` section to the README (default-branch landing page), mirroring what already lives on `release/1.0`. Highlights real VRMMetalKit usage across Arkavo apps:

- **Avatar Muse** (out now, iOS) — AI companion; VRMMetalKit renders/animates the avatar, ARKit anchors it in the real world.
- **Arkavo Creator** (coming soon, macOS) — streaming studio with a live virtual-presenter avatar.
- **Game of Mods** (coming soon, Steam) — multi-avatar scenes with on-device inference; leans on the perf stack.

Docs-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)