### PR TITLE
Thread-safe `drawOffscreen` entry point + strong-capture the in-flight semaphore

### DIFF
--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -1462,6 +1462,22 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
     private var cachedDummyView: DummyView?
     private var cachedDummyViewSize: (Int, Int)?
 
+    /// Viewport size for ``drawOffscreen(to:depth:commandBuffer:renderPassDescriptor:)``,
+    /// which bypasses the `MTKView` plumbing entirely.
+    private var offscreenViewportSize: CGSize?
+
+    /// Thread-safe offscreen draw for render loops that don't run on the main
+    /// actor (e.g. a CompositorServices frame loop on visionOS). Identical to
+    /// ``drawOffscreenHeadless(to:depth:commandBuffer:renderPassDescriptor:)``
+    /// but passes the viewport size explicitly instead of routing it through
+    /// an `MTKView`, so it is callable from any thread. Not reentrant: call
+    /// from a single render thread.
+    public func drawOffscreen(to colorTexture: MTLTexture, depth: MTLTexture, commandBuffer: MTLCommandBuffer, renderPassDescriptor: MTLRenderPassDescriptor) {
+        offscreenViewportSize = CGSize(width: colorTexture.width, height: colorTexture.height)
+        defer { offscreenViewportSize = nil }
+        drawCore(in: nil, commandBuffer: commandBuffer, renderPassDescriptor: renderPassDescriptor)
+    }
+
     /// Renders the VRM model to the view.
     ///
     /// Call this method once per frame from your `MTKViewDelegate.draw(in:)` implementation.
@@ -1488,7 +1504,7 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
         drawCore(in: view, commandBuffer: commandBuffer, renderPassDescriptor: renderPassDescriptor)
     }
 
-    private func drawCore(in view: MTKView, commandBuffer: MTLCommandBuffer, renderPassDescriptor: MTLRenderPassDescriptor) {
+    private func drawCore(in view: MTKView?, commandBuffer: MTLCommandBuffer, renderPassDescriptor: MTLRenderPassDescriptor) {
         // DEBUG: Confirm we're in drawCore
         if frameCounter <= 2 || frameCounter % 60 == 0 {
             vrmLog("[VRMRenderer] drawCore() executing, frame \(frameCounter)")
@@ -1843,12 +1859,17 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
         // Ambient color default is set in Uniforms struct initialization
         // Get viewport size from view
         let viewportSize: CGSize
-        if let dummyView = view as? DummyView {
+        if let explicitSize = offscreenViewportSize {
+            // drawOffscreen(to:...) path — no view involved at all
+            viewportSize = explicitSize
+        } else if let dummyView = view as? DummyView {
             // DummyView's drawableSize is nonisolated, safe to access directly
             viewportSize = dummyView.drawableSize
-        } else {
+        } else if let view {
             // Real MTKView requires main actor isolation
             viewportSize = MainActor.assumeIsolated { view.drawableSize }
+        } else {
+            viewportSize = .zero
         }
         uniforms.viewportSize = SIMD2<Float>(Float(viewportSize.width), Float(viewportSize.height))
         // Set debug mode (0=off, 1=UV, 2=hasBaseColorTexture, 3=baseColorFactor)

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -3992,10 +3992,19 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
             }
         }
 
-        // Add command buffer completion handler for error checking and semaphore signaling
+        // Add command buffer completion handler for error checking and semaphore signaling.
+        // The semaphore is captured STRONGLY (not through weak self): if the
+        // renderer's last reference drops while this frame is still on the GPU
+        // (host tears down its render loop — e.g. a visionOS immersive space
+        // closing), a `self?.…signal()` would be skipped and the semaphore
+        // would be deallocated below its creation value, which libdispatch
+        // traps on ("BUG IN CLIENT OF LIBDISPATCH: Semaphore object
+        // deallocated while in use"). Holding it here keeps it alive until
+        // every outstanding wait has been balanced.
+        let inflight = inflightSemaphore
         commandBuffer.addCompletedHandler { [weak self] buffer in
             // Signal that this frame's uniform buffer is available again
-            self?.inflightSemaphore.signal()
+            inflight.signal()
 
             // Record GPU timing if performance tracking is enabled
             if let tracker = self?.performanceTracker {


### PR DESCRIPTION
Two independent thread-safety fixes, both found driving the renderer from a
CompositorServices frame loop on visionOS (which renders off the main actor),
both reproducible without visionOS.

### 1. `drawOffscreen(to:depth:commandBuffer:renderPassDescriptor:)`

`drawOffscreenHeadless` is `@MainActor` and routes the viewport size through a
cached `MTKView` (`DummyView`), so a host whose render loop does not run on the
main actor cannot use it without hopping actors mid-frame. The new
`drawOffscreen` is the same draw path with the viewport size passed explicitly —
no `MTKView` anywhere — nonisolated and callable from any thread. `drawCore`'s
`view` parameter becomes optional; the viewport-size cascade gains an
explicit-size branch ahead of the `DummyView` / `MainActor.assumeIsolated`
paths. No rendering output changes; no baselines affected.

### Concurrency contract (the `@MainActor` question)

The intended contract, stated explicitly since this PR changes the API surface:

- **Single render thread.** The renderer expects exactly one frame producer.
  `drawOffscreen` is nonisolated but NOT reentrant: the in-flight ring
  (uniform buffers + `inflightSemaphore`) assumes one thread issues frames, and
  `offscreenViewportSize` is set/cleared inside a single `drawCore` invocation.
  "Any thread" means "any single thread", not "many threads concurrently" —
  same expectation `MTKViewDelegate.draw(in:)` carries today, minus the
  main-actor pin.
- **`model.lock` covers model mutation vs. the frame.** `VRMModel`'s internal
  `NSLock` (shared with `AnimationPlayer`) is taken by `drawCore` for the
  duration of the frame's model reads; animation/expression writers take it on
  their side. That contract is unchanged — this PR adds no new shared state.
- **Existing entry points keep their isolation.** `draw(in:)` and
  `drawOffscreenHeadless` remain `@MainActor`; nothing about their behavior
  changes.

### 2. Strong-capture the in-flight semaphore in the completion handler

`drawCore`'s command-buffer completion handler signalled the in-flight
semaphore through `[weak self]`. If the renderer's last reference drops while a
frame is still on the GPU — a host tearing down its render loop, e.g. an
immersive space closing — the signal is skipped and the semaphore deallocates
below its creation value, which libdispatch traps on:

```
BUG IN CLIENT OF LIBDISPATCH: Semaphore object deallocated while in use
```

Reproduced deterministically by releasing the renderer immediately after
committing a frame. Capturing the semaphore itself keeps it alive until every
outstanding wait is balanced. The spring-bone snapshot handler already used the
strong-capture pattern; this brings the frame path in line.

### Verification

- `swift build` + full package test suite pass on macOS (no behavior change on
  the MTKView paths — `drawCore` body is untouched except the viewport-size
  read).
- Exercised as the only draw entry point of a native visionOS app
  (two `drawOffscreen` calls per frame, one per eye, from the
  CompositorServices render thread).