### PR TITLE
docs: declare visionOS 26+ support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 **VRMMetalKit** is a high-performance Swift Package for loading, rendering, and animating VRM 1.0 avatars using Apple's Metal framework.
-- **Target:** macOS 26+, iOS 26+
+- **Target:** macOS 26+, iOS 26+, visionOS 26+
 - **Language:** Swift 6.2
 - **Repo:** [https://github.com/arkavo-org/VRMMetalKit](https://github.com/arkavo-org/VRMMetalKit)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A high-performance Swift Package for loading and rendering 3D assets on Apple's 
 - **GLTFMetalKit** — glTF 2.0 PBR renderer for static / skinned / morphed / animated assets. Targets the inanimate-objects half of the ecosystem (props, scenery, items) and clears the Khronos Sample Assets credibility bar (PBR + IBL + skinning + morph + animation + KHR_lights_punctual + KHR_materials_unlit).
 
 [![Swift](https://img.shields.io/badge/Swift-6.2-orange.svg)](https://swift.org)
-[![Platforms](https://img.shields.io/badge/Platforms-macOS%2026%2B%20%7C%20iOS%2026%2B-blue.svg)](https://developer.apple.com)
+[![Platforms](https://img.shields.io/badge/Platforms-macOS%2026%2B%20%7C%20iOS%2026%2B%20%7C%20visionOS%2026%2B-blue.svg)](https://developer.apple.com)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Models License](https://img.shields.io/badge/Models-VPL%201.0-green.svg)](LICENSE-MODELS.md)
 

--- a/Sources/VRMMetalKit/VRMMetalKit.docc/Articles/GettingStarted.md
+++ b/Sources/VRMMetalKit/VRMMetalKit.docc/Articles/GettingStarted.md
@@ -6,7 +6,13 @@ Set up a Metal-backed VRM renderer in under twenty lines of Swift.
 
 This article walks through the minimum integration: adding the package, loading a VRM 1.0 avatar from disk, and drawing it into an `MTKView`. It's aimed at developers who already have a Metal-based app and want to drop in a VRM runtime without reaching for a higher-level engine.
 
-VRMMetalKit targets **macOS 26+** and **iOS 26+** and is written in **Swift 6.2** with strict concurrency. The public surface is `Sendable`-aware, but the renderer itself is main-actor-bound — keep that in mind when wiring it into your view hierarchy. Once you have a basic frame on screen, see the sister articles linked at the bottom for animation, ARKit driving, physics, and validation.
+VRMMetalKit targets **macOS 26+**, **iOS 26+**, and **visionOS 26+**, and is written in **Swift 6.2** with strict concurrency. The public surface is `Sendable`-aware. The `MTKView` entry points — ``VRMRenderer/draw(in:commandBuffer:renderPassDescriptor:)`` and ``VRMRenderer/drawOffscreenHeadless(to:depth:commandBuffer:renderPassDescriptor:)`` — are main-actor-bound, so keep that in mind when wiring the renderer into your view hierarchy. Once you have a basic frame on screen, see the sister articles linked at the bottom for animation, ARKit driving, physics, and validation.
+
+### On visionOS
+
+There is no `MTKView` in an immersive scene, so drive the renderer with ``VRMRenderer/drawOffscreen(to:depth:commandBuffer:renderPassDescriptor:)`` instead. It is nonisolated and callable from a CompositorServices frame loop off the main actor — issue one call per eye against that frame's drawable, sharing a single simulation step. It is not reentrant: use a single render thread.
+
+visionOS support is currently **build-verified in CI**. The dedicated visionOS shader slice has not landed yet, so visionOS falls back to the macOS `.metallib` slice and rendering is not yet validated to the same bar as macOS and iOS — see [issue #87](https://github.com/arkavo-org/VRMMetalKit/issues/87).
 
 ## Add the package
 

--- a/Sources/VRMMetalKit/VRMMetalKit.docc/VRMMetalKit.md
+++ b/Sources/VRMMetalKit/VRMMetalKit.docc/VRMMetalKit.md
@@ -6,7 +6,7 @@ High-performance loading, rendering, and animation of VRM 1.0 avatars on Apple p
 
 VRMMetalKit is a Swift Package that loads VRM 1.0 (and 0.0 fallback) avatars, renders them with an MToon-compliant non-photorealistic pipeline, plays VRMA animations with humanoid retargeting, simulates SpringBone physics on the GPU, and drives expressions and body pose from ARKit.
 
-Use VRMMetalKit when you need a self-contained, Metal-native avatar runtime on macOS 26+ or iOS 26+ — for example, a virtual presence app, an avatar-based recording tool, or a creator preview surface that must match VRM 1.0 spec behavior without depending on a web stack.
+Use VRMMetalKit when you need a self-contained, Metal-native avatar runtime on macOS 26+, iOS 26+, or visionOS 26+ — for example, a virtual presence app, an avatar-based recording tool, or a creator preview surface that must match VRM 1.0 spec behavior without depending on a web stack.
 
 ## Topics
 


### PR DESCRIPTION
Follows the platform declaration landing in #389 and the Xcode Cloud **Build - visionOS** action going green on `eb861cd`.

Draft because the support claim is deliberately scoped — see "Why build-verified, not supported" below. If you want it stated unqualified, that's a one-paragraph deletion and I'll mark it ready.

## Changes

- **README** platform badge → `macOS 26+ | iOS 26+ | visionOS 26+`
- **CLAUDE.md** target line, and both DocC landing pages
- **GettingStarted** gains a visionOS section covering the render path

## The visionOS render path

Worth documenting because it isn't the obvious one: there is no `MTKView` in an immersive scene, so hosts drive ``VRMRenderer/drawOffscreen(to:depth:commandBuffer:renderPassDescriptor:)`` instead — nonisolated, one call per eye against that frame's CompositorServices drawable, sharing a single simulation step, single render thread. That's the pattern @enitimeago validated on device (#87), and it's why #384's thread-safe entry point mattered.

## Why "build-verified", not "supported"

I ran the suite against the Apple Vision Pro simulator before writing the claim. Mixed result:

| | |
|---|---|
| Shader library loads | ✅ `testLoadBundledLibrarySucceeds` passes |
| Passing | 12 cases, incl. `drawOffscreen` off the main thread and the semaphore-teardown regression |
| Failing | all MSAA pipeline-selection cases, both morph weights-buffer cases, one renderer viewport case |

Consistent with visionOS falling back to the macOS `.metallib` (`bundledLibraryName`'s `#else`) and pipeline creation failing there. I could not extract the underlying error from the test output and did not root-cause it, so I'm not asserting a cause — only that parity isn't demonstrated.

So the badge says visionOS while GettingStarted says build-verified and points at #87. The alternative — an unqualified claim — would imply macOS/iOS parity the suite doesn't show.

**Bearing on visionOS test coverage:** the `VRMMetalKitHost` scheme already has `VRMMetalKitTests` in its TestAction, so adding a visionOS *Test* action (and feature-branch start conditions) is an App Store Connect config change, not a code change. But it would be red today. Recommend staying build-only until the visionOS `.metallib` slice lands as part of step 5, then flipping it.

## Drive-by correction

The same GettingStarted paragraph claimed "the renderer itself is main-actor-bound". That stopped being true when #384 added the nonisolated `drawOffscreen`. Narrowed to the two `MTKView` entry points, which are still `@MainActor`.

## Verification

`swift build` clean; `swift package generate-documentation --target VRMMetalKit` builds with no unresolved references for the three symbol links added (the one warning is pre-existing, `GLTFError` in `VRMError`).
