### PR TITLE
perf(logging): make internal vrmLog @autoclosure so log arguments compile out

### DIFF
--- a/Sources/VRMMetalKit/ARKit/ARKitFaceDriver.swift
+++ b/Sources/VRMMetalKit/ARKit/ARKitFaceDriver.swift
@@ -464,12 +464,12 @@ public struct DriverStatistics: Sendable {
 // MARK: - Conditional Logging
 
 #if VRM_METALKIT_ENABLE_LOGS
-func vrmLog(_ message: String) {
-    print("[VRMMetalKit] \(message)")
+func vrmLog(_ message: @autoclosure () -> String) {
+    print("[VRMMetalKit] \(message())")
 }
 #else
 @inline(__always)
-func vrmLog(_ message: String) { }
+func vrmLog(_ message: @autoclosure () -> String) { }
 #endif
 
 // MARK: - Always-On Error Logging


### PR DESCRIPTION
## Summary

VRMMetalKit's module-internal `vrmLog` took an **eager `String`**:

```swift
@inline(__always) func vrmLog(_ message: String) { }   // before
```

The empty inlined body removes the *call*, but the *argument* is evaluated at the call site regardless. `String(format:)` is an opaque bridged call the optimizer cannot prove side-effect-free, so it survives DCE at `-O` — in builds **without** `VRM_METALKIT_ENABLE_LOGS`. CLAUDE.md advertises these flags as "zero-cost debug logging"; that claim was not true for this function.

`GLTFCore.vrmLog` **already uses `@autoclosure`** (`GLTFLogger.swift:53`). The 2-line stub at the bottom of `ARKitFaceDriver.swift` shadowed it for all 711 VRMMetalKit call sites, silently reintroducing the exact cost the GLTFCore version was written to avoid. This is a regression against the project's own established pattern, not a new idea.

## Correction to #375

Backlog item 1 of #375 states the `meshName`/`materialName` pulls are *"only consumed by `vrmLog`, which is `@autoclosure` and compiles out."* That describes GLTFCore's `vrmLog`, not the internal one those call sites actually resolve to. The premise was wrong — which is a good part of why the audit recorded `drawCore retain_value=314`.

This PR makes that premise true. Item 1 becomes genuinely dead-code once merged; items 2 and 3 are untouched, so this **refs** rather than closes #375.

## Measurements

Canonical `-O -wmo` SIL, replayed from the real frontend invocation, `drawCore` body — before/after on the **same commit**:

| | before | after |
|---|---:|---:|
| SIL lines | 25,003 | **11,749** (−53%) |
| `retain_value` | 314 | **150** (−52%) |
| `strong_release` | 803 | **132** (−83%) |
| `alloc_ref` | 7 | **3** |
| module CVarArg heap allocs | 20 | **10** |

The pre-fix `retain_value` of **314 matches #375's recorded figure exactly**, confirming this is the same measurement the audit took.

The 10 surviving CVarArg allocations are `SpriteCacheSystem.Statistics.description`, `BenchmarkReport.renderTable`, `VRMShaderLibraryLoader` hash, and `BoneTrajectoryDumper` — none per-frame, all legitimate.

Mechanism isolated independently on the same toolchain:

| minimal repro | CVarArg allocs | SIL lines |
|---|---:|---:|
| eager `String` param | 1 | 72 |
| `@autoclosure` | 0 | 10 |

## Scope and risk

`@autoclosure` is source-compatible — **711 call sites across 27 files are unchanged**. The one real risk is deferred evaluation dropping side effects in log arguments; all 711 sites were scanned for `+=`, `-=`, `.append(`, `.insert(`, `.removeAll` → **zero hits**.

## Verification

- `swift build -c release` — clean
- `swift build -c release -Xswiftc -DVRM_METALKIT_ENABLE_LOGS` — clean
- `swift test --parallel --num-workers 14 -j 16 --disable-sandbox` — **1909 tests, 0 failures**
- Logging still emits with the flag on (82 `[VRMMetalKit]` lines in a filtered run) — confirms `@autoclosure` didn't silently swallow output

## What this is not

**This is a code-size and allocation result, not a measured frame-time win**, and #375's conclusion stands unchanged: the render path is GPU-bound with ~16 ms/frame of headroom. Most eliminated sites sat behind `frameCounter <= 2` / `== 10` guards and are cold. The genuinely recurring ones are two `applyMorphTargetsCompute` sites under `frameCounter % 60 == 0` — roughly one allocation burst per second per morphed primitive.

Defensible claims: `drawCore` I-cache footprint halved, ARC traffic halved, and a recurring once-per-second allocation removed. Frame-time impact is expected to be unobservable; no bench run is claimed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
