### PR TITLE
fix: guard pipeline binary archive against simulator SIGABRT

### DIFF
--- a/Sources/VRMMetalKit/Renderer/VRMPipelineCache.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMPipelineCache.swift
@@ -212,6 +212,29 @@ public final class VRMPipelineCache: Sendable {
         }
     }
 
+    /// Whether this platform can serialise an `MTLBinaryArchive` to disk.
+    ///
+    /// `false` on the iOS/tvOS/watchOS simulator, whose Metal loader has no
+    /// target GPU architecture to pack a slice for: `MTLBinaryArchive.serialize(to:)`
+    /// trips `+[MTLLoader sliceIDForDevice:legacyDriverVersion:airntDriverVersion:]:
+    /// failed assertion 'Target device architecture is nil'` and aborts the
+    /// process with `SIGABRT`. That is an assertion, not an `NSError`, so it is
+    /// uncatchable — no `try?` at any call site can defend against it, which is
+    /// why persistence must be refused up front rather than attempted and
+    /// recovered from. `makeBinaryArchive` and `addRenderPipelineFunctions`
+    /// both succeed there; only serialisation traps.
+    ///
+    /// Metal exposes no runtime capability query for this, so the compile-time
+    /// environment check is the only available detection. Consumers can read
+    /// this instead of writing their own `#if targetEnvironment(simulator)`.
+    public static var isPersistentArchiveSupported: Bool {
+        #if targetEnvironment(simulator)
+        return false
+        #else
+        return true
+        #endif
+    }
+
     /// Enables on-disk pipeline persistence, loading any archive already cached
     /// for this device + shader build.
     ///
@@ -219,6 +242,10 @@ public final class VRMPipelineCache: Sendable {
     /// builds from the archive when the matching function set is present and
     /// records new builds into it; call ``flushPersistentArchive()`` to write
     /// the accumulated archive back to disk (e.g. after first-model load).
+    ///
+    /// Silently degrades to plain in-memory caching where
+    /// ``isPersistentArchiveSupported`` is `false`; ``getStatistics()`` reports
+    /// `persistentArchiveEnabled == false` in that case.
     ///
     /// - Parameters:
     ///   - device: The `MTLDevice` the archive is built against.
@@ -229,6 +256,10 @@ public final class VRMPipelineCache: Sendable {
     /// - Throws: the underlying Metal error if an existing archive file is
     ///   incompatible (wrong GPU family) or corrupt.
     public func enablePersistentArchive(device: MTLDevice, directory: URL, shaderHash: String) throws {
+        guard Self.isPersistentArchiveSupported else {
+            vrmLog("[VRMPipelineCache] Pipeline archive unavailable on the simulator (serialisation aborts); using in-memory cache.")
+            return
+        }
         let url = PipelineBinaryArchive.cacheURL(
             in: directory, deviceName: device.name, shaderHash: shaderHash)
         let archive = try PipelineBinaryArchive(device: device, url: url)
@@ -243,6 +274,11 @@ public final class VRMPipelineCache: Sendable {
     /// Writes the in-memory archive to disk when new pipelines have been
     /// recorded since the last flush. No-op when persistence is disabled, the
     /// archive was preloaded unchanged, or nothing new was built.
+    ///
+    /// Also a no-op where ``isPersistentArchiveSupported`` is `false`, because
+    /// ``enablePersistentArchive(device:directory:shaderHash:)`` never installs
+    /// an archive there — reaching Metal's serialiser on the simulator would
+    /// abort the process rather than throw.
     ///
     /// - Returns: `true` if the archive was actually serialized, `false` if the
     ///   flush was a no-op.

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer+Pipeline.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer+Pipeline.swift
@@ -47,6 +47,10 @@ extension VRMRenderer {
     /// any failure degrades silently to plain in-memory caching.
     static func enablePipelineArchiveIfRequested(device: MTLDevice, config: RendererConfig) -> Bool {
         guard config.enablePipelineArchive else { return false }
+        guard VRMPipelineCache.isPersistentArchiveSupported else {
+            vrmLog("[VRMRenderer] Pipeline archive requested but archive serialisation aborts on the simulator; skipping persistence.")
+            return false
+        }
         guard let shaderHash = VRMShaderLibraryLoader.bundledLibraryHash() else {
             vrmLog("[VRMRenderer] Pipeline archive requested but the bundled shader hash is unavailable; skipping persistence.")
             return false

--- a/Tests/VRMMetalKitTests/VRMRendererPipelineArchiveTests.swift
+++ b/Tests/VRMMetalKitTests/VRMRendererPipelineArchiveTests.swift
@@ -31,8 +31,24 @@ final class VRMRendererPipelineArchiveTests: XCTestCase {
         VRMPipelineCache.shared.clearCache()
     }
 
+    /// The capability query must report `false` exactly on the simulator, where
+    /// `MTLBinaryArchive.serialize(to:)` trips an uncatchable Metal assertion
+    /// (`+[MTLLoader sliceIDForDevice:...] 'Target device architecture is nil'`),
+    /// and `true` on every real-GPU platform.
+    func testPersistentArchiveSupportMatchesPlatform() {
+        #if targetEnvironment(simulator)
+        XCTAssertFalse(VRMPipelineCache.isPersistentArchiveSupported,
+                       "Archive serialisation aborts on the simulator; support must be reported false.")
+        #else
+        XCTAssertTrue(VRMPipelineCache.isPersistentArchiveSupported,
+                      "Archive serialisation works on real GPUs; support must be reported true.")
+        #endif
+    }
+
     /// With the flag on, constructing a renderer must build pipelines through
-    /// the archive and flush a non-empty archive file into the configured dir.
+    /// the archive and flush a non-empty archive file into the configured dir —
+    /// unless the platform cannot serialise archives, where the request must
+    /// degrade silently to in-memory caching rather than abort the process.
     func testRendererWritesArchiveWhenFlagEnabled() throws {
         try skipOnBetaMetalDriverAborts()
         let dir = FileManager.default.temporaryDirectory
@@ -44,12 +60,52 @@ final class VRMRendererPipelineArchiveTests: XCTestCase {
         config.strict = .off
         config.enablePipelineArchive = true
         config.pipelineArchiveDirectory = dir
+        let enabled = VRMRenderer.enablePipelineArchiveIfRequested(device: device, config: config)
         _ = VRMRenderer(device: device, config: config)
 
         let files = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
-        XCTAssertTrue(
-            files.contains { $0.hasSuffix(".metallib") },
-            "Renderer with enablePipelineArchive must write a pipeline archive; found \(files)")
+        if VRMPipelineCache.isPersistentArchiveSupported {
+            XCTAssertTrue(enabled, "Archive must be enabled on a platform that supports serialisation.")
+            XCTAssertTrue(
+                files.contains { $0.hasSuffix(".metallib") },
+                "Renderer with enablePipelineArchive must write a pipeline archive; found \(files)")
+        } else {
+            XCTAssertFalse(enabled, "Archive must bail out on a platform that cannot serialise it.")
+            XCTAssertTrue(files.isEmpty,
+                          "Unsupported platform must write no archive; found \(files)")
+        }
+    }
+
+    /// The public choke point must be safe on its own: a consumer that wires
+    /// ``VRMPipelineCache/enablePersistentArchive(device:directory:shaderHash:)``
+    /// directly (as `VRMBenchmark` does) and then flushes must not abort on the
+    /// simulator. `flushPersistentArchive()` is documented to *throw* on failure,
+    /// so a `try?` at the call site is the only defence a consumer has — and an
+    /// assertion walks straight through it.
+    func testDirectArchiveWiringNeverAborts() throws {
+        try skipOnBetaMetalDriverAborts()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmk-cache-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try VRMPipelineCache.shared.enablePersistentArchive(
+            device: device, directory: dir, shaderHash: "test-hash")
+
+        XCTAssertEqual(
+            VRMPipelineCache.shared.getStatistics().persistentArchiveEnabled,
+            VRMPipelineCache.isPersistentArchiveSupported,
+            "Persistence must engage only where the archive can actually be serialised.")
+
+        var config = RendererConfig()
+        config.strict = .off
+        _ = VRMRenderer(device: device, config: config)
+
+        // Must return (or throw) — never trap.
+        let flushed = try VRMPipelineCache.shared.flushPersistentArchive()
+        if !VRMPipelineCache.isPersistentArchiveSupported {
+            XCTAssertFalse(flushed, "Flush must be a no-op where persistence never engaged.")
+        }
     }
 
     /// After init, the renderer must not leave the archive enabled on the


### PR DESCRIPTION
## Problem

`MTLBinaryArchive.serialize(to:)` **aborts** on the iOS simulator rather than throwing:

```
+[MTLLoader sliceIDForDevice:legacyDriverVersion:airntDriverVersion:]:692:
failed assertion `Target device architecture is nil'
Child process terminated with signal 6: Abort trap
```

The simulator's Metal loader has no target GPU architecture to pack a slice for. Narrowed to the exact call: `makeBinaryArchive` and `addRenderPipelineFunctions` both **succeed**; only serialisation traps.

Because that is an assertion and not an `NSError`, the documented contract of `flushPersistentArchive()` — *"Throws: the underlying Metal error if serialisation fails"* — is unhonorable on simulator. The `try?` at `VRMRenderer.swift:988` is defending against an error that never arrives, while the assertion walks straight through it. An assertion isn't catchable, so no consumer can guard against this downstream.

**Every consumer that sets `RendererConfig.enablePipelineArchive = true` crashes on launch in the simulator.** Muse found it first.

Metal exposes no runtime capability query (there is no `MTLDevice.supportsBinaryArchiveSerialization`), so `#if targetEnvironment(simulator)` is the only available detection — and it has to sit where the archive gets enabled, which is VMK. Platform-conditional behaviour is already established here: `VRMShaderLibraryLoader` branches on the same check and ships a dedicated `VRMMetalKitShaders_iOSSimulator.metallib` slice.

## Changes

- **`VRMPipelineCache.isPersistentArchiveSupported`** — public capability query, so consumers can read this instead of writing their own `#if`.
- **Bail-out in `enablePersistentArchive`** — the choke point every path crosses, including consumers that wire the public API directly (as `VRMBenchmark` does). `flushPersistentArchive()` is then a no-op because no archive was ever installed.
- **A fourth bail-out in `enablePipelineArchiveIfRequested`** — alongside the existing flag-off / no-shader-hash / no-caches-dir cases, each already documented as degrading "silently to plain in-memory caching". This keeps the return value truthful and wastes no work.

Guarding only `enablePipelineArchiveIfRequested` would have left the public API still abort-prone, since `VRMPipelineCache.enablePersistentArchive` is public and independently reachable — hence the deeper choke point as the primary guard.

## Verification

Built the package for the iOS simulator and linked a driver against the actual `VRMMetalKit` module (iPhone 17 Pro, iOS 26.5):

| | unfixed | fixed |
|---|---|---|
| `VRMRenderer(device:config:)` with flag on | **abort, exit 134** | exits 0, archive skipped |

The control run aborts at precisely the call site under discussion — `VRMRenderer`'s init-time flush, after the pipeline builds — confirming the repro is not incidental.

Tests were written first and failed to compile before the fix. They assert **both** branches (positive on macOS, bail-out on simulator) rather than being vacuous off-simulator. `testRendererWritesArchiveWhenFlagEnabled` needed the same treatment, since it asserted an archive file *is* written.

macOS behaviour is unchanged — it takes the `isPersistentArchiveSupported == true` path, so rendering is byte-identical by construction (no sanity render included for that reason).

### Note on suite state

A local `swift test` run shows **2 failures** in `SpringBoneStressPosePenetrationTests.testLookUp_augmented_noForeheadPenetration` (temple residual 0.0209m vs 0.002m budget). These reproduce identically on clean `main` at a0e5be2, so they are not from this change. Note they are **local-only** — Xcode Cloud is green on `main` for both Test - iOS and Test - macOS, so this is a local-environment discrepancy rather than a red baseline.

## Behaviour change

Setting `enablePipelineArchive = true` on the simulator now silently degrades to in-memory caching instead of aborting the process. No on-disk archive is written there; device and macOS persistence are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

