### PR TITLE
feat(visionos): declare visionOS support so Xcode Cloud can build it

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
     name: "VRMMetalKit",
     platforms: [
         .macOS(.v26),
-        .iOS(.v26)
+        .iOS(.v26),
+        .visionOS(.v26)
     ],
     products: [
         .library(

--- a/VRMMetalKitCI.xcodeproj/project.pbxproj
+++ b/VRMMetalKitCI.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -310,7 +310,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";


### PR DESCRIPTION
Platform scaffolding so a **visionOS action can be added to the Xcode Cloud workflow**. No GitHub Actions job — Xcode Cloud is where this project's build/test matrix lives.

## Changes

- `Package.swift` — declare `.visionOS(.v26)`.
- `VRMMetalKitCI` — extend `SUPPORTED_PLATFORMS` with `xros xrsimulator` on both the Debug and Release configurations.

Two files, three lines. That's everything the repo needs; the workflow action itself is configured in App Store Connect, which I can't do from here.

## Verification

Clean build against the Apple Vision Pro simulator, with the prior `Debug-xrsimulator` products deleted first so nothing stale could mask the result:

```
BUILT_PRODUCTS_DIR = .../Build/Products/Debug-xrsimulator
platform VISIONOSSIMULATOR
   minos 26.0
```

macOS `swift build` unaffected.

**No source changes were needed.** `MTKView` — the main portability risk, used across five files in `Sources/VRMMetalKit/` with no `#if os(visionOS)` guards anywhere — ships in the XRSimulator SDK annotated `API_AVAILABLE(macos(10.11), ios(9.0))` with no `API_UNAVAILABLE(visionos)`.

## The destination trap, and what actually prevents it

A visionOS Simulator destination can be satisfied by the `Designed for [iPad,iPhone]` variant, which emits an **iOS** binary — a gate that goes green while testing nothing.

`SUPPORTED_PLATFORMS` is what prevents that. Demonstrated both ways on the same scheme and destination:

| Branch | `SUPPORTED_PLATFORMS` | Result |
|---|---|---|
| `main` | no `xros`/`xrsimulator` | `Debug-iphonesimulator`, `LC_BUILD_VERSION` = `IOSSIMULATOR` |
| this PR | + `xros xrsimulator` | `Debug-xrsimulator`, `LC_BUILD_VERSION` = `VISIONOSSIMULATOR` |

An earlier revision of this description credited `TARGETED_DEVICE_FAMILY = "1,2,7"` for this. **That was wrong on two counts** and has been removed rather than the setting added: it was never applied to the file, and it is not the mechanism — it's an app-level key that drives an app's `UIDeviceFamily`, while `VRMMetalKitHost` is a `com.apple.product-type.framework`. Adding a no-op setting to preserve a false rationale would be worse than deleting the claim.

## When configuring the Xcode Cloud action

1. **Make it build-only for now.** The xros/xrsimulator metallib slices and the `VRMShaderLibraryLoader` runtime-selection branch belong to step 5 of the #87 upstreaming sequence and aren't duplicated here. Without them visionOS falls through to the macOS slice (`bundledLibraryName`'s `#else`), so any GPU test would fail for reasons unrelated to the change under test. `ci_post_clone.sh` needs no change — `make shaders` still produces the slices the other platforms use.

2. **Assert the product is native.** Since the compat variant fails silently rather than loudly, the action is worth a check that `BUILT_PRODUCTS_DIR` ends in `-xrsimulator` (or that `vtool -show-build` reports `VISIONOSSIMULATOR`) rather than trusting a green build alone.

3. Target the **simulator**: `generic/platform=visionOS` (device) does not resolve for this scheme even with the visionOS platform installed.

## Scope note for @enitimeago's step 5

This lands only the platform declaration. The metallib slices and runtime selection are untouched and remain yours — but the `Package.swift` `.visionOS` line will already be present, so that hunk can drop from step 5.
