### PR TITLE
Raise maxMorphTargets cap 64 -> 256: real avatars exceed 64 blendshapes

### DIFF
--- a/Sources/VRMMetalKit/Core/VRMConstants.swift
+++ b/Sources/VRMMetalKit/Core/VRMConstants.swift
@@ -45,8 +45,12 @@ public enum VRMConstants {
         /// Maximum number of morph targets simultaneously active during vertex shading.
         public static let maxActiveMorphs: Int = 8
 
-        /// Maximum number of morph targets supported per mesh.
-        public static let maxMorphTargets: Int = 64
+        /// Maximum number of morph targets supported per mesh. This is a
+        /// sanity cap against malicious files, not a hardware limit — keep it
+        /// comfortably above real avatars: avatars made for VRChat can be
+        /// can be baked with blendshape sets of 150+ targets (expression
+        /// binds observed at index 150), which a 64 cap silently discarded.
+        public static let maxMorphTargets: Int = 256
 
         /// Active-morph count at which the renderer switches from CPU to GPU morph evaluation.
         public static let morphComputeThreshold: Int = 8


### PR DESCRIPTION
The per-mesh morph cap is a sanity guard against malicious files, not a hardware limit — but at 64 it silently discards expression binds on ordinary avatars. [`ndmf-vrm-exporter`](https://github.com/hkrn/ndmf-vrm-exporter) bakes VRChat blendshape sets of 150+ targets: on our reference avatar every emotion preset (happy=150, angry=149, sad=148, relaxed up to 128) and both blinks (72/73) were dropped by the cap, leaving the face completely static while bone-driven motion worked. Only the visemes (indices 10–14) survived. Nothing warns; the model just loads with a dead face.

256 keeps the guard (out-of-range binds ≥ 256 are still rejected) while clearing real-world content comfortably. The controller's weights buffer is allocated from the same constant, so all paths stay consistent.

### On `LoaderSecurityTests`

No test change turned out to be needed: the suite reads `VRMConstants.Rendering.maxMorphTargets` rather than hardcoding 64, so its out-of-range rejection cases follow the constant. All 46 loader-security and morph tests pass on the branch as-is. (Happy to add an explicit `XCTAssertEqual(cap, 256)` pin if you'd rather the value itself be asserted.)