### PR TITLE
refactor(vmk): confine VRM authoring to the test target (render-only VMK)

### DIFF
--- a/Sources/VRMMetalKit/VRMMetalKit.docc/VRMMetalKit.md
+++ b/Sources/VRMMetalKit/VRMMetalKit.docc/VRMMetalKit.md
@@ -41,20 +41,6 @@ Use VRMMetalKit when you need a self-contained, Metal-native avatar runtime on m
 - ``ParallelMaterialLoader``
 - <doc:LoadingVRMModels>
 
-### Building
-
-- ``VRMBuilder``
-- ``SkeletonPreset``
-- ``SkeletonDefinition``
-- ``BoneData``
-- ``GLTFDocumentBuilder``
-- ``CharacterRecipe``
-- ``MaterialConfig``
-- ``AccessoryConfig``
-- ``RecipeError``
-- ``SkeletonPresetMapper``
-- ``ExpressionMapper``
-
 ### glTF Internals
 
 - ``GLTFDocument``

--- a/Tests/VRMMetalKitTests/Authoring/CharacterRecipe.swift
+++ b/Tests/VRMMetalKitTests/Authoring/CharacterRecipe.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import simd
+@testable import VRMMetalKit
 
 /// Character recipe - declarative format for VRM character creation
 ///

--- a/Tests/VRMMetalKitTests/Authoring/VRMBuilder.swift
+++ b/Tests/VRMMetalKitTests/Authoring/VRMBuilder.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import simd
+@testable import VRMMetalKit
 
 /// Fluent builder that authors a ``VRMModel`` in-memory and pairs with
 /// `VRMModel.serialize(to:)` to write the model out as a `.vrm` file.

--- a/Tests/VRMMetalKitTests/Authoring/VRMModel+Serialization.swift
+++ b/Tests/VRMMetalKitTests/Authoring/VRMModel+Serialization.swift
@@ -16,6 +16,7 @@
 
 
 import Foundation
+@testable import VRMMetalKit
 
 /// Extension for serializing VRM models to .vrm files
 extension VRMModel {

--- a/Tests/VRMMetalKitTests/MToonSpecComplianceTests.swift
+++ b/Tests/VRMMetalKitTests/MToonSpecComplianceTests.swift
@@ -428,10 +428,3 @@ final class MToonSpecComplianceTests: XCTestCase {
         return glbData
     }
 }
-
-private extension UInt32 {
-    var data: Data {
-        var value = self
-        return Data(bytes: &value, count: MemoryLayout<UInt32>.size)
-    }
-}

--- a/Tests/VRMMetalKitTests/VRMMetaSpecTests.swift
+++ b/Tests/VRMMetalKitTests/VRMMetaSpecTests.swift
@@ -327,12 +327,3 @@ final class VRMMetaSpecTests: XCTestCase {
         return glb
     }
 }
-
-// MARK: - UInt32 Data helpers
-
-private extension UInt32 {
-    var data: Data {
-        var value = self
-        return Data(bytes: &value, count: MemoryLayout<UInt32>.size)
-    }
-}


### PR DESCRIPTION
## Summary

`VRMMetalKit` now **renders only**. All VRM *authoring* code — `VRMBuilder`, `CharacterRecipe`, and `VRMModel` serialization — moves out of `Sources/VRMMetalKit/Builder/` into `Tests/VRMMetalKitTests/Authoring/`, where it serves as the test fixture factory. No authoring code ships in the VMK library.

This restores a clean render-only boundary: `import VRMMetalKit` gives loading + rendering, nothing else.

> ⚠️ **Breaking public-API removal** — see [Release / versioning](#release--versioning) below.

## What changed

**Moved to `Tests/VRMMetalKitTests/Authoring/` (test-only infrastructure):**
- `VRMBuilder.swift`
- `CharacterRecipe.swift`
- `VRMModel+Serialization.swift`

**Supporting edits:**
- Added `@testable import VRMMetalKit` to the moved files — needed to reach the module-internal `func vrmLog(_ message: String)` (`Sources/VRMMetalKit/ARKit/ARKitFaceDriver.swift:467`) and the `VRMNode` initializer, exactly like every other test file does.
- Removed the now-duplicate `UInt32.data` GLB-chunk helpers from `VRMMetaSpecTests` and `MToonSpecComplianceTests`. The canonical copy lives in the moved `VRMModel+Serialization.swift`; the two test-local `private` copies collided once all three files shared the test module (the internal and file-private members of the same name on the same type are ambiguous). Removing the private copies is **required**, not just tidy.
- Removed the dangling **"Building"** section from the `VRMMetalKit.docc` index (all its symbols left the module).

**Pure move.** `VRMBuilder.swift` differs from `main` by exactly **one line** — the added `@testable import VRMMetalKit`. No authoring logic was edited.

## Why test-target confinement (not a separate library)

A `VRMAuthoring` library product was considered and spiked first. It works, but it adds a shippable surface, a new `Package.swift` target/product, ~37 test-file `import` swaps, and a cross-module logger — all to expose code whose only real consumer is **this repo's own tests**. Confining it to the test target achieves the render-only boundary with zero new public surface and no Package.swift churn. The builder stays in-module for the tests that use it as a fixture factory (spring-bone, animation, expression, MToon, VRMA tests).

## <a id="release--versioning"></a>Release / versioning

This is a **source-breaking public-surface removal**: `VRMBuilder`, `CharacterRecipe`, `SkeletonPreset`, `SkeletonPresetMapper`, `RecipeError`, `ExpressionMapper`, and the `VRMModel.serialize(...)` entry points leave the shipped library. Per review, this should **not** ride silently into a stable tag:

- **Version bump required** (latest tag is `0.21.0`; this warrants at least a minor bump, or a major if treating the render/authoring split as the new 1.0 boundary). No `CHANGELOG` file exists in-repo and there is no in-source version constant — versioning is purely git tags — so the bump is a tagging/release-action item, not a file edit.
- **Release note** should call out the removed symbols and point downstream consumers at where authoring now lives (test target here; a future `VRMAuthoring` library if/when external consumers need it).
- Per the repo's pre-release-until-Muse-validates convention, the API-surface removal deserves to land as a pre-release tag.

## Verification

- `Sources/VRMMetalKit/` has **zero** references to `VRMBuilder` / `SkeletonPreset` / `CharacterRecipe` — confirmed render-only.
- `swift build` — clean.
- `swift build --build-tests` — clean.
- `swift test` — **1757 passed, 0 failures** (184 skipped, environment-gated render tests — unchanged baseline).

## Render path

Untouched. `Renderer/`, `Loader/`, `Core/`, `Animation/` are byte-identical to `main`. This is a pure carve-out.

## Risks / follow-ups

- **`perf/crowd-impostors` reconciliation:** the `SynthBody*.swift` files live on that branch (not `main`). Whoever rebases/merges it must move them into `Tests/VRMMetalKitTests/Authoring/` too — the `Builder/` directory no longer exists on `main`. Flagged here so it isn't lost.
- **Downstream consumers** (GameOfMods `ConstructKit`/`OperatorCore`, SynthNPCKit) that imported `VRMBuilder` must source their character authoring elsewhere — out of scope for this repo, but the release note should point at it.

## Review responses

- **vrmLog rationale corrected.** An earlier draft of this PR claimed the `vrmLog("…", level: .error)` call referenced "an overload that does not exist / never compiled." That was wrong: `public func vrmLog(_:level:category:function:line:)` exists in `GLTFCore/Core/GLTFLogger.swift:55` with `.error` a valid case, and VMK re-exports it via `@_exported import GLTFCore` (`GLTFCoreReexports.swift:17`). The call compiled fine before *and* after the move. That line was therefore reverted to its original form so the diff is a pure move — no behavior change.
- **Moved types stay `public`** — harmless in a test target (public is meaningless there); left as-is in case a future `VRMAuthoring` library is spiked. No action.