### PR TITLE
perf(renderer): crowd-impostor prototype

### DIFF
--- a/Sources/VRMBenchmark/main.swift
+++ b/Sources/VRMBenchmark/main.swift
@@ -50,6 +50,10 @@ struct BenchmarkOptions {
     var archiveDir: String? = nil            // --archive-dir DIR (pipeline mode)
     var avatarCount: Int = 1                  // --avatar-count N (Game of Mods multi-avatar)
     var avatarSpacing: Float = 1.2            // --avatar-spacing M (meters between avatars)
+    var detailLevel: String = "full3d"        // --detail-level full3d|cached|hybrid
+    var spriteResolution: Int = 256           // --sprite-resolution N
+    var maxFull3D: Int = 3                    // --max-full3d N (hybrid mode budget)
+    var enableImpostors: Bool = false         // --impostors
 }
 
 func usage() {
@@ -97,6 +101,10 @@ func usage() {
                          N copies of the model are placed in a row; tests
                          multi-avatar throughput for Game of Mods.
       --avatar-spacing M Distance between avatars in meters (default 1.2).
+      --impostors         Enable crowd impostors (default off).
+      --detail-level L    full3d | cached | hybrid (default full3d).
+      --sprite-resolution N Cached sprite size in pixels (default 256).
+      --max-full3d N      Maximum full-3D avatars in hybrid mode (default 3).
 
     Recommended invocation:
       swift run -c release VRMBenchmark <vrm-path> --vrma <vrma-path> --frames 500
@@ -200,6 +208,17 @@ func parseArguments() -> BenchmarkOptions? {
         case "--avatar-spacing":
             guard let v = nextValue(for: a) else { return nil }
             opts.avatarSpacing = Float(v) ?? 1.2
+        case "--impostors":
+            opts.enableImpostors = true
+        case "--detail-level":
+            guard let v = nextValue(for: a) else { return nil }
+            opts.detailLevel = v.lowercased()
+        case "--sprite-resolution":
+            guard let v = nextValue(for: a) else { return nil }
+            opts.spriteResolution = max(32, Int(v) ?? 256)
+        case "--max-full3d":
+            guard let v = nextValue(for: a) else { return nil }
+            opts.maxFull3D = max(0, Int(v) ?? 3)
         case "--threshold":
             guard let v = nextValue(for: a) else { return nil }
             let parts = v.split(separator: ":").map(String.init)
@@ -673,9 +692,20 @@ struct VRMBenchmarkCLI {
         config.sampleCount = opts.sampleCount
         config.strict = .off
         config.enableDepthPrepass = opts.depthPrepass
+        config.enableCrowdImpostors = opts.enableImpostors
+        config.impostorSpriteResolution = opts.spriteResolution
+        config.impostorMaxFull3D = opts.maxFull3D
 
         let avatarCount = opts.avatarCount
         let spacing = opts.avatarSpacing
+
+        // When running hybrid multi-avatar benchmarks, share a single priority
+        // system across all renderer instances so the max-full3d budget is
+        // applied across the whole crowd, not per-avatar.
+        let sharedPrioritySystem: CharacterPrioritySystem? = (opts.enableImpostors && opts.detailLevel == "hybrid" && avatarCount > 1)
+            ? CharacterPrioritySystem()
+            : nil
+        sharedPrioritySystem?.budget.maxFull3DCharacters = opts.maxFull3D
 
         // Multi-avatar: create N renderers, each with its own model copy.
         // For single avatar (the default), this is just one renderer.
@@ -708,6 +738,19 @@ struct VRMBenchmarkCLI {
 
             let r = VRMRenderer(device: device, config: config)
             if i == 0 { r.performanceTracker = PerformanceTracker() }
+            switch opts.detailLevel {
+            case "cached", "cachedsprite": r.detailLevel = .cachedSprite
+            case "hybrid":               r.detailLevel = .hybrid
+            case "full3d", "full3D":     r.detailLevel = .full3D
+            default:
+                FileHandle.standardError.write(Data("ERROR: unknown --detail-level '\(opts.detailLevel)'. Expected full3d|cached|hybrid.\n".utf8))
+                exit(1)
+            }
+            if let sharedPrioritySystem = sharedPrioritySystem {
+                r.prioritySystem = sharedPrioritySystem
+            } else {
+                r.prioritySystem?.budget.maxFull3DCharacters = opts.maxFull3D
+            }
             r.loadModel(avatarModel)
             r.outlineWidth = opts.outlineWidth
             r.enableSpringBone = opts.enableSpringBone
@@ -892,6 +935,20 @@ struct VRMBenchmarkCLI {
         for _ in 0..<opts.warmup {
             renderOnce(&discard)
         }
+
+        // Pre-populate sprite cache for impostor modes so the measured phase
+        // actually exercises cached-sprite draws, not cache-miss fallbacks.
+        if opts.enableImpostors {
+            await MainActor.run {
+                for avatar in avatars {
+                    guard let cb = commandQueue.makeCommandBuffer() else { continue }
+                    avatar.renderer.warmImpostorCache(commandBuffer: cb)
+                    cb.commit()
+                    cb.waitUntilCompleted()
+                }
+            }
+        }
+
         renderer.resetPerformanceMetrics()
 
         // Measure

--- a/Sources/VRMMetalKit/Animation/VRMMorphTargets.swift
+++ b/Sources/VRMMetalKit/Animation/VRMMorphTargets.swift
@@ -658,6 +658,19 @@ public class VRMExpressionController: @unchecked Sendable {
         customCurrentWeights[name]
     }
 
+    /// Returns a serializable snapshot of all current preset and custom
+    /// expression weights, keyed by name. Used by crowd-impostor pose hashing.
+    public func allExpressionWeights() -> [String: Float] {
+        var result: [String: Float] = [:]
+        for (preset, weight) in currentWeights {
+            result[preset.rawValue] = weight
+        }
+        for (name, weight) in customCurrentWeights {
+            result[name] = weight
+        }
+        return result
+    }
+
     // MARK: - Preset Animations
 
     /// Plays a one-shot blink that rises to full weight over `duration` and decays back to `0` over the same `duration`.

--- a/Sources/VRMMetalKit/Core/StrictMode.swift
+++ b/Sources/VRMMetalKit/Core/StrictMode.swift
@@ -154,8 +154,24 @@ public struct RendererConfig {
     /// flags from the uniform buffer at runtime.
     public var enableMToonFunctionConstants: Bool = true
 
+    /// Crowd-impostor prototype (default `false`). When `true`, ``VRMRenderer``
+    /// may draw a cached sprite quad instead of the full 3D avatar, depending on
+    /// ``VRMRenderer/detailLevel``. Currently opt-in only; no default behavior
+    /// changes when `false`.
+    public var enableCrowdImpostors: Bool = false
+
+    /// Resolution of cached impostor sprites. Lower values reduce cache memory
+    /// and fragment cost; higher values retain fidelity. Only used when
+    /// ``enableCrowdImpostors`` is `true`.
+    public var impostorSpriteResolution: Int = 256
+
+    /// Maximum number of avatars to render in full 3D when ``detailLevel`` is
+    /// `.hybrid`; remaining eligible avatars become cached sprites. Only used
+    /// when ``enableCrowdImpostors`` is `true`.
+    public var impostorMaxFull3D: Int = 3
+
     /// Creates a renderer configuration. Defaults match the production baseline.
-    public init(strict: StrictLevel = .off, colorPixelFormat: MTLPixelFormat = .bgra8Unorm, renderFilter: RenderFilter? = nil, drawUntil: Int? = nil, drawOnlyIndex: Int? = nil, testIdentityPalette: Int? = nil, sampleCount: Int = 1, depthBiasScale: Float = 1.0, alphaToCoverageForMASK: Bool = false, synchronousSpringBone: Bool = false, dualQuaternionSkinning: Bool = false, enableMToonFunctionConstants: Bool = true) {
+    public init(strict: StrictLevel = .off, colorPixelFormat: MTLPixelFormat = .bgra8Unorm, renderFilter: RenderFilter? = nil, drawUntil: Int? = nil, drawOnlyIndex: Int? = nil, testIdentityPalette: Int? = nil, sampleCount: Int = 1, depthBiasScale: Float = 1.0, alphaToCoverageForMASK: Bool = false, synchronousSpringBone: Bool = false, dualQuaternionSkinning: Bool = false, enableMToonFunctionConstants: Bool = true, enableCrowdImpostors: Bool = false, impostorSpriteResolution: Int = 256, impostorMaxFull3D: Int = 3) {
         self.strict = strict
         self.colorPixelFormat = colorPixelFormat
         self.renderFilter = renderFilter
@@ -168,6 +184,9 @@ public struct RendererConfig {
         self.synchronousSpringBone = synchronousSpringBone
         self.dualQuaternionSkinning = dualQuaternionSkinning
         self.enableMToonFunctionConstants = enableMToonFunctionConstants
+        self.enableCrowdImpostors = enableCrowdImpostors
+        self.impostorSpriteResolution = impostorSpriteResolution
+        self.impostorMaxFull3D = impostorMaxFull3D
     }
 }
 

--- a/Sources/VRMMetalKit/Renderer/SpriteCacheSystem.swift
+++ b/Sources/VRMMetalKit/Renderer/SpriteCacheSystem.swift
@@ -202,7 +202,7 @@ public class SpriteCacheSystem: @unchecked Sendable {
             hasher.combine(qz)
         }
 
-        return UInt64(hasher.finalize())
+        return UInt64(truncatingIfNeeded: hasher.finalize())
     }
 
     // MARK: - Cache Lookup

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer+Pipeline.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer+Pipeline.swift
@@ -183,6 +183,15 @@ extension VRMRenderer {
             depthStencilStates["opaqueEqual"] = state
         }
 
+        // Cached sprite impostor: alpha-blended quad that tests against the
+        // scene depth but does not write depth (sprites are composited, not solid).
+        let spriteDepthDescriptor = MTLDepthStencilDescriptor()
+        spriteDepthDescriptor.depthCompareFunction = .lessEqual
+        spriteDepthDescriptor.isDepthWriteEnabled = false
+        if let state = device.makeDepthStencilState(descriptor: spriteDepthDescriptor) {
+            depthStencilStates["sprite"] = state
+        }
+
         // Pre-create sampler states
         let samplerDescriptor = MTLSamplerDescriptor()
         samplerDescriptor.minFilter = .linear
@@ -832,8 +841,9 @@ extension VRMRenderer {
             pipelineDescriptor.vertexDescriptor = vertexDescriptor
             pipelineDescriptor.rasterSampleCount = config.sampleCount
 
-            // Color attachment (BGRA8)
-            pipelineDescriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
+            // Color attachment (match the renderer's configured target so the
+            // cached-sprite pipeline can be used regardless of view format).
+            pipelineDescriptor.colorAttachments[0].pixelFormat = config.colorPixelFormat
             pipelineDescriptor.colorAttachments[0].isBlendingEnabled = true
             pipelineDescriptor.colorAttachments[0].sourceRGBBlendFactor = .sourceAlpha
             pipelineDescriptor.colorAttachments[0].destinationRGBBlendFactor = .oneMinusSourceAlpha
@@ -842,7 +852,7 @@ extension VRMRenderer {
             pipelineDescriptor.colorAttachments[0].destinationAlphaBlendFactor = .oneMinusSourceAlpha
             pipelineDescriptor.colorAttachments[0].alphaBlendOperation = .add
 
-            // Depth attachment
+            // Depth attachment (fixed 32-bit float for now; matches the main render pass)
             pipelineDescriptor.depthAttachmentPixelFormat = .depth32Float
 
             // Create pipeline state

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -479,6 +479,13 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
     var spriteIndexBuffer: MTLBuffer?
     let spriteIndexCount: Int = 6
 
+    /// Stable identifier used when registering this renderer with ``prioritySystem``
+    /// and as the ``SpriteCacheSystem`` character key.
+    private let impostorCharacterID: String = UUID().uuidString
+
+    /// Tracks whether this renderer has already registered itself with ``prioritySystem``.
+    private var impostorRegisteredInPrioritySystem: Bool = false
+
     // Skinning
     private var skinningSystem: VRMSkinningSystem?
     /// Legacy per-frame animation state. Newer code should use ``AnimationPlayer``;
@@ -1523,28 +1530,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
             }
         }
 
-        // Run compute pass for morphs BEFORE render encoder
-        performanceTracker?.beginPhase(.morphSetup)
-        let morphedBuffers = applyMorphTargetsCompute(commandBuffer: commandBuffer)
-        performanceTracker?.endPhase(.morphSetup)
-        if !morphedBuffers.isEmpty {
-            performanceTracker?.recordMorphCompute()
-        }
-
-        // Debug: Log morphed buffer count
-        if frameCounter == 1 || frameCounter % 60 == 0 {
-            if !morphedBuffers.isEmpty {
-                vrmLog("[VRMRenderer] Frame \(frameCounter): \(morphedBuffers.count) primitives have morphed positions")
-            }
-        }
-
-        // Debug SpringBone status once
-        if !hasLoggedSpringBone {
-            vrmLog("[VRMRenderer] Draw called: enableSpringBone=\(enableSpringBone), springBone=\(model.springBone != nil ? "exists" : "nil"), springBoneComputeSystem=\(springBoneComputeSystem != nil ? "exists" : "nil")")
-            hasLoggedSpringBone = true
-        }
-
-        // Calculate actual deltaTime. `simulationDeltaTime` is the
+        // Calculate actual deltaTime once per frame. `simulationDeltaTime` is the
         // explicit offline-rendering escape: when set, use it directly
         // so tests / video extractors / conformance harnesses get a
         // deterministic physics timestep independent of wall-clock.
@@ -1572,6 +1558,57 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
             lastUpdateTime = currentTime
             // Clamp deltaTime to reasonable values (prevent huge jumps)
             clampedDeltaTime = min(deltaTime, 1.0 / 30.0)  // Max 30ms per frame
+        }
+
+        // Crowd-impostor fast path: if this renderer is allowed to draw as a
+        // cached sprite and the pose is already in the sprite cache, skip the
+        // expensive morph / spring-bone / skinning / full-3D work entirely.
+        if config.enableCrowdImpostors,
+           detailLevel != .full3D,
+           let spriteCache = spriteCacheSystem,
+           let poseHash = computeImpostorPoseHash(),
+           shouldRenderAsImpostor(cameraPosition: cameraPosition(from: viewMatrix), deltaTime: TimeInterval(clampedDeltaTime)) {
+            if let cachedPose = spriteCache.getCachedPose(poseHash: poseHash) {
+                guard let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor) else {
+                    if config.strict != .off {
+                        do {
+                            try strictValidator?.handle(.encoderCreationFailed(type: "render"))
+                        } catch {
+                            vrmLog("❌ [VRMRenderer] Failed to create render encoder: \(error)")
+                        }
+                    }
+                    inflightSemaphore.signal()
+                    return
+                }
+                encoderStateCache.reset()
+                drawImpostorSprite(encoder: encoder, poseTexture: cachedPose.texture, view: view)
+                encoder.endEncoding()
+                frameCounter += 1
+                performanceTracker?.recordDrawCall(triangles: 2, vertices: 4)
+                completeFrame(commandBuffer: commandBuffer)
+                return
+            }
+        }
+
+        // Run compute pass for morphs BEFORE render encoder
+        performanceTracker?.beginPhase(.morphSetup)
+        let morphedBuffers = applyMorphTargetsCompute(commandBuffer: commandBuffer)
+        performanceTracker?.endPhase(.morphSetup)
+        if !morphedBuffers.isEmpty {
+            performanceTracker?.recordMorphCompute()
+        }
+
+        // Debug: Log morphed buffer count
+        if frameCounter == 1 || frameCounter % 60 == 0 {
+            if !morphedBuffers.isEmpty {
+                vrmLog("[VRMRenderer] Frame \(frameCounter): \(morphedBuffers.count) primitives have morphed positions")
+            }
+        }
+
+        // Debug SpringBone status once
+        if !hasLoggedSpringBone {
+            vrmLog("[VRMRenderer] Draw called: enableSpringBone=\(enableSpringBone), springBone=\(model.springBone != nil ? "exists" : "nil"), springBoneComputeSystem=\(springBoneComputeSystem != nil ? "exists" : "nil")")
+            hasLoggedSpringBone = true
         }
 
         // Update SpringBone GPU physics BEFORE the render encoder is created.
@@ -3897,11 +3934,17 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
 
         performanceTracker?.endPhase(.commandEncode)
         encoder.endEncoding()
+        completeFrame(commandBuffer: commandBuffer)
 
-        // End performance tracking
+    }
+
+    // MARK: - Frame Completion
+
+    /// Shared end-of-frame bookkeeping: strict validation, performance tracking,
+    /// and command-buffer completion/semaphore signalling.
+    private func completeFrame(commandBuffer: MTLCommandBuffer) {
         performanceTracker?.endFrame()
 
-        // End frame validation
         if config.strict != .off {
             do {
                 try strictValidator?.endFrame()
@@ -3914,25 +3957,20 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
             }
         }
 
-        // Add command buffer completion handler for error checking and semaphore signaling
         commandBuffer.addCompletedHandler { [weak self] buffer in
-            // Signal that this frame's uniform buffer is available again
             self?.inflightSemaphore.signal()
 
-            // Record GPU timing if performance tracking is enabled
             if let tracker = self?.performanceTracker {
                 let gpuTime = buffer.gpuEndTime - buffer.gpuStartTime
                 tracker.recordGPUTime(gpuTime)
             }
 
-            if self?.config.checkCommandBufferErrors == true {
-                if buffer.status == .error {
-                    let error = buffer.error
-                    if self?.config.strict == .fail {
-                        vrmLog("❌ [VRMRenderer] Command buffer failed: \(error?.localizedDescription ?? "unknown error")")
-                    } else if self?.config.strict == .warn {
-                        vrmLog("⚠️ [StrictMode] Command buffer error: \(error?.localizedDescription ?? "unknown")")
-                    }
+            if self?.config.checkCommandBufferErrors == true, buffer.status == .error {
+                let error = buffer.error
+                if self?.config.strict == .fail {
+                    vrmLog("❌ [VRMRenderer] Command buffer failed: \(error?.localizedDescription ?? "unknown error")")
+                } else if self?.config.strict == .warn {
+                    vrmLog("⚠️ [StrictMode] Command buffer error: \(error?.localizedDescription ?? "unknown")")
                 }
             }
         }
@@ -4580,4 +4618,224 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
     /// Current debug mode (0 = normal, 1-16 = various debug visualizations)
     private var currentDebugMode: Int = 0
 
+    // MARK: - Crowd Impostor Helpers
+
+    private struct SpriteUniforms {
+        var viewProjectionMatrix: simd_float4x4
+        var viewportSize: SIMD2<Float>
+        var padding1: Float = 0
+        var padding2: Float = 0
+    }
+
+    private struct SpriteInstance {
+        var modelMatrix: simd_float4x4
+        var tintColor: SIMD4<Float>
+        var texOffset: SIMD2<Float>
+        var texScale: SIMD2<Float>
+    }
+
+    /// Extracts the camera world-space position from the current view matrix.
+    private func cameraPosition(from viewMatrix: simd_float4x4) -> SIMD3<Float> {
+        let inv = viewMatrix.inverse
+        return SIMD3<Float>(inv.columns.3.x, inv.columns.3.y, inv.columns.3.z)
+    }
+
+    /// Computes a deterministic pose hash for the current frame.
+    private func computeImpostorPoseHash() -> UInt64? {
+        guard let spriteCache = spriteCacheSystem,
+              let expressionController = expressionController else {
+            return nil
+        }
+        let expressionWeights = expressionController.allExpressionWeights()
+        return spriteCache.computePoseHash(
+            characterID: impostorCharacterID,
+            expressionWeights: expressionWeights
+        )
+    }
+
+    /// Determines whether this renderer's avatar should draw as a cached sprite this frame.
+    private func shouldRenderAsImpostor(cameraPosition: SIMD3<Float>, deltaTime: TimeInterval) -> Bool {
+        switch detailLevel {
+        case .full3D:
+            return false
+        case .cachedSprite:
+            return true
+        case .hybrid:
+            guard let prioritySystem = prioritySystem,
+                  model != nil else { return false }
+            // The benchmark/host is expected to register characters explicitly.
+            // If this renderer has not been registered yet, treat it as a background
+            // character so the prototype works out of the box for single-avatar tests.
+            if !impostorRegisteredInPrioritySystem {
+                prioritySystem.registerCharacter(
+                    characterID: impostorCharacterID,
+                    displayName: "VRMRenderer Avatar",
+                    position: avatarWorldPosition() ?? SIMD3<Float>(0, 0, 0)
+                )
+                impostorRegisteredInPrioritySystem = true
+            }
+            let decisions = prioritySystem.computeRenderingDecisions(
+                cameraPosition: cameraPosition,
+                deltaTime: deltaTime
+            )
+            return decisions[impostorCharacterID] == .cached
+        }
+    }
+
+    /// World-space position of the avatar, used for sprite placement and priority registration.
+    private func avatarWorldPosition() -> SIMD3<Float>? {
+        guard let model = model else { return nil }
+        if let humanoid = model.humanoid,
+           let hipsIndex = humanoid.getBoneNode(.hips),
+           hipsIndex < model.nodes.count {
+            let hips = model.nodes[hipsIndex]
+            return SIMD3<Float>(hips.worldMatrix.columns.3.x,
+                                hips.worldMatrix.columns.3.y,
+                                hips.worldMatrix.columns.3.z)
+        }
+        if let root = model.nodes.first {
+            return SIMD3<Float>(root.worldMatrix.columns.3.x,
+                                root.worldMatrix.columns.3.y,
+                                root.worldMatrix.columns.3.z)
+        }
+        return nil
+    }
+
+    /// Computes a billboard transform that places the cached sprite at the avatar's
+    /// world position and orients it to face the camera.
+    private func impostorWorldTransform() -> simd_float4x4? {
+        guard let model = model,
+              let position = avatarWorldPosition() else { return nil }
+
+        let bounds = model.calculateSkinnedBoundingBox()
+        let height = max(bounds.size.y, 0.01)
+        let width = max(bounds.size.x, 0.01)
+        // Preserve the avatar's aspect ratio; sprites are 1:1 by default so scale
+        // the quad to match the AABB proportions.
+        let size = SIMD2<Float>(width, height)
+
+        // Face the camera: rotate so the sprite's +Z aligns with the camera's view direction.
+        let invView = viewMatrix.inverse
+        let forward = normalize(SIMD3<Float>(-invView.columns.2.x,
+                                             -invView.columns.2.y,
+                                             -invView.columns.2.z))
+        let up = SIMD3<Float>(0, 1, 0)
+        let right = normalize(cross(up, forward))
+        let actualUp = cross(forward, right)
+
+        var m = matrix_identity_float4x4
+        m.columns.0 = SIMD4<Float>(right * (size.x * 0.5), 0)
+        m.columns.1 = SIMD4<Float>(actualUp * (size.y * 0.5), 0)
+        m.columns.2 = SIMD4<Float>(forward, 0)
+        m.columns.3 = SIMD4<Float>(position, 1)
+        return m
+    }
+
+    /// Draws a cached sprite quad using the existing sprite pipeline.
+    private func drawImpostorSprite(
+        encoder: MTLRenderCommandEncoder,
+        poseTexture: MTLTexture,
+        view: MTKView
+    ) {
+        guard let pipeline = spritePipelineState,
+              let vertexBuffer = spriteVertexBuffer,
+              let indexBuffer = spriteIndexBuffer,
+              let depthState = depthStencilStates["sprite"] else {
+            vrmLog("⚠️ [VRMRenderer] Sprite pipeline not ready; skipping impostor draw")
+            return
+        }
+
+        let drawableSize = MainActor.assumeIsolated { view.drawableSize }
+        var uniforms = SpriteUniforms(
+            viewProjectionMatrix: projectionMatrix * viewMatrix,
+            viewportSize: SIMD2<Float>(Float(drawableSize.width), Float(drawableSize.height))
+        )
+        guard let instanceMatrix = impostorWorldTransform() else { return }
+        var instance = SpriteInstance(
+            modelMatrix: instanceMatrix,
+            tintColor: SIMD4<Float>(1, 1, 1, 1),
+            texOffset: SIMD2<Float>(0, 0),
+            texScale: SIMD2<Float>(1, 1)
+        )
+
+        encoder.setRenderPipelineState(pipeline)
+        encoder.setDepthStencilState(depthState)
+        encoder.setCullMode(.none)
+        encoder.setVertexBuffer(vertexBuffer, offset: 0, index: 0)
+        encoder.setVertexBytes(&uniforms, length: MemoryLayout<SpriteUniforms>.stride, index: 1)
+        encoder.setVertexBytes(&instance, length: MemoryLayout<SpriteInstance>.stride, index: 2)
+        encoder.setFragmentTexture(poseTexture, index: 0)
+        if let sampler = samplerStates["default"] {
+            encoder.setFragmentSamplerState(sampler, index: 0)
+        }
+        encoder.drawIndexedPrimitives(
+            type: .triangle,
+            indexCount: spriteIndexCount,
+            indexType: .uint16,
+            indexBuffer: indexBuffer,
+            indexBufferOffset: 0
+        )
+    }
+
+    /// Renders the current pose to the sprite cache so subsequent frames can use
+    /// the impostor fast path. The host should call this after animation has been
+    /// applied and before entering the measured cached-sprite phase.
+    @MainActor
+    public func warmImpostorCache(commandBuffer: MTLCommandBuffer) {
+        guard config.enableCrowdImpostors,
+              detailLevel != .full3D,
+              let spriteCache = spriteCacheSystem,
+              let poseHash = computeImpostorPoseHash() else { return }
+
+        if spriteCache.isCached(poseHash: poseHash) { return }
+
+        let resolution = CGSize(
+            width: config.impostorSpriteResolution,
+            height: config.impostorSpriteResolution
+        )
+
+        let colorTexture: MTLTexture
+        let depthTexture: MTLTexture
+        let colorDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: config.colorPixelFormat,
+            width: Int(resolution.width),
+            height: Int(resolution.height),
+            mipmapped: false
+        )
+        colorDesc.usage = [.renderTarget, .shaderRead]
+        colorDesc.storageMode = .private
+        guard let ct = device.makeTexture(descriptor: colorDesc) else { return }
+        colorTexture = ct
+
+        let depthDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .depth32Float,
+            width: Int(resolution.width),
+            height: Int(resolution.height),
+            mipmapped: false
+        )
+        depthDesc.usage = .renderTarget
+        depthDesc.storageMode = .private
+        guard let dt = device.makeTexture(descriptor: depthDesc) else { return }
+        depthTexture = dt
+
+        let renderPassDescriptor = MTLRenderPassDescriptor()
+        renderPassDescriptor.colorAttachments[0].texture = colorTexture
+        renderPassDescriptor.colorAttachments[0].loadAction = .clear
+        renderPassDescriptor.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+        renderPassDescriptor.colorAttachments[0].storeAction = .store
+        renderPassDescriptor.depthAttachment.texture = depthTexture
+        renderPassDescriptor.depthAttachment.loadAction = .clear
+        renderPassDescriptor.depthAttachment.clearDepth = 1.0
+        renderPassDescriptor.depthAttachment.storeAction = .dontCare
+
+        drawOffscreenHeadless(
+            to: colorTexture,
+            depth: depthTexture,
+            commandBuffer: commandBuffer,
+            renderPassDescriptor: renderPassDescriptor
+        )
+
+        spriteCache.cachePose(texture: colorTexture, poseHash: poseHash, characterID: impostorCharacterID)
+        vrmLog("[VRMRenderer] Warmed impostor cache for character \(impostorCharacterID), pose \(poseHash)")
+    }
 }


### PR DESCRIPTION
Adds an opt-in crowd-impostor path that reuses the existing SpriteCacheSystem + CharacterPrioritySystem. When enabled, distant or background avatars render as cached sprite billboards instead of full 3D.

### Highlights
- `RendererConfig` gains `enableCrowdImpostors`, `impostorSpriteResolution`, and `impostorMaxFull3D`.
- `VRMRenderer.drawCore` now has an early-out impostor branch on cache hit; cache miss falls back to full 3D.
- New `warmImpostorCache(commandBuffer:)` lets hosts pre-populate the cache before entering a cached-sprite phase.
- Sprite pipeline now respects `config.colorPixelFormat`; a dedicated sprite depth-stencil state is added.
- `VRMExpressionController.allExpressionWeights()` feeds the pose hash.
- `VRMBenchmark` adds `--impostors`, `--detail-level`, `--sprite-resolution`, and `--max-full3d`; hybrid multi-avatar runs share one priority system across renderers.

### Benchmarks (release, AvatarSample_A_1.0.vrm.glb, 100 frames)
| config | total/frame | CPU encode | draw calls | triangles |
|--------|-------------|------------|------------|-----------|
| full3d (1 avatar) | ~0.43 ms | ~0.40 ms | 20 | 46,984 |
| cached (1 avatar, 256²) | ~0.21 ms | ~0.04 ms | 1 | 2 |
| full3d (5 avatars) | ~3.26 ms | ~2.14 ms | 20* | 46,984* |
| hybrid (5 avatars, max-full3d=1) | ~0.99 ms | ~0.60 ms | 1* | 2* |

\* Counters are reported from the first renderer instance only; encode/total times cover all avatars.

- [x] `swift build` passes
- [x] `swift test` passes
- [x] Benchmark runs in full3d/cached/hybrid modes