### PR TITLE
Follow-up to #384/#385: test coverage + remove per-frame viewport state

### DIFF
--- a/Sources/VRMMetalKit/Core/VRMConstants.swift
+++ b/Sources/VRMMetalKit/Core/VRMConstants.swift
@@ -45,11 +45,22 @@ public enum VRMConstants {
         /// Maximum number of morph targets simultaneously active during vertex shading.
         public static let maxActiveMorphs: Int = 8
 
-        /// Maximum number of morph targets supported per mesh. This is a
-        /// sanity cap against malicious files, not a hardware limit — keep it
-        /// comfortably above real avatars: avatars made for VRChat can be
-        /// can be baked with blendshape sets of 150+ targets (expression
-        /// binds observed at index 150), which a 64 cap silently discarded.
+        /// Highest addressable morph index, and therefore the length (in
+        /// floats) of the dense weights buffer.
+        ///
+        /// This is a *bounds check on expression binds*, not a resource cap and
+        /// not a hardware limit. Its safety role is to keep a bind's
+        /// `morphIndex` inside the weights buffer, which is allocated from this
+        /// same constant — the two must always move together. It does **not**
+        /// bound how much morph geometry a file can load: the loader never
+        /// consults it, and the morphed position/normal buffers are sized from
+        /// vertex counts. Raising it therefore does not widen the memory
+        /// exposure of a hostile file.
+        ///
+        /// Keep it comfortably above real avatars: avatars made for VRChat can
+        /// be baked with blendshape sets of 150+ targets (expression binds
+        /// observed at index 150), which a 64 cap silently discarded — every
+        /// emotion preset dropped, leaving the face static.
         public static let maxMorphTargets: Int = 256
 
         /// Active-morph count at which the renderer switches from CPU to GPU morph evaluation.

--- a/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
+++ b/Sources/VRMMetalKit/Renderer/VRMRenderer.swift
@@ -1456,26 +1456,45 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
             cachedDummyViewSize = (w, h)
         }
         vrmLog("[VRMRenderer] drawOffscreenHeadless called - size: \(w)x\(h)")
-        drawCore(in: view, commandBuffer: commandBuffer, renderPassDescriptor: renderPassDescriptor)
+        drawCore(viewport: .view(view), commandBuffer: commandBuffer, renderPassDescriptor: renderPassDescriptor)
     }
 
     private var cachedDummyView: DummyView?
     private var cachedDummyViewSize: (Int, Int)?
 
-    /// Viewport size for ``drawOffscreen(to:depth:commandBuffer:renderPassDescriptor:)``,
-    /// which bypasses the `MTKView` plumbing entirely.
-    private var offscreenViewportSize: CGSize?
+    /// Where ``drawCore(viewport:commandBuffer:renderPassDescriptor:)`` sources
+    /// the frame's viewport size.
+    ///
+    /// Modelled as a sum type rather than an optional `MTKView` plus an
+    /// optional size so that "exactly one of the two is present" is enforced by
+    /// the type rather than by convention: there is no fourth case to fall
+    /// through to, and no per-frame renderer state for concurrent entry points
+    /// to race on.
+    private enum ViewportSource {
+        case view(MTKView)
+        case explicit(CGSize)
+    }
 
     /// Thread-safe offscreen draw for render loops that don't run on the main
     /// actor (e.g. a CompositorServices frame loop on visionOS). Identical to
     /// ``drawOffscreenHeadless(to:depth:commandBuffer:renderPassDescriptor:)``
     /// but passes the viewport size explicitly instead of routing it through
-    /// an `MTKView`, so it is callable from any thread. Not reentrant: call
-    /// from a single render thread.
+    /// an `MTKView`, so it is callable from any thread.
+    ///
+    /// The colour and depth attachments come from `renderPassDescriptor`;
+    /// `colorTexture` supplies the viewport dimensions and `depth` is accepted
+    /// for symmetry with ``drawOffscreenHeadless(to:depth:commandBuffer:renderPassDescriptor:)``.
+    ///
+    /// - Important: Not reentrant. The renderer expects a single frame
+    ///   producer — the in-flight ring (uniform buffers + `inflightSemaphore`)
+    ///   assumes one thread issues frames. "Any thread" means "any one thread",
+    ///   the same expectation `MTKViewDelegate.draw(in:)` carries, minus the
+    ///   main-actor pin.
     public func drawOffscreen(to colorTexture: MTLTexture, depth: MTLTexture, commandBuffer: MTLCommandBuffer, renderPassDescriptor: MTLRenderPassDescriptor) {
-        offscreenViewportSize = CGSize(width: colorTexture.width, height: colorTexture.height)
-        defer { offscreenViewportSize = nil }
-        drawCore(in: nil, commandBuffer: commandBuffer, renderPassDescriptor: renderPassDescriptor)
+        drawCore(
+            viewport: .explicit(CGSize(width: colorTexture.width, height: colorTexture.height)),
+            commandBuffer: commandBuffer,
+            renderPassDescriptor: renderPassDescriptor)
     }
 
     /// Renders the VRM model to the view.
@@ -1501,10 +1520,10 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
     ///
     /// - Important: Ensure `viewMatrix` and `projectionMatrix` are set before calling.
     @MainActor public func draw(in view: MTKView, commandBuffer: MTLCommandBuffer, renderPassDescriptor: MTLRenderPassDescriptor) {
-        drawCore(in: view, commandBuffer: commandBuffer, renderPassDescriptor: renderPassDescriptor)
+        drawCore(viewport: .view(view), commandBuffer: commandBuffer, renderPassDescriptor: renderPassDescriptor)
     }
 
-    private func drawCore(in view: MTKView?, commandBuffer: MTLCommandBuffer, renderPassDescriptor: MTLRenderPassDescriptor) {
+    private func drawCore(viewport: ViewportSource, commandBuffer: MTLCommandBuffer, renderPassDescriptor: MTLRenderPassDescriptor) {
         // DEBUG: Confirm we're in drawCore
         if frameCounter <= 2 || frameCounter % 60 == 0 {
             vrmLog("[VRMRenderer] drawCore() executing, frame \(frameCounter)")
@@ -1859,17 +1878,21 @@ public final class VRMRenderer: NSObject, @unchecked Sendable {
         // Ambient color default is set in Uniforms struct initialization
         // Get viewport size from view
         let viewportSize: CGSize
-        if let explicitSize = offscreenViewportSize {
-            // drawOffscreen(to:...) path — no view involved at all
-            viewportSize = explicitSize
-        } else if let dummyView = view as? DummyView {
-            // DummyView's drawableSize is nonisolated, safe to access directly
-            viewportSize = dummyView.drawableSize
-        } else if let view {
-            // Real MTKView requires main actor isolation
-            viewportSize = MainActor.assumeIsolated { view.drawableSize }
-        } else {
-            viewportSize = .zero
+        switch viewport {
+        case .explicit(let size):
+            // drawOffscreen(to:...) path — no view involved at all, so nothing
+            // here touches the main actor.
+            viewportSize = size
+        case .view(let view):
+            if let dummyView = view as? DummyView {
+                // DummyView's drawableSize is nonisolated, safe to access directly
+                viewportSize = dummyView.drawableSize
+            } else {
+                // Real MTKView requires main actor isolation. Only reachable
+                // from the @MainActor entry points, which is why the explicit
+                // case above must not route through here.
+                viewportSize = MainActor.assumeIsolated { view.drawableSize }
+            }
         }
         uniforms.viewportSize = SIMD2<Float>(Float(viewportSize.width), Float(viewportSize.height))
         // Set debug mode (0=off, 1=UV, 2=hasBaseColorTexture, 3=baseColorFactor)

--- a/Tests/VRMMetalKitTests/MorphWeightsBufferCapacityTests.swift
+++ b/Tests/VRMMetalKitTests/MorphWeightsBufferCapacityTests.swift
@@ -1,0 +1,77 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+import Metal
+@testable import VRMMetalKit
+
+/// Pins the invariant that makes ``VRMConstants/Rendering/maxMorphTargets``
+/// safe to raise (#385 took it 64 → 256).
+///
+/// The constant does double duty: it bounds the `morphIndex` an expression bind
+/// may use, *and* it sizes the dense weights buffer those indices address. The
+/// bound is only a memory-safety property while the two agree — a cap raised
+/// without the buffer following would let an in-range bind write past the
+/// allocation. Asserting the relationship rather than the literal value keeps
+/// this meaningful when the cap is next tuned.
+final class MorphWeightsBufferCapacityTests: XCTestCase {
+
+    private var device: MTLDevice!
+
+    override func setUp() async throws {
+        guard let d = MTLCreateSystemDefaultDevice() else { throw XCTSkip("Metal device not available") }
+        device = d
+    }
+
+    /// The weights buffer must be able to hold a float for every addressable
+    /// morph index.
+    func testWeightsBufferCoversEveryAddressableMorphIndex() throws {
+        let system = try VRMMorphTargetSystem(device: device)
+        guard let buffer = system.getMorphWeightsBuffer() else {
+            throw XCTSkip("Weights buffer not allocated")
+        }
+
+        let cap = VRMConstants.Rendering.maxMorphTargets
+        let required = cap * MemoryLayout<Float>.stride
+        XCTAssertGreaterThanOrEqual(
+            buffer.length, required,
+            "Weights buffer holds \(buffer.length / MemoryLayout<Float>.stride) floats but morph "
+            + "indices up to \(cap - 1) are accepted. The cap and the buffer must be sized from "
+            + "the same constant, or an in-range bind writes past the allocation.")
+    }
+
+    /// Writing at the highest in-range index must stay inside the buffer and
+    /// land where the shader will read it.
+    func testHighestInRangeIndexWritesInsideTheBuffer() throws {
+        let system = try VRMMorphTargetSystem(device: device)
+        guard let buffer = system.getMorphWeightsBuffer() else {
+            throw XCTSkip("Weights buffer not allocated")
+        }
+
+        let cap = VRMConstants.Rendering.maxMorphTargets
+        let lastIndex = cap - 1
+        var weights = [Float](repeating: 0, count: cap)
+        weights[lastIndex] = 0.75
+        system.updateMorphWeights(weights)
+
+        let stored = buffer.contents()
+            .advanced(by: lastIndex * MemoryLayout<Float>.stride)
+            .load(as: Float.self)
+        XCTAssertEqual(
+            stored, 0.75, accuracy: 1e-6,
+            "Weight at the highest in-range morph index (\(lastIndex)) did not reach the buffer.")
+    }
+}

--- a/Tests/VRMMetalKitTests/VRMRendererOffscreenThreadSafetyTests.swift
+++ b/Tests/VRMMetalKitTests/VRMRendererOffscreenThreadSafetyTests.swift
@@ -1,0 +1,234 @@
+//
+// Copyright 2025 Arkavo
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+import Metal
+import simd
+@testable import VRMMetalKit
+
+/// Regression coverage for the two thread-safety fixes in #384, neither of
+/// which shipped with a test.
+///
+/// Deliberately *not* `@MainActor`: the whole point of
+/// ``VRMRenderer/drawOffscreen(to:depth:commandBuffer:renderPassDescriptor:)``
+/// is that a host whose render loop does not run on the main actor (a
+/// CompositorServices frame loop on visionOS) can drive it. A `@MainActor`
+/// test class would run every case on the main thread and silently pass even
+/// if the main-actor pin came back.
+final class VRMRendererOffscreenThreadSafetyTests: XCTestCase {
+
+    private var device: MTLDevice!
+    private var queue: MTLCommandQueue!
+    private var model: VRMModel!
+
+    override func setUp() async throws {
+        guard let d = MTLCreateSystemDefaultDevice() else { throw XCTSkip("Metal device not available") }
+        guard let q = d.makeCommandQueue() else { throw XCTSkip("Could not create command queue") }
+        device = d
+        queue = q
+
+        // A model is mandatory, not incidental: `drawCore` returns at its
+        // `guard let model` before ever reaching the viewport cascade or
+        // installing the command-buffer completion handler. Without one, every
+        // case here would pass while exercising none of the code under test.
+        let path = getTestVRM10ModelPath()
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw XCTSkip("Test VRM 1.0 model not found (set MUSE_RESOURCES_PATH)")
+        }
+        model = try await VRMModel.load(from: URL(fileURLWithPath: path), device: d)
+    }
+
+    /// Renderer with the model loaded and camera set, ready to produce a frame.
+    private func makeRenderer(aspect: Float) -> VRMRenderer {
+        var config = RendererConfig()
+        config.sampleCount = 1
+        config.strict = .off
+        let renderer = VRMRenderer(device: device, config: config)
+        renderer.loadModel(model)
+        renderer.projectionMatrix = makePerspectiveProjection(
+            fovY: Float.pi / 4, aspectRatio: aspect, nearZ: 0.01, farZ: 100.0)
+        renderer.viewMatrix = RenderTestSupport.makeLookAt(
+            eye: SIMD3<Float>(0, 1.2, 2.0),
+            center: SIMD3<Float>(0, 1.2, 0),
+            up: SIMD3<Float>(0, 1, 0))
+        return renderer
+    }
+
+    // MARK: - Fixtures
+
+    /// `@unchecked Sendable`: the textures and the pass descriptor are built
+    /// once on the test thread, then handed to exactly one render thread and
+    /// never mutated afterwards, so the hand-off is the only cross-thread
+    /// access and it happens-before the render.
+    private struct Target: @unchecked Sendable {
+        let color: MTLTexture
+        let depth: MTLTexture
+        let descriptor: MTLRenderPassDescriptor
+    }
+
+    private func makeTarget(width: Int, height: Int) throws -> Target {
+        let colorDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm, width: width, height: height, mipmapped: false)
+        colorDesc.usage = [.renderTarget, .shaderRead]
+        colorDesc.storageMode = .private
+
+        let depthDesc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .depth32Float, width: width, height: height, mipmapped: false)
+        depthDesc.usage = [.renderTarget]
+        depthDesc.storageMode = .private
+
+        guard let color = device.makeTexture(descriptor: colorDesc),
+              let depth = device.makeTexture(descriptor: depthDesc) else {
+            throw XCTSkip("Could not allocate render targets")
+        }
+
+        let pass = MTLRenderPassDescriptor()
+        pass.colorAttachments[0].texture = color
+        pass.colorAttachments[0].loadAction = .clear
+        pass.colorAttachments[0].storeAction = .store
+        pass.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+        pass.depthAttachment.texture = depth
+        pass.depthAttachment.loadAction = .clear
+        pass.depthAttachment.storeAction = .dontCare
+        pass.depthAttachment.clearDepth = 1.0
+
+        return Target(color: color, depth: depth, descriptor: pass)
+    }
+
+    /// Runs `body` on a dedicated non-main thread and waits for it, so a
+    /// main-actor violation surfaces as a trap here rather than being masked
+    /// by the test already running on the main thread.
+    private func onRenderThread(timeout: TimeInterval = 30, _ body: @escaping @Sendable () -> Void) {
+        let done = expectation(description: "render thread finished")
+        let thread = Thread {
+            body()
+            done.fulfill()
+        }
+        thread.name = "VRM Test Render Thread"
+        thread.start()
+        wait(for: [done], timeout: timeout)
+    }
+
+    // MARK: - drawOffscreen off the main actor
+
+    /// `drawOffscreen` must complete when driven from a non-main thread.
+    ///
+    /// Before #384 this was impossible: the only offscreen entry point was
+    /// `@MainActor drawOffscreenHeadless`, and `drawCore`'s viewport read went
+    /// through `MainActor.assumeIsolated`, which traps off the main actor.
+    func testDrawOffscreenRunsOnBackgroundThread() throws {
+        let renderer = makeRenderer(aspect: 128.0 / 96.0)
+        let target = try makeTarget(width: 128, height: 96)
+
+        onRenderThread { [queue] in
+            guard let commandBuffer = queue?.makeCommandBuffer() else {
+                XCTFail("Could not create command buffer"); return
+            }
+            XCTAssertFalse(Thread.isMainThread, "Test must exercise a non-main thread to be meaningful.")
+            renderer.drawOffscreen(
+                to: target.color, depth: target.depth,
+                commandBuffer: commandBuffer, renderPassDescriptor: target.descriptor)
+            commandBuffer.commit()
+            commandBuffer.waitUntilCompleted()
+            XCTAssertNil(commandBuffer.error, "Offscreen frame failed: \(String(describing: commandBuffer.error))")
+        }
+    }
+
+    /// The viewport handed to the shaders must be the render target's
+    /// dimensions — not the 1280x720 `Uniforms` default, and not a stale size
+    /// left over from another entry point.
+    func testDrawOffscreenPublishesTextureDimensionsAsViewport() throws {
+        let width = 321, height = 214   // deliberately unlike any default
+        let renderer = makeRenderer(aspect: Float(width) / Float(height))
+        let target = try makeTarget(width: width, height: height)
+
+        onRenderThread { [queue] in
+            guard let commandBuffer = queue?.makeCommandBuffer() else {
+                XCTFail("Could not create command buffer"); return
+            }
+            renderer.drawOffscreen(
+                to: target.color, depth: target.depth,
+                commandBuffer: commandBuffer, renderPassDescriptor: target.descriptor)
+            commandBuffer.commit()
+            commandBuffer.waitUntilCompleted()
+        }
+
+        // `currentUniformBufferIndex` is private, so scan the triple-buffered
+        // ring for the frame that was just written.
+        let expected = SIMD2<Float>(Float(width), Float(height))
+        let found = renderer.uniformsBuffers.contains { buffer in
+            buffer.contents().load(as: Uniforms.self).viewportSize == expected
+        }
+        XCTAssertTrue(
+            found,
+            "No uniform buffer carries the offscreen viewport \(expected); "
+            + "sizes seen: \(renderer.uniformsBuffers.map { $0.contents().load(as: Uniforms.self).viewportSize })")
+    }
+
+    // MARK: - Semaphore lifetime across teardown
+
+    /// Releasing the renderer while a frame is still on the GPU must not trap.
+    ///
+    /// The completion handler signalled `inflightSemaphore` through
+    /// `[weak self]`; when the host dropped its last reference mid-flight (an
+    /// immersive space closing), the signal was skipped and the semaphore
+    /// deallocated below its creation value — which libdispatch traps on with
+    /// "BUG IN CLIENT OF LIBDISPATCH: Semaphore object deallocated while in
+    /// use". #384 captures the semaphore strongly; this pins that.
+    func testReleasingRendererWithFrameInFlightDoesNotTrap() throws {
+        let target = try makeTarget(width: 64, height: 64)
+        // Holds the only strong reference, so the render thread can drop it
+        // mid-flight. The renderer itself is built on the test thread, keeping
+        // this case about teardown rather than about background construction.
+        let box = RendererBox(makeRenderer(aspect: 1.0))
+
+        onRenderThread { [queue] in
+            guard let commandBuffer = queue?.makeCommandBuffer() else {
+                XCTFail("Could not create command buffer"); return
+            }
+            // No local strong binding: the box must hold the ONLY reference,
+            // or nilling it below will not actually deallocate the renderer
+            // and this case silently stops testing anything.
+            box.renderer!.drawOffscreen(
+                to: target.color, depth: target.depth,
+                commandBuffer: commandBuffer, renderPassDescriptor: target.descriptor)
+            commandBuffer.commit()
+
+            // Last reference drops while the frame is still on the GPU. A
+            // weak-self signal would be skipped here, leaving the semaphore
+            // below its creation value when it deallocates.
+            // Guards against this case silently going vacuous: if a future
+            // change makes something else retain the renderer, the scenario
+            // stops reproducing and the assertion below catches that.
+            weak var probe = box.renderer
+            box.renderer = nil
+            XCTAssertNil(
+                probe,
+                "The box must hold the only reference — if the renderer survives here, "
+                + "this case is no longer exercising teardown-with-frame-in-flight.")
+
+            commandBuffer.waitUntilCompleted()
+            XCTAssertNil(commandBuffer.error, "Frame failed: \(String(describing: commandBuffer.error))")
+        }
+    }
+}
+
+/// Mutable single-reference holder so a test can release the renderer from a
+/// different thread than the one that built it.
+private final class RendererBox: @unchecked Sendable {
+    var renderer: VRMRenderer?
+    init(_ renderer: VRMRenderer?) { self.renderer = renderer }
+}


### PR DESCRIPTION
Both #384 and #385 landed without tests. This adds the missing coverage and hardens one design point found while reviewing them.

**No rendering change.** The sanity render is pixel-identical to b216d9e (0 differing pixels at 1024x1024) — which also confirms #384 and #385 themselves changed no output.

## #384 — thread-safe `drawOffscreen`

**Removed the per-frame viewport state.** `offscreenViewportSize` was an instance property written from the nonisolated `drawOffscreen` and read on the `@MainActor` MTKView path. A host doing on-screen preview *plus* offscreen capture — the natural pairing — raced on it, and the failure mode was silent: the MTKView frame picks up the offscreen viewport size. The "single render thread" contract in #384's description covers intended use, but it was documented rather than enforced.

Replacing it with a `ViewportSource` sum type passed into `drawCore` makes "exactly one of view / explicit size" a type-level property. That also deletes:
- the `defer { offscreenViewportSize = nil }`, and
- the `viewportSize = .zero` fallback, which would have silently published a degenerate `(0,0)` viewport to the shaders had it ever been reached.

**Added `VRMRendererOffscreenThreadSafetyTests`** — deliberately *not* `@MainActor`, so the cases genuinely run off the main thread rather than passing on it:

1. `drawOffscreen` completes when driven from a background thread.
2. The viewport published to the shaders is the render target's dimensions.
3. Releasing the renderer with a frame in flight does not trap.

Two things worth noting about how these are built:

- **All three load a real model.** `drawCore` returns at its `guard let model` *before* reaching either the viewport cascade or the completion handler. Without a model every case passes while exercising none of the code under test — I hit exactly that on the first draft.
- **Case 3 was verified against a reverted fix.** With `self?.inflightSemaphore.signal()` restored, it crashes with SIGTRAP — the libdispatch `Semaphore object deallocated while in use` trap. It is load-bearing, not decorative. It also asserts the renderer actually deallocated, because a stray strong reference (my first draft had one, via a `guard let` binding) quietly stops the scenario reproducing.

## #385 — `maxMorphTargets` 64 → 256

**Corrected the constant's documentation.** It described itself as "a sanity cap against malicious files", which overstates its role. The loader never consults it, and the morphed position/normal buffers are sized from vertex counts — so it does not bound a hostile file's memory at all. What it actually is: a bounds check on expression binds, keeping `morphIndex` inside the weights buffer allocated from the same constant. Worth stating precisely, since the old wording invites a future reader to treat it as a resource limit. Also fixes a duplicated "can be".

**Added `MorphWeightsBufferCapacityTests`** pinning the relationship that makes the raise safe: the buffer covers every addressable index, and a write at the highest in-range index lands inside it. This asserts the invariant rather than the literal `256`, so it stays meaningful when the cap is next tuned — unlike the `XCTAssertEqual(cap, 256)` pin offered during review, which would have to change whenever the constant does while protecting nothing.

`LoaderSecurityTests` needed no change: it derives the cap (`let cap = VRMConstants.Rendering.maxMorphTargets`) rather than hardcoding 64. The review ask to update it was based on a wrong premise.

## Verification

- `swift build` clean; full suite run locally.
- 5 new tests pass; case 3 confirmed to fail (SIGTRAP) against a reverted fix.
- Sanity render pixel-identical to pre-merge baseline.

### Pre-existing, not from this PR

- `SpringBoneStressPosePenetrationTests.testLookUp_augmented_noForeheadPenetration` fails locally (temple residual 0.0209m vs 0.002m budget), identically on `main` and on b216d9e. Xcode Cloud is green on `main`, so this looks local-environment-specific.
- The committed `AvatarSample_U.png` differs from a fresh render at every commit tested, including before this work. Likely a different fixture or flags (the repo ships `AvatarSample_U_0.0.vrm.glb`, a VRM 0.0 file) rather than a regression. Left alone — worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
